### PR TITLE
fix: macOS 26で再生オプションメニューが点滅して操作できない問題を修正

### DIFF
--- a/kiririn/Features/Player/PlayerOverlayView.swift
+++ b/kiririn/Features/Player/PlayerOverlayView.swift
@@ -1873,7 +1873,7 @@ struct PlayerOverlayView_iOS: View {
 
         if showsOptionsMenu {
             Menu {
-                playerPlaybackOptionMenuEntries(
+                PlayerPlaybackOptionMenuEntries(
                     playerState: playerState,
                     isSeekActionAvailable: isSeekActionAvailable
                 )
@@ -1894,7 +1894,7 @@ struct PlayerOverlayView_iOS: View {
         usesGlass: Bool
     ) -> some View {
         Menu {
-            playerPlaybackOptionMenuEntries(
+            PlayerPlaybackOptionMenuEntries(
                 playerState: playerState,
                 isSeekActionAvailable: isSeekActionAvailable
             )

--- a/kiririn/Features/Player/PlayerSettingsSheet.swift
+++ b/kiririn/Features/Player/PlayerSettingsSheet.swift
@@ -18,145 +18,159 @@ enum PlayerPlaybackOptionCatalog {
     }
 }
 
-@ViewBuilder
-func playerPlaybackOptionMenuEntries(playerState: PlayerState, isSeekActionAvailable: Bool)
-    -> some View
-{
-    if isSeekActionAvailable {
+/// 再生オプションメニューの中身。
+///
+/// `PlayerOverlayView` の body は `playbackStatus` の時刻更新（VLC から毎秒数回）で頻繁に
+/// 再評価される。メニュー内容を独立した `View` として切り出すことで、`@Observable` の
+/// 追跡対象を再生速度・トラック・モード・プラグインに限定し、時刻更新による再生成を避ける。
+/// これをインラインの `@ViewBuilder func` にすると、開いているメニューが毎秒作り直されて
+/// チェックマークが点滅し、クリックも受け付けなくなる。
+struct PlayerPlaybackOptionMenuEntries: View {
+    let playerState: PlayerState
+    let isSeekActionAvailable: Bool
+
+    var body: some View {
+        content
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if isSeekActionAvailable {
+            Menu {
+                Picker(
+                    "再生速度",
+                    selection: Binding(
+                        get: { playerState.playbackRate },
+                        set: { playerState.setRate($0) }
+                    )
+                ) {
+                    ForEach(PlayerPlaybackOptionCatalog.rateOptions, id: \.self) { rate in
+                        Text(PlayerPlaybackOptionCatalog.rateLabel(rate)).tag(rate)
+                    }
+                }
+                .labelsHidden()
+            } label: {
+                Label {
+                    Text("再生速度")
+                } icon: {
+                    accentMenuIcon(systemName: "gauge")
+                }
+            }
+        }
+
         Menu {
             Picker(
-                "再生速度",
+                "映像トラック",
                 selection: Binding(
-                    get: { playerState.playbackRate },
-                    set: { playerState.setRate($0) }
+                    get: { playerState.selectedVideoTrack },
+                    set: { if let track = $0 { playerState.selectVideoTrack(track) } }
                 )
             ) {
-                ForEach(PlayerPlaybackOptionCatalog.rateOptions, id: \.self) { rate in
-                    Text(PlayerPlaybackOptionCatalog.rateLabel(rate)).tag(rate)
+                Text("トラックなし").tag(PlayerVideoTrack?.none).disabled(true).selectionDisabled()
+                ForEach(Array(playerState.availableVideoTracks.enumerated()), id: \.element.id) {
+                    index, track in
+                    Text(PlayerPlaybackOptionCatalog.videoTrackLabel(index: index, track: track))
+                        .tag(PlayerVideoTrack?.some(track))
                 }
             }
             .labelsHidden()
         } label: {
             Label {
-                Text("再生速度")
+                Text("映像トラック")
             } icon: {
-                accentMenuIcon(systemName: "gauge")
+                accentMenuIcon(systemName: "video")
             }
         }
-    }
 
-    Menu {
-        Picker(
-            "映像トラック",
-            selection: Binding(
-                get: { playerState.selectedVideoTrack },
-                set: { if let track = $0 { playerState.selectVideoTrack(track) } }
-            )
-        ) {
-            Text("トラックなし").tag(PlayerVideoTrack?.none).disabled(true).selectionDisabled()
-            ForEach(Array(playerState.availableVideoTracks.enumerated()), id: \.element.id) {
-                index, track in
-                Text(PlayerPlaybackOptionCatalog.videoTrackLabel(index: index, track: track))
-                    .tag(PlayerVideoTrack?.some(track))
-            }
-        }
-        .labelsHidden()
-    } label: {
-        Label {
-            Text("映像トラック")
-        } icon: {
-            accentMenuIcon(systemName: "video")
-        }
-    }
-
-    Menu {
-        Picker(
-            "音声トラック",
-            selection: Binding(
-                get: { playerState.selectedAudioTrack },
-                set: { if let track = $0 { playerState.selectAudioTrack(track) } }
-            )
-        ) {
-            Text("トラックなし").tag(PlayerAudioTrack?.none).disabled(true).selectionDisabled()
-            ForEach(Array(playerState.availableAudioTracks.enumerated()), id: \.element.id) {
-                index, track in
-                Text(PlayerPlaybackOptionCatalog.audioTrackLabel(index: index, track: track))
-                    .tag(PlayerAudioTrack?.some(track))
-            }
-        }
-        .labelsHidden()
-    } label: {
-        Label {
-            Text("音声トラック")
-        } icon: {
-            accentMenuIcon(systemName: "speaker.wave.2")
-        }
-    }
-
-    #if DEBUG
         Menu {
             Picker(
-                "ステレオモード",
+                "音声トラック",
                 selection: Binding(
-                    get: { playerState.selectedAudioStereoMode },
-                    set: { playerState.selectAudioStereoMode($0) }
+                    get: { playerState.selectedAudioTrack },
+                    set: { if let track = $0 { playerState.selectAudioTrack(track) } }
                 )
             ) {
-                ForEach(PlayerAudioStereoMode.allCases) { mode in
+                Text("トラックなし").tag(PlayerAudioTrack?.none).disabled(true).selectionDisabled()
+                ForEach(Array(playerState.availableAudioTracks.enumerated()), id: \.element.id) {
+                    index, track in
+                    Text(PlayerPlaybackOptionCatalog.audioTrackLabel(index: index, track: track))
+                        .tag(PlayerAudioTrack?.some(track))
+                }
+            }
+            .labelsHidden()
+        } label: {
+            Label {
+                Text("音声トラック")
+            } icon: {
+                accentMenuIcon(systemName: "speaker.wave.2")
+            }
+        }
+
+        #if DEBUG
+            Menu {
+                Picker(
+                    "ステレオモード",
+                    selection: Binding(
+                        get: { playerState.selectedAudioStereoMode },
+                        set: { playerState.selectAudioStereoMode($0) }
+                    )
+                ) {
+                    ForEach(PlayerAudioStereoMode.allCases) { mode in
+                        Text(mode.displayName).tag(mode)
+                    }
+                }
+                .labelsHidden()
+            } label: {
+                Label {
+                    Text("ステレオモード")
+                } icon: {
+                    accentMenuIcon(systemName: "headphones")
+                }
+            }
+        #endif
+
+        Menu {
+            Picker(
+                "音声ミックスモード",
+                selection: Binding(
+                    get: { playerState.selectedAudioMixMode },
+                    set: { playerState.selectAudioMixMode($0) }
+                )
+            ) {
+                ForEach(PlayerAudioMixMode.allCases) { mode in
                     Text(mode.displayName).tag(mode)
                 }
             }
             .labelsHidden()
         } label: {
             Label {
-                Text("ステレオモード")
+                Text("音声モード")
             } icon: {
                 accentMenuIcon(systemName: "headphones")
             }
         }
-    #endif
 
-    Menu {
-        Picker(
-            "音声ミックスモード",
-            selection: Binding(
-                get: { playerState.selectedAudioMixMode },
-                set: { playerState.selectAudioMixMode($0) }
-            )
-        ) {
-            ForEach(PlayerAudioMixMode.allCases) { mode in
-                Text(mode.displayName).tag(mode)
-            }
-        }
-        .labelsHidden()
-    } label: {
-        Label {
-            Text("音声モード")
-        } icon: {
-            accentMenuIcon(systemName: "headphones")
-        }
-    }
-
-    Button {
-        playerState.reloadCurrentPlayable()
-    } label: {
-        Label {
-            Text("再読み込み")
-        } icon: {
-            accentMenuIcon(systemName: "arrow.clockwise")
-        }
-    }
-
-    if !playerState.availableOverlayPlugins.isEmpty {
         Button {
-            playerState.showingPluginOverlay.toggle()
+            playerState.reloadCurrentPlayable()
         } label: {
             Label {
-                Text(playerState.showingPluginOverlay ? "プラグイン非表示" : "プラグイン表示")
+                Text("再読み込み")
             } icon: {
-                accentMenuIcon(
-                    systemName: playerState.showingPluginOverlay
-                        ? "puzzlepiece.extension.fill" : "puzzlepiece.extension")
+                accentMenuIcon(systemName: "arrow.clockwise")
+            }
+        }
+
+        if !playerState.availableOverlayPlugins.isEmpty {
+            Button {
+                playerState.showingPluginOverlay.toggle()
+            } label: {
+                Label {
+                    Text(playerState.showingPluginOverlay ? "プラグイン非表示" : "プラグイン表示")
+                } icon: {
+                    accentMenuIcon(
+                        systemName: playerState.showingPluginOverlay
+                            ? "puzzlepiece.extension.fill" : "puzzlepiece.extension")
+                }
             }
         }
     }

--- a/kiririn/Features/Player/PlayerState.swift
+++ b/kiririn/Features/Player/PlayerState.swift
@@ -632,8 +632,8 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
 
     private func loadAudioTracks() {
         guard let player else {
-            availableAudioTracks = []
-            selectedAudioTrack = nil
+            if !availableAudioTracks.isEmpty { availableAudioTracks = [] }
+            if selectedAudioTrack != nil { selectedAudioTrack = nil }
             return
         }
 
@@ -647,23 +647,35 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
                     channels: channels
                 )
             }
-        availableAudioTracks = tracks
+        // トラック更新イベントは高頻度で発火するため、変化時のみ書き込む
+        // （@Observable は同値でも代入のたびに通知し、メニュー等の UI を作り直してしまう）
+        if availableAudioTracks != tracks {
+            availableAudioTracks = tracks
+        }
 
-        selectedAudioTrack = tracks.first(where: { $0.id == selectedAudioTrackID })
+        let selected = tracks.first(where: { $0.id == selectedAudioTrackID })
+        if selectedAudioTrack != selected {
+            selectedAudioTrack = selected
+        }
     }
 
     private func loadVideoTracks() {
         guard let player else {
-            availableVideoTracks = []
-            selectedVideoTrack = nil
+            if !availableVideoTracks.isEmpty { availableVideoTracks = [] }
+            if selectedVideoTrack != nil { selectedVideoTrack = nil }
             return
         }
 
         let tracks = player.videoTracks
             .filter { !$0.trackId.isEmpty }
             .map { PlayerVideoTrack(id: $0.trackId, name: $0.trackName) }
-        availableVideoTracks = tracks
-        selectedVideoTrack = tracks.first(where: { $0.id == selectedVideoTrackID })
+        if availableVideoTracks != tracks {
+            availableVideoTracks = tracks
+        }
+        let selected = tracks.first(where: { $0.id == selectedVideoTrackID })
+        if selectedVideoTrack != selected {
+            selectedVideoTrack = selected
+        }
     }
 
     private func refreshSubtitleTrack() {
@@ -1412,7 +1424,22 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
     }
 
     private func clearPlaybackError() {
-        playbackErrorMessage = nil
+        if playbackErrorMessage != nil {
+            playbackErrorMessage = nil
+        }
+    }
+
+    // @Observable は同値でも代入のたびに通知するため、変化時のみ書き込むヘルパー。
+    private func setPlaybackLoadingIfChanged(_ value: Bool) {
+        if isPlaybackLoading != value {
+            isPlaybackLoading = value
+        }
+    }
+
+    private func setPlayingIfChanged(_ value: Bool) {
+        if isPlaying != value {
+            isPlaying = value
+        }
     }
 
     private func resolvePlaybackErrorMessage(preferredMessage: String?) -> String {
@@ -1456,30 +1483,34 @@ extension PlayerState {
         // VLCLibrary.currentErrorMessage is thread-local and must be read on the callback thread.
         let errorMessageOnCallbackThread = (state == .error) ? VLCLibrary.currentErrorMessage : nil
         Task { @MainActor in
+            // @Observable は同値でも代入のたびに通知するため、値が変わるときだけ書き込む。
+            // （.buffering はライブ視聴中に高頻度で発火する）
             switch state {
             case .opening, .buffering:
-                isPlaybackLoading = !didStartPlayback
+                setPlaybackLoadingIfChanged(!didStartPlayback)
             case .playing:
                 didStartPlayback = true
-                isPlaybackLoading = false
-                isPlaying = true
+                setPlaybackLoadingIfChanged(false)
+                setPlayingIfChanged(true)
                 clearPlaybackError()
                 didObservePlayingForRestore = true
                 syncAudioModesFromVLC()
                 applyAudioOutput()
                 requestPlaybackRestoreIfPossible(trigger: "state.playing")
             case .error:
-                isPlaybackLoading = false
-                isPlaying = false
+                setPlaybackLoadingIfChanged(false)
+                setPlayingIfChanged(false)
                 playbackErrorMessage = resolvePlaybackErrorMessage(
                     preferredMessage: errorMessageOnCallbackThread)
             case .paused, .stopped, .stopping:
-                isPlaybackLoading = false
-                isPlaying = false
+                setPlaybackLoadingIfChanged(false)
+                setPlayingIfChanged(false)
             default:
                 break
             }
-            playbackStatus.isPlaying = isPlaying
+            if playbackStatus.isPlaying != isPlaying {
+                playbackStatus.isPlaying = isPlaying
+            }
             syncCurrentPlayableSeekability()
         }
     }
@@ -1489,13 +1520,22 @@ extension PlayerState {
             guard let player = player else { return }
             let time = max(0, Double(player.time.intValue) / 1000.0)
             let duration = max(0, currentPlayable?.length ?? 0)
+            // @Observable は同値でも代入のたびに通知するため、値が変わるときだけ書き込む。
+            // （毎ティックの無条件代入は開いているメニュー等の UI を毎秒作り直してしまう）
             if duration == 0 || time <= duration {
-                playbackStatus.time = time
+                if playbackStatus.time != time {
+                    playbackStatus.time = time
+                }
             }
-            playbackStatus.position = Float(player.position)
+            let position = Float(player.position)
+            if playbackStatus.position != position {
+                playbackStatus.position = position
+            }
             if playbackStatus.time > 0 || playbackStatus.position > 0.001 {
                 didStartPlayback = true
-                isPlaybackLoading = false
+                if isPlaybackLoading {
+                    isPlaybackLoading = false
+                }
                 didObservePlaybackProgressForRestore = true
                 requestPlaybackRestoreIfPossible(trigger: "time.changed")
             }

--- a/kiririn/Features/Player/macOS/DetachedPlayerOverlayView.swift
+++ b/kiririn/Features/Player/macOS/DetachedPlayerOverlayView.swift
@@ -380,127 +380,11 @@ struct DetachedPlayerOverlayView_macOS: View {
                 }
                 .keyboardShortcut("r", modifiers: .command)
 
-                Menu {
-                    if playerState.player?.isSeekable ?? false {
-                        Picker(
-                            "再生速度",
-                            selection: Binding(
-                                get: { playerState.playbackRate },
-                                set: { playerState.setRate($0) }
-                            )
-                        ) {
-                            ForEach(PlayerPlaybackOptionCatalog.rateOptions, id: \.self) {
-                                rate in
-                                Text(PlayerPlaybackOptionCatalog.rateLabel(rate)).tag(rate)
-                            }
-                        }
-                    }
-
-                    Picker(
-                        "映像トラック",
-                        selection: Binding(
-                            get: { playerState.selectedVideoTrack },
-                            set: {
-                                if let track = $0 { playerState.selectVideoTrack(track) }
-                            }
-                        )
-                    ) {
-                        Text("トラックなし").tag(PlayerVideoTrack?.none).disabled(true)
-                            .selectionDisabled(true)
-                        ForEach(
-                            Array(playerState.availableVideoTracks.enumerated()),
-                            id: \.element.id
-                        ) { index, track in
-                            Text(
-                                PlayerPlaybackOptionCatalog.videoTrackLabel(
-                                    index: index, track: track)
-                            )
-                            .tag(PlayerVideoTrack?.some(track))
-                        }
-                    }
-
-                    Picker(
-                        "音声トラック",
-                        selection: Binding(
-                            get: { playerState.selectedAudioTrack },
-                            set: {
-                                if let track = $0 { playerState.selectAudioTrack(track) }
-                            }
-                        )
-                    ) {
-                        Text("トラックなし").tag(PlayerAudioTrack?.none).disabled(true)
-                            .selectionDisabled(true)
-                        ForEach(
-                            Array(playerState.availableAudioTracks.enumerated()),
-                            id: \.element.id
-                        ) { index, track in
-                            Text(
-                                PlayerPlaybackOptionCatalog.audioTrackLabel(
-                                    index: index, track: track)
-                            )
-                            .tag(PlayerAudioTrack?.some(track))
-                        }
-                    }
-
-                    #if DEBUG
-                        Picker(
-                            "ステレオモード",
-                            selection: Binding(
-                                get: { playerState.selectedAudioStereoMode },
-                                set: { playerState.selectAudioStereoMode($0) }
-                            )
-                        ) {
-                            ForEach(PlayerAudioStereoMode.allCases) { mode in
-                                Text(mode.displayName).tag(mode)
-                            }
-                        }
-                    #endif
-
-                    Picker(
-                        "音声ミックスモード",
-                        selection: Binding(
-                            get: { playerState.selectedAudioMixMode },
-                            set: { playerState.selectAudioMixMode($0) }
-                        )
-                    ) {
-                        ForEach(PlayerAudioMixMode.allCases) { mode in
-                            Text(mode.displayName).tag(mode)
-                        }
-                    }
-
-                    Button {
-                        playerState.reloadCurrentPlayable()
-                    } label: {
-                        Label("再読み込み", systemImage: "arrow.clockwise")
-                    }
-
-                    if !playerState.availableOverlayPlugins.isEmpty {
-                        Button {
-                            playerState.showingPluginOverlay.toggle()
-                        } label: {
-                            if playerState.showingPluginOverlay {
-                                Image(systemName: "checkmark")
-                            }
-                            Text("プラグインを表示")
-                        }
-                    }
-
-                    Section("プラグインウィンドウ") {
-                        ForEach(
-                            pluginStore.plugins.filter {
-                                $0.isEnabled
-                            }
-                        ) { plugin in
-                            Button(plugin.name) {
-                                openWindow(id: AppWindowID.plugin.rawValue, value: plugin.id)
-                            }
-                        }
-                    }
-                } label: {
-                    Image(systemName: "ellipsis")
-                        .frame(width: 20 * scale, height: 20 * scale)
-                        .contentShape(.rect)
-                }
+                DetachedPlayerOptionsMenu(
+                    playerState: playerState,
+                    pluginStore: pluginStore,
+                    scale: scale
+                )
             }
             .font(.system(size: 15 * scale, weight: .semibold))
             .padding(.horizontal, 12 * scale)
@@ -826,6 +710,165 @@ struct DetachedPlayerOverlayView_macOS: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.2, execute: task)
     }
 
+}
+
+/// 再生オプションメニュー（macOS 分離プレイヤー用）。
+///
+/// SwiftUI の `Menu` を使うと、再生中の状態更新（VLC から毎秒数回）でホスト側の再評価が走った
+/// 際に、macOS 26 では開いているメニューごと再構築されてサブメニューのマークが点滅し、
+/// クリックも受け付けなくなる。素の `NSMenu` をクリック時に一度だけ構築してポップアップする
+/// ことで、SwiftUI の更新サイクルから完全に切り離す（表示中の内容は開いた時点のスナップショット）。
+private struct DetachedPlayerOptionsMenu: View {
+    let playerState: PlayerState
+    let pluginStore: PluginStore
+    let scale: CGFloat
+
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        Button {
+            presentMenu()
+        } label: {
+            Image(systemName: "ellipsis")
+                .frame(width: 20 * scale, height: 20 * scale)
+                .contentShape(.rect)
+        }
+    }
+
+    private func presentMenu() {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+
+        if playerState.player?.isSeekable ?? false {
+            let rateMenu = NSMenu()
+            let currentRate = playerState.playbackRate
+            for rate in PlayerPlaybackOptionCatalog.rateOptions {
+                let item = ClosureMenuItem(
+                    title: PlayerPlaybackOptionCatalog.rateLabel(rate)
+                ) { [playerState] in
+                    playerState.setRate(rate)
+                }
+                item.state = currentRate == rate ? .on : .off
+                rateMenu.addItem(item)
+            }
+            menu.addItem(submenuItem(title: "再生速度", submenu: rateMenu))
+        }
+
+        let videoMenu = NSMenu()
+        let noVideoItem = NSMenuItem(title: "トラックなし", action: nil, keyEquivalent: "")
+        noVideoItem.isEnabled = false
+        noVideoItem.state = playerState.selectedVideoTrack == nil ? .on : .off
+        videoMenu.addItem(noVideoItem)
+        for (index, track) in playerState.availableVideoTracks.enumerated() {
+            let item = ClosureMenuItem(
+                title: PlayerPlaybackOptionCatalog.videoTrackLabel(index: index, track: track)
+            ) { [playerState] in
+                playerState.selectVideoTrack(track)
+            }
+            item.state = playerState.selectedVideoTrack == track ? .on : .off
+            videoMenu.addItem(item)
+        }
+        menu.addItem(submenuItem(title: "映像トラック", submenu: videoMenu))
+
+        let audioMenu = NSMenu()
+        let noAudioItem = NSMenuItem(title: "トラックなし", action: nil, keyEquivalent: "")
+        noAudioItem.isEnabled = false
+        noAudioItem.state = playerState.selectedAudioTrack == nil ? .on : .off
+        audioMenu.addItem(noAudioItem)
+        for (index, track) in playerState.availableAudioTracks.enumerated() {
+            let item = ClosureMenuItem(
+                title: PlayerPlaybackOptionCatalog.audioTrackLabel(index: index, track: track)
+            ) { [playerState] in
+                playerState.selectAudioTrack(track)
+            }
+            item.state = playerState.selectedAudioTrack == track ? .on : .off
+            audioMenu.addItem(item)
+        }
+        menu.addItem(submenuItem(title: "音声トラック", submenu: audioMenu))
+
+        #if DEBUG
+            let stereoMenu = NSMenu()
+            for mode in PlayerAudioStereoMode.allCases {
+                let item = ClosureMenuItem(title: mode.displayName) { [playerState] in
+                    playerState.selectAudioStereoMode(mode)
+                }
+                item.state = playerState.selectedAudioStereoMode == mode ? .on : .off
+                stereoMenu.addItem(item)
+            }
+            menu.addItem(submenuItem(title: "ステレオモード", submenu: stereoMenu))
+        #endif
+
+        let mixMenu = NSMenu()
+        for mode in PlayerAudioMixMode.allCases {
+            let item = ClosureMenuItem(title: mode.displayName) { [playerState] in
+                playerState.selectAudioMixMode(mode)
+            }
+            item.state = playerState.selectedAudioMixMode == mode ? .on : .off
+            mixMenu.addItem(item)
+        }
+        menu.addItem(submenuItem(title: "音声ミックスモード", submenu: mixMenu))
+
+        menu.addItem(
+            ClosureMenuItem(title: "再読み込み", systemImage: "arrow.clockwise") { [playerState] in
+                playerState.reloadCurrentPlayable()
+            }
+        )
+
+        if !playerState.availableOverlayPlugins.isEmpty {
+            let toggleItem = ClosureMenuItem(title: "プラグインを表示") { [playerState] in
+                playerState.showingPluginOverlay.toggle()
+            }
+            toggleItem.state = playerState.showingPluginOverlay ? .on : .off
+            menu.addItem(toggleItem)
+        }
+
+        let enabledPlugins = pluginStore.plugins.filter { $0.isEnabled }
+        if !enabledPlugins.isEmpty {
+            menu.addItem(.separator())
+            menu.addItem(.sectionHeader(title: "プラグインウィンドウ"))
+            for plugin in enabledPlugins {
+                let pluginID = plugin.id
+                menu.addItem(
+                    ClosureMenuItem(title: plugin.name) { [openWindow] in
+                        openWindow(id: AppWindowID.plugin.rawValue, value: pluginID)
+                    }
+                )
+            }
+        }
+
+        guard let event = NSApp.currentEvent,
+            let contentView = event.window?.contentView
+        else { return }
+        NSMenu.popUpContextMenu(menu, with: event, for: contentView)
+    }
+
+    private func submenuItem(title: String, submenu: NSMenu) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.submenu = submenu
+        return item
+    }
+}
+
+/// クロージャを実行できる NSMenuItem。SwiftUI から NSMenu を組み立てるための補助。
+private final class ClosureMenuItem: NSMenuItem {
+    private let handler: () -> Void
+
+    init(title: String, systemImage: String? = nil, handler: @escaping () -> Void) {
+        self.handler = handler
+        super.init(title: title, action: #selector(invoke), keyEquivalent: "")
+        target = self
+        if let systemImage {
+            image = NSImage(systemSymbolName: systemImage, accessibilityDescription: nil)
+        }
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc private func invoke() {
+        handler()
+    }
 }
 
 private struct PlayerSlider: View {


### PR DESCRIPTION
Resolves #17

## 問題

macOS 26 (Tahoe) で分離プレイヤーの再生オプションメニュー（…）を開くと、サブメニューのマークが高速で表示・非表示を繰り返して震え、項目をクリックしても反応しない。

macOS 26 で再現。macOS 15 では再現しない。

## 原因

- `PlayerState` は `@Observable` で、VLC の `mediaPlayerTimeChanged` 等から毎秒数回書き込みがある（`@Observable` は同値代入でも通知を発火する）
- macOS 26 では SwiftUI の `Menu` が**表示中でも**ホスト側のビュー更新でメニューアイテムごと再構築されるようになったため、開いているメニューが毎秒作り直され、点滅・クリック不能になっていた
- 子ビューへの切り出しや同値ガードでは `playbackStatus.time` のように実際に値が変わる更新は止められず、SwiftUI `Menu` のままでは回避不能だった

## 修正

- **macOS 分離プレイヤーの再生オプションメニューを `NSMenu` + `popUpContextMenu` に置き換え**（`rightMouseDown` の右クリックメニューと同方式）。クリック時に一度だけ構築されるため SwiftUI の更新サイクルの影響を受けない。チェックマーク・サブメニュー・DEBUG 限定のステレオモード・プラグインウィンドウのセクションは既存どおり
- `PlayerState` の高頻度な書き込み（`isPlaybackLoading`、トラック一覧、再生状態など）を変化時のみに限定し、オーバーレイ全体が毎秒数回再描画されていたのを抑制
- iOS 側のメニュー内容 `playerPlaybackOptionMenuEntries` も独立 View (`PlayerPlaybackOptionMenuEntries`) に切り出し

## 確認

- macOS 26 実機のライブ再生でメニューの点滅が解消し、クリックが反応することを確認
- メニュー内容は開いた時点のスナップショットになる（ネイティブメニューの標準挙動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)