### PR TITLE
fix: プラグインの展開をアプリで行うように

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,7 @@ permissions:
     contents: read
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.run_id) || format('{0}-{1}', github.workflow, github.ref) }}
 
 env:
     PROJECT: kiririn.xcodeproj

--- a/Packages/KppxKit/Sources/KppxKit/PluginDecoder.swift
+++ b/Packages/KppxKit/Sources/KppxKit/PluginDecoder.swift
@@ -33,6 +33,28 @@ public struct PluginPackage {
         return output
     }
 
+    public func extract(to directoryURL: URL, fileManager: FileManager = .default) throws {
+        let destinationURL = directoryURL.standardizedFileURL
+        guard destinationURL.isFileURL else {
+            throw PluginDecoderError.invalidArchive
+        }
+
+        try fileManager.createDirectory(
+            at: destinationURL,
+            withIntermediateDirectories: true
+        )
+
+        for entry in archive {
+            let path = try Self.validatedFileName(entry.path)
+            let isDirectory = entry.type == .directory
+            let outputURL = destinationURL.appending(
+                path: path,
+                directoryHint: isDirectory ? .isDirectory : .notDirectory
+            )
+            _ = try archive.extract(entry, to: outputURL)
+        }
+    }
+
     private static func archive(from url: URL) throws -> Archive {
         do {
             return try Archive(url: url, accessMode: .read)

--- a/Packages/KppxKit/Sources/KppxKit/PluginDecoder.swift
+++ b/Packages/KppxKit/Sources/KppxKit/PluginDecoder.swift
@@ -17,12 +17,12 @@ public struct PluginPackage {
         guard let entry = archive[path] else {
             return false
         }
-        return entry.type != .directory
+        return entry.type == .file
     }
 
     public func fileData(named fileName: String) throws -> Data? {
         let path = try Self.validatedFileName(fileName)
-        guard let entry = archive[path], entry.type != .directory else {
+        guard let entry = archive[path], entry.type == .file else {
             return nil
         }
 
@@ -46,7 +46,15 @@ public struct PluginPackage {
 
         for entry in archive {
             let path = try Self.validatedFileName(entry.path)
-            let isDirectory = entry.type == .directory
+            let isDirectory: Bool
+            switch entry.type {
+            case .file:
+                isDirectory = false
+            case .directory:
+                isDirectory = true
+            case .symlink:
+                throw PluginDecoderError.unsupportedEntry
+            }
             let outputURL = destinationURL.appending(
                 path: path,
                 directoryHint: isDirectory ? .isDirectory : .notDirectory
@@ -66,6 +74,9 @@ public struct PluginPackage {
     private static func validateEntries(in archive: Archive) throws {
         for entry in archive {
             _ = try validatedFileName(entry.path)
+            guard entry.type != .symlink else {
+                throw PluginDecoderError.unsupportedEntry
+            }
         }
     }
 
@@ -84,10 +95,12 @@ public struct PluginPackage {
 
 public enum PluginDecoderError: LocalizedError, Equatable {
     case invalidArchive
+    case unsupportedEntry
 
     public var errorDescription: String? {
         switch self {
         case .invalidArchive: return "無効なプラグインパッケージです"
+        case .unsupportedEntry: return "シンボリックリンクを含むプラグインパッケージは利用できません"
         }
     }
 }

--- a/Packages/KppxKit/Sources/KppxKit/PluginDecoder.swift
+++ b/Packages/KppxKit/Sources/KppxKit/PluginDecoder.swift
@@ -81,7 +81,8 @@ public struct PluginPackage {
     }
 
     private static func validatedFileName(_ fileName: String) throws -> String {
-        guard !fileName.hasPrefix("/"),
+        guard !fileName.isEmpty,
+            !fileName.hasPrefix("/"),
             !fileName.split(separator: "/").contains("..")
         else {
             throw NSError(

--- a/Packages/KppxKit/Sources/KppxKit/PluginManifest.swift
+++ b/Packages/KppxKit/Sources/KppxKit/PluginManifest.swift
@@ -376,8 +376,18 @@ public struct PluginManifestParser: Sendable {
 
     public static func resourceHash(forArchiveURL archiveURL: URL) throws -> String {
         do {
-            let data = try Data(contentsOf: archiveURL)
-            return data.sha256Hex
+            let handle = try FileHandle(forReadingFrom: archiveURL)
+            defer {
+                try? handle.close()
+            }
+
+            var hasher = SHA256()
+            while true {
+                let chunk = try handle.read(upToCount: 1024 * 1024) ?? Data()
+                guard !chunk.isEmpty else { break }
+                hasher.update(data: chunk)
+            }
+            return hasher.finalize().map { String(format: "%02x", $0) }.joined()
         } catch {
             throw PluginManifestValidationError(messages: [
                 "プラグインパッケージの読み込みに失敗しました: \(error.localizedDescription)"
@@ -406,11 +416,5 @@ public struct PluginManifestParser: Sendable {
         }
 
         return path
-    }
-}
-
-extension Data {
-    var sha256Hex: String {
-        SHA256.hash(data: self).map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Packages/KppxKit/Tests/KppxKitTests/PluginDecoderTests.swift
+++ b/Packages/KppxKit/Tests/KppxKitTests/PluginDecoderTests.swift
@@ -44,6 +44,29 @@ struct PluginDecoderTests {
         #expect(data == nil)
     }
 
+    @Test func extractsPackageToDirectory() throws {
+        let contents = Data("hello plugin".utf8)
+        let packageData = storedZIPData(files: [
+            ("manifest.json", Data("{}".utf8)),
+            ("pages/panel.html", contents),
+        ])
+        let tempURL = try tempFileForTest(data: packageData, suffix: "kppx")
+        let outputURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "plugin_extract_\(UUID().uuidString)",
+            isDirectory: true
+        )
+        defer {
+            try? FileManager.default.removeItem(at: tempURL)
+            try? FileManager.default.removeItem(at: outputURL)
+        }
+
+        let package = try PluginDecoder.decode(url: tempURL)
+        try package.extract(to: outputURL)
+
+        let extractedURL = outputURL.appending(path: "pages/panel.html")
+        #expect(try Data(contentsOf: extractedURL) == contents)
+    }
+
     @Test func rejectsAbsolutePath() throws {
         let packageData = storedZIPData(files: [
             ("/etc/passwd", Data("danger".utf8))

--- a/Packages/KppxKit/Tests/KppxKitTests/PluginDecoderTests.swift
+++ b/Packages/KppxKit/Tests/KppxKitTests/PluginDecoderTests.swift
@@ -82,6 +82,21 @@ struct PluginDecoderTests {
         }
     }
 
+    @Test func rejectsEmptyPath() throws {
+        let packageData = storedZIPData(files: [
+            ("", Data("danger".utf8))
+        ])
+        let tempURL = try tempFileForTest(data: packageData, suffix: "kppx")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        do {
+            _ = try PluginDecoder.decode(url: tempURL)
+            #expect(Bool(false))
+        } catch {
+            #expect(Bool(true))
+        }
+    }
+
     @Test func rejectsSymbolicLinkEntry() throws {
         let packageData = storedZIPData(entries: [
             .file(path: "manifest.json", contents: Data("{}".utf8)),

--- a/Packages/KppxKit/Tests/KppxKitTests/PluginDecoderTests.swift
+++ b/Packages/KppxKit/Tests/KppxKitTests/PluginDecoderTests.swift
@@ -82,6 +82,24 @@ struct PluginDecoderTests {
         }
     }
 
+    @Test func rejectsSymbolicLinkEntry() throws {
+        let packageData = storedZIPData(entries: [
+            .file(path: "manifest.json", contents: Data("{}".utf8)),
+            .symbolicLink(path: "pages/panel.html", destination: "../../outside.html"),
+        ])
+        let tempURL = try tempFileForTest(data: packageData, suffix: "kppx")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        do {
+            _ = try PluginDecoder.decode(url: tempURL)
+            #expect(Bool(false))
+        } catch let error as PluginDecoderError {
+            #expect(error == .unsupportedEntry)
+        } catch {
+            #expect(Bool(false))
+        }
+    }
+
     @Test func rejectsInvalidArchive() throws {
         let tempURL = try tempFileForTest(data: Data([0x00, 0x01, 0x02]), suffix: "kppx")
         defer { try? FileManager.default.removeItem(at: tempURL) }
@@ -98,12 +116,41 @@ struct PluginDecoderTests {
 }
 
 private func storedZIPData(files: [(String, Data)]) -> Data {
+    storedZIPData(entries: files.map { .file(path: $0.0, contents: $0.1) })
+}
+
+private struct TestZIPEntry {
+    let path: String
+    let contents: Data
+    let versionMadeBy: UInt16
+    let externalFileAttributes: UInt32
+
+    static func file(path: String, contents: Data) -> TestZIPEntry {
+        TestZIPEntry(
+            path: path,
+            contents: contents,
+            versionMadeBy: 20,
+            externalFileAttributes: 0
+        )
+    }
+
+    static func symbolicLink(path: String, destination: String) -> TestZIPEntry {
+        TestZIPEntry(
+            path: path,
+            contents: Data(destination.utf8),
+            versionMadeBy: UInt16((3 << 8) | 20),
+            externalFileAttributes: 0xa1ff_0000
+        )
+    }
+}
+
+private func storedZIPData(entries: [TestZIPEntry]) -> Data {
     var localEntries = Data()
     var centralDirectory = Data()
 
-    for (path, contents) in files {
-        let pathData = Data(path.utf8)
-        let crc = crc32(contents)
+    for entry in entries {
+        let pathData = Data(entry.path.utf8)
+        let crc = crc32(entry.contents)
         let localHeaderOffset = UInt32(localEntries.count)
 
         localEntries.append(littleEndian(UInt32(0x0403_4b50)))
@@ -113,29 +160,29 @@ private func storedZIPData(files: [(String, Data)]) -> Data {
         localEntries.append(littleEndian(UInt16(0)))
         localEntries.append(littleEndian(UInt16(0)))
         localEntries.append(littleEndian(crc))
-        localEntries.append(littleEndian(UInt32(contents.count)))
-        localEntries.append(littleEndian(UInt32(contents.count)))
+        localEntries.append(littleEndian(UInt32(entry.contents.count)))
+        localEntries.append(littleEndian(UInt32(entry.contents.count)))
         localEntries.append(littleEndian(UInt16(pathData.count)))
         localEntries.append(littleEndian(UInt16(0)))
         localEntries.append(pathData)
-        localEntries.append(contents)
+        localEntries.append(entry.contents)
 
         centralDirectory.append(littleEndian(UInt32(0x0201_4b50)))
-        centralDirectory.append(littleEndian(UInt16(20)))
+        centralDirectory.append(littleEndian(entry.versionMadeBy))
         centralDirectory.append(littleEndian(UInt16(20)))
         centralDirectory.append(littleEndian(UInt16(0)))
         centralDirectory.append(littleEndian(UInt16(0)))
         centralDirectory.append(littleEndian(UInt16(0)))
         centralDirectory.append(littleEndian(UInt16(0)))
         centralDirectory.append(littleEndian(crc))
-        centralDirectory.append(littleEndian(UInt32(contents.count)))
-        centralDirectory.append(littleEndian(UInt32(contents.count)))
+        centralDirectory.append(littleEndian(UInt32(entry.contents.count)))
+        centralDirectory.append(littleEndian(UInt32(entry.contents.count)))
         centralDirectory.append(littleEndian(UInt16(pathData.count)))
         centralDirectory.append(littleEndian(UInt16(0)))
         centralDirectory.append(littleEndian(UInt16(0)))
         centralDirectory.append(littleEndian(UInt16(0)))
         centralDirectory.append(littleEndian(UInt16(0)))
-        centralDirectory.append(littleEndian(UInt32(0)))
+        centralDirectory.append(littleEndian(entry.externalFileAttributes))
         centralDirectory.append(littleEndian(localHeaderOffset))
         centralDirectory.append(pathData)
     }
@@ -147,8 +194,8 @@ private func storedZIPData(files: [(String, Data)]) -> Data {
     output.append(littleEndian(UInt32(0x0605_4b50)))
     output.append(littleEndian(UInt16(0)))
     output.append(littleEndian(UInt16(0)))
-    output.append(littleEndian(UInt16(files.count)))
-    output.append(littleEndian(UInt16(files.count)))
+    output.append(littleEndian(UInt16(entries.count)))
+    output.append(littleEndian(UInt16(entries.count)))
     output.append(littleEndian(UInt32(centralDirectory.count)))
     output.append(littleEndian(centralDirectoryOffset))
     output.append(littleEndian(UInt16(0)))

--- a/kiririn/Features/Plugin/PluginOverlayView.swift
+++ b/kiririn/Features/Plugin/PluginOverlayView.swift
@@ -346,9 +346,11 @@ final class ExtensionPluginRuntimeRegistry {
             return try await resolvePendingLoad(pendingLoad, for: plugin, store: store)
         }
 
-        let manifest = try store.resolvedManifest(for: plugin)
-
-        let resourceBaseURL = try store.resourceBaseURL(for: plugin)
+        let resourceBaseURL = try await store.resourceBaseURL(for: plugin)
+        let manifest = try store.resolvedManifest(
+            for: plugin,
+            resourceBaseURL: resourceBaseURL
+        )
         let pendingLoad = PendingRuntimeLoad(
             token: UUID(),
             task: Task { @MainActor in

--- a/kiririn/Features/Plugin/PluginStore.swift
+++ b/kiririn/Features/Plugin/PluginStore.swift
@@ -200,6 +200,7 @@ class PluginStore {
     private let pluginsKey = "kiririn.plugin.definitions"
     private let developerModeKey = "kiririn.plugin.developer_mode_enabled"
     private let pluginDirectoryName = "Plugins"
+    private static let webKitExtractedArchivePrefix = "WebKitExtractedArchive-"
     private static let currentAppVersion =
         PluginManifestParser.trimmedNonEmpty(
             Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String)
@@ -780,7 +781,8 @@ class PluginStore {
             return
         }
 
-        for fileURL in files where fileURL.lastPathComponent.hasPrefix("WebKitExtractedArchive-") {
+        for fileURL in files
+        where fileURL.lastPathComponent.hasPrefix(Self.webKitExtractedArchivePrefix) {
             try? fileManager.removeItem(at: fileURL)
         }
     }
@@ -1162,8 +1164,60 @@ class PluginStore {
             return URL(fileURLWithPath: plugin.resourceBasePath, isDirectory: true)
         }
 
-        return pluginDirectoryURL.appending(
-            path: plugin.resourceBasePath)
+        return try extractedResourceBaseURL(forArchiveURL: archiveURL(for: plugin))
+    }
+
+    private func extractedResourceBaseURL(forArchiveURL archiveURL: URL) throws -> URL {
+        let resourceHash = try PluginManifestParser.resourceHash(forArchiveURL: archiveURL)
+        let extractedURL = extractedArchiveURL(resourceHash: resourceHash)
+        var isDirectory: ObjCBool = false
+        if fileManager.fileExists(
+            atPath: extractedURL.path(percentEncoded: false),
+            isDirectory: &isDirectory
+        ) {
+            if isDirectory.boolValue {
+                return extractedURL
+            }
+            try fileManager.removeItem(at: extractedURL)
+        }
+
+        let package = try PluginDecoder.decode(url: archiveURL)
+        let stagingURL = fileManager.temporaryDirectory.appending(
+            path: "\(Self.webKitExtractedArchivePrefix)staging-\(UUID().uuidString)",
+            directoryHint: .isDirectory
+        )
+        try? fileManager.removeItem(at: stagingURL)
+        defer {
+            try? fileManager.removeItem(at: stagingURL)
+        }
+
+        try package.extract(to: stagingURL, fileManager: fileManager)
+        if fileManager.fileExists(atPath: extractedURL.path(percentEncoded: false)) {
+            return extractedURL
+        }
+        do {
+            try fileManager.moveItem(at: stagingURL, to: extractedURL)
+        } catch {
+            var isDirectory: ObjCBool = false
+            if fileManager.fileExists(
+                atPath: extractedURL.path(percentEncoded: false),
+                isDirectory: &isDirectory
+            ),
+                isDirectory.boolValue
+            {
+                return extractedURL
+            }
+            throw error
+        }
+        return extractedURL
+    }
+
+    private func extractedArchiveURL(resourceHash: String) -> URL {
+        let hashPrefix = String(resourceHash.prefix(16))
+        return fileManager.temporaryDirectory.appending(
+            path: "\(Self.webKitExtractedArchivePrefix)\(hashPrefix)",
+            directoryHint: .isDirectory
+        )
     }
 
     private func refreshExtensionBundlePlugin(_ plugin: PluginDefinition) throws -> PluginDefinition
@@ -1200,7 +1254,8 @@ class PluginStore {
             return updated
         }
 
-        let currentHash = try PluginManifestParser.resourceHash(forArchiveURL: resourceURL)
+        let currentHash = try PluginManifestParser.resourceHash(
+            forArchiveURL: archiveURL(for: plugin))
         if let storedHash = plugin.resourceHash {
             if storedHash != currentHash {
                 updated = markPluginBlocked(updated)
@@ -1378,7 +1433,10 @@ class PluginStore {
     }
 
     private func archiveURL(for plugin: PluginDefinition) throws -> URL {
-        try resourceBaseURL(for: plugin)
+        if plugin.sourceType == .localFolder {
+            return try resourceBaseURL(for: plugin)
+        }
+        return pluginDirectoryURL.appending(path: plugin.resourceBasePath)
     }
 
     private func validateManifestRuntimeCompatibility(_ manifest: ExtensionPluginManifest) throws

--- a/kiririn/Features/Plugin/PluginStore.swift
+++ b/kiririn/Features/Plugin/PluginStore.swift
@@ -228,6 +228,7 @@ class PluginStore {
     @ObservationIgnored var onLocalFolderManifestChanged: ((UUID) -> Void)?
 
     private var resolvedManifestCache: [UUID: ExtensionPluginManifest] = [:]
+    @ObservationIgnored private var archiveHashCache: [String: String] = [:]
     @ObservationIgnored private var localManifestWatchers: [UUID: DispatchSourceFileSystemObject] =
         [:]
     @ObservationIgnored private var localManifestWatcherPaths: [UUID: String] = [:]
@@ -534,7 +535,7 @@ class PluginStore {
                     "保存済みのローカルフォルダを読み込めませんでした"
                 ])
             }
-            updated.resourceHash = try PluginManifestParser.resourceHash(forArchiveURL: archiveURL)
+            updated.resourceHash = try cachedResourceHash(forArchiveURL: archiveURL)
         case .localFolder(let url, let bookmarkData):
             guard plugin.sourceType == .localFolder else {
                 throw PluginManifestValidationError(messages: [
@@ -1164,11 +1165,22 @@ class PluginStore {
             return URL(fileURLWithPath: plugin.resourceBasePath, isDirectory: true)
         }
 
-        return try extractedResourceBaseURL(forArchiveURL: archiveURL(for: plugin))
+        return try extractedResourceBaseURL(
+            forArchiveURL: archiveURL(for: plugin),
+            storedResourceHash: plugin.resourceHash
+        )
     }
 
-    private func extractedResourceBaseURL(forArchiveURL archiveURL: URL) throws -> URL {
-        let resourceHash = try PluginManifestParser.resourceHash(forArchiveURL: archiveURL)
+    private func extractedResourceBaseURL(
+        forArchiveURL archiveURL: URL,
+        storedResourceHash: String?
+    ) throws -> URL {
+        let resourceHash: String
+        if let storedResourceHash {
+            resourceHash = storedResourceHash
+        } else {
+            resourceHash = try cachedResourceHash(forArchiveURL: archiveURL)
+        }
         let extractedURL = extractedArchiveURL(resourceHash: resourceHash)
         var isDirectory: ObjCBool = false
         if fileManager.fileExists(
@@ -1192,9 +1204,6 @@ class PluginStore {
         }
 
         try package.extract(to: stagingURL, fileManager: fileManager)
-        if fileManager.fileExists(atPath: extractedURL.path(percentEncoded: false)) {
-            return extractedURL
-        }
         do {
             try fileManager.moveItem(at: stagingURL, to: extractedURL)
         } catch {
@@ -1218,6 +1227,28 @@ class PluginStore {
             path: "\(Self.webKitExtractedArchivePrefix)\(hashPrefix)",
             directoryHint: .isDirectory
         )
+    }
+
+    private func cachedResourceHash(forArchiveURL archiveURL: URL) throws -> String {
+        let cacheKey = try? archiveHashCacheKey(forArchiveURL: archiveURL)
+        if let cacheKey, let cachedHash = archiveHashCache[cacheKey] {
+            return cachedHash
+        }
+
+        let hash = try PluginManifestParser.resourceHash(forArchiveURL: archiveURL)
+        if let cacheKey {
+            archiveHashCache[cacheKey] = hash
+        }
+        return hash
+    }
+
+    private func archiveHashCacheKey(forArchiveURL archiveURL: URL) throws -> String {
+        let path = archiveURL.standardizedFileURL.path(percentEncoded: false)
+        let attributes = try fileManager.attributesOfItem(atPath: path)
+        let fileSize = (attributes[.size] as? NSNumber)?.uint64Value ?? 0
+        let modificationDate =
+            (attributes[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
+        return "\(path)|\(fileSize)|\(modificationDate)"
     }
 
     private func refreshExtensionBundlePlugin(_ plugin: PluginDefinition) throws -> PluginDefinition
@@ -1254,8 +1285,7 @@ class PluginStore {
             return updated
         }
 
-        let currentHash = try PluginManifestParser.resourceHash(
-            forArchiveURL: archiveURL(for: plugin))
+        let currentHash = try cachedResourceHash(forArchiveURL: archiveURL(for: plugin))
         if let storedHash = plugin.resourceHash {
             if storedHash != currentHash {
                 updated = markPluginBlocked(updated)
@@ -1315,7 +1345,7 @@ class PluginStore {
             sourceType: sourceType,
             resourceBasePath: archiveFileName,
             resourceBookmark: nil,
-            resourceHash: try PluginManifestParser.resourceHash(forArchiveURL: installedArchiveURL),
+            resourceHash: try cachedResourceHash(forArchiveURL: installedArchiveURL),
             isBlocked: false,
             manifestUpdateURL: manifest.manifestUpdateURL,
             manifestVersion: manifest.version,

--- a/kiririn/Features/Plugin/PluginStore.swift
+++ b/kiririn/Features/Plugin/PluginStore.swift
@@ -200,7 +200,7 @@ class PluginStore {
     private let pluginsKey = "kiririn.plugin.definitions"
     private let developerModeKey = "kiririn.plugin.developer_mode_enabled"
     private let pluginDirectoryName = "Plugins"
-    private static let webKitExtractedArchivePrefix = "WebKitExtractedArchive-"
+    nonisolated private static let webKitExtractedArchivePrefix = "WebKitExtractedArchive-"
     private static let currentAppVersion =
         PluginManifestParser.trimmedNonEmpty(
             Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String)
@@ -488,7 +488,7 @@ class PluginStore {
         let preview: PluginInstallPreview
         switch plugin.sourceType {
         case .localFolder:
-            let localFolderURL = try resourceBaseURL(for: plugin)
+            let localFolderURL = try resourceBaseURLSynchronously(for: plugin)
             preview = try previewPlugin(
                 localFolderURL: localFolderURL,
                 bookmarkData: plugin.resourceBookmark
@@ -587,7 +587,7 @@ class PluginStore {
 
     private func localManifestURL(for plugin: PluginDefinition) -> URL? {
         guard plugin.sourceType == .localFolder,
-            let resourceURL = try? resourceBaseURL(for: plugin)
+            let resourceURL = try? resourceBaseURLSynchronously(for: plugin)
         else {
             return nil
         }
@@ -724,7 +724,18 @@ class PluginStore {
             return manifest
         }
 
-        let resourceURL = try resourceBaseURL(for: plugin)
+        let resourceURL = try resourceBaseURLSynchronously(for: plugin)
+        return try resolvedManifest(for: plugin, resourceBaseURL: resourceURL)
+    }
+
+    func resolvedManifest(
+        for plugin: PluginDefinition,
+        resourceBaseURL resourceURL: URL
+    ) throws -> ExtensionPluginManifest {
+        if let manifest = resolvedManifestCache[plugin.id] {
+            return manifest
+        }
+
         let manifest = try manifestParser.parse(
             atResourceURL: resourceURL,
             fileManager: fileManager
@@ -1139,7 +1150,29 @@ class PluginStore {
         resolvedManifestCache[plugin.id]?.pagePath(for: area)
     }
 
-    func resourceBaseURL(for plugin: PluginDefinition) throws -> URL {
+    func resourceBaseURL(for plugin: PluginDefinition) async throws -> URL {
+        if plugin.sourceType == .localFolder {
+            return try localFolderResourceBaseURL(for: plugin)
+        }
+
+        return try await extractedResourceBaseURL(
+            forArchiveURL: archiveURL(for: plugin),
+            storedResourceHash: plugin.resourceHash
+        )
+    }
+
+    private func resourceBaseURLSynchronously(for plugin: PluginDefinition) throws -> URL {
+        if plugin.sourceType == .localFolder {
+            return try localFolderResourceBaseURL(for: plugin)
+        }
+
+        return try extractedResourceBaseURLSynchronously(
+            forArchiveURL: archiveURL(for: plugin),
+            storedResourceHash: plugin.resourceHash
+        )
+    }
+
+    private func localFolderResourceBaseURL(for plugin: PluginDefinition) throws -> URL {
         if plugin.sourceType == .localFolder {
             if let bookmark = plugin.resourceBookmark {
                 var isStale = false
@@ -1165,36 +1198,95 @@ class PluginStore {
             return URL(fileURLWithPath: plugin.resourceBasePath, isDirectory: true)
         }
 
-        return try extractedResourceBaseURL(
-            forArchiveURL: archiveURL(for: plugin),
-            storedResourceHash: plugin.resourceHash
-        )
+        return pluginDirectoryURL.appending(path: plugin.resourceBasePath)
     }
 
     private func extractedResourceBaseURL(
         forArchiveURL archiveURL: URL,
         storedResourceHash: String?
-    ) throws -> URL {
-        let resourceHash: String
-        if let storedResourceHash {
-            resourceHash = storedResourceHash
-        } else {
-            resourceHash = try cachedResourceHash(forArchiveURL: archiveURL)
+    ) async throws -> URL {
+        let cacheKey = try? archiveHashCacheKey(forArchiveURL: archiveURL)
+        let cachedHash = cacheKey.flatMap { archiveHashCache[$0] }
+        let temporaryDirectory = fileManager.temporaryDirectory
+        let result = try await Task.detached(priority: .utility) {
+            try Self.extractArchiveResourceBaseURL(
+                forArchiveURL: archiveURL,
+                temporaryDirectory: temporaryDirectory,
+                storedResourceHash: storedResourceHash,
+                cachedResourceHash: cachedHash,
+                cacheKey: cacheKey
+            )
+        }.value
+
+        if let cacheKey = result.cacheKey,
+            let computedResourceHash = result.computedResourceHash
+        {
+            archiveHashCache[cacheKey] = computedResourceHash
         }
-        let extractedURL = extractedArchiveURL(resourceHash: resourceHash)
+        return result.resourceBaseURL
+    }
+
+    private func extractedResourceBaseURLSynchronously(
+        forArchiveURL archiveURL: URL,
+        storedResourceHash: String?
+    ) throws -> URL {
+        let cacheKey = try? archiveHashCacheKey(forArchiveURL: archiveURL)
+        let cachedHash = cacheKey.flatMap { archiveHashCache[$0] }
+        let result = try Self.extractArchiveResourceBaseURL(
+            forArchiveURL: archiveURL,
+            temporaryDirectory: fileManager.temporaryDirectory,
+            storedResourceHash: storedResourceHash,
+            cachedResourceHash: cachedHash,
+            cacheKey: cacheKey
+        )
+        if let cacheKey = result.cacheKey,
+            let computedResourceHash = result.computedResourceHash
+        {
+            archiveHashCache[cacheKey] = computedResourceHash
+        }
+        return result.resourceBaseURL
+    }
+
+    private struct ArchiveExtractionResult: Sendable {
+        let resourceBaseURL: URL
+        let cacheKey: String?
+        let computedResourceHash: String?
+    }
+
+    nonisolated private static func extractArchiveResourceBaseURL(
+        forArchiveURL archiveURL: URL,
+        temporaryDirectory: URL,
+        storedResourceHash: String?,
+        cachedResourceHash: String?,
+        cacheKey: String?
+    ) throws -> ArchiveExtractionResult {
+        let resourceHash = try resolvedResourceHash(
+            forArchiveURL: archiveURL,
+            storedResourceHash: storedResourceHash,
+            cachedResourceHash: cachedResourceHash
+        )
+        let computedResourceHash =
+            storedResourceHash == nil && cachedResourceHash == nil ? resourceHash : nil
+        let extractedURL = extractedArchiveURL(
+            resourceHash: resourceHash,
+            temporaryDirectory: temporaryDirectory
+        )
+        let fileManager = FileManager.default
+        let extractedPath = extractedURL.path(percentEncoded: false)
         var isDirectory: ObjCBool = false
-        if fileManager.fileExists(
-            atPath: extractedURL.path(percentEncoded: false),
-            isDirectory: &isDirectory
-        ) {
+        if fileManager.fileExists(atPath: extractedPath, isDirectory: &isDirectory) {
             if isDirectory.boolValue {
-                return extractedURL
+                return ArchiveExtractionResult(
+                    resourceBaseURL: extractedURL,
+                    cacheKey: cacheKey,
+                    computedResourceHash: computedResourceHash
+                )
             }
             try fileManager.removeItem(at: extractedURL)
         }
 
         let package = try PluginDecoder.decode(url: archiveURL)
-        let stagingURL = fileManager.temporaryDirectory.appending(
+        let stagingURL = temporaryDirectory.appending(
             path: "\(Self.webKitExtractedArchivePrefix)staging-\(UUID().uuidString)",
             directoryHint: .isDirectory
         )
@@ -1209,21 +1301,46 @@ class PluginStore {
         } catch {
             var isDirectory: ObjCBool = false
             if fileManager.fileExists(
-                atPath: extractedURL.path(percentEncoded: false),
+                atPath: extractedPath,
                 isDirectory: &isDirectory
             ),
                 isDirectory.boolValue
             {
-                return extractedURL
+                return ArchiveExtractionResult(
+                    resourceBaseURL: extractedURL,
+                    cacheKey: cacheKey,
+                    computedResourceHash: computedResourceHash
+                )
             }
             throw error
         }
-        return extractedURL
+        return ArchiveExtractionResult(
+            resourceBaseURL: extractedURL,
+            cacheKey: cacheKey,
+            computedResourceHash: computedResourceHash
+        )
     }
 
-    private func extractedArchiveURL(resourceHash: String) -> URL {
+    nonisolated private static func resolvedResourceHash(
+        forArchiveURL archiveURL: URL,
+        storedResourceHash: String?,
+        cachedResourceHash: String?
+    ) throws -> String {
+        if let storedResourceHash {
+            return storedResourceHash
+        }
+        if let cachedResourceHash {
+            return cachedResourceHash
+        }
+        return try PluginManifestParser.resourceHash(forArchiveURL: archiveURL)
+    }
+
+    nonisolated private static func extractedArchiveURL(
+        resourceHash: String,
+        temporaryDirectory: URL
+    ) -> URL {
         let hashPrefix = String(resourceHash.prefix(16))
-        return fileManager.temporaryDirectory.appending(
+        return temporaryDirectory.appending(
             path: "\(Self.webKitExtractedArchivePrefix)\(hashPrefix)",
             directoryHint: .isDirectory
         )
@@ -1253,7 +1370,7 @@ class PluginStore {
 
     private func refreshExtensionBundlePlugin(_ plugin: PluginDefinition) throws -> PluginDefinition
     {
-        let resourceURL = try resourceBaseURL(for: plugin)
+        let resourceURL = try resourceBaseURLSynchronously(for: plugin)
         let manifest = try manifestParser.parse(
             atResourceURL: resourceURL,
             fileManager: fileManager
@@ -1464,7 +1581,7 @@ class PluginStore {
 
     private func archiveURL(for plugin: PluginDefinition) throws -> URL {
         if plugin.sourceType == .localFolder {
-            return try resourceBaseURL(for: plugin)
+            return try resourceBaseURLSynchronously(for: plugin)
         }
         return pluginDirectoryURL.appending(path: plugin.resourceBasePath)
     }

--- a/kiririn/Features/ProgramGuide/ProgramGuideView.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideView.swift
@@ -714,7 +714,6 @@ struct ProgramGuideView: View {
         let typeOrder = ["GR", "BS", "CS", "SKY"]
         let sorted =
             services
-            .filter { $0.type == .digitalTelevision || $0.type == .uhdtv }
             .sorted { lhs, rhs in
                 let lhsFavorite = lhs.favoritedAt != nil
                 let rhsFavorite = rhs.favoritedAt != nil

--- a/kiririn/Features/Recordings/RecordsSections.swift
+++ b/kiririn/Features/Recordings/RecordsSections.swift
@@ -37,20 +37,16 @@ struct ServerRecordsView: View {
                         } description: {
                             Text(error)
                         } actions: {
-                            Button {
-                                Task {
-                                    await refreshRecords()
-                                }
-                            } label: {
-                                Text("再試行")
-                            }
+                            reloadButton
                         }
                     } else {
-                        ContentUnavailableView(
-                            "録画番組がありません",
-                            systemImage: "film.stack",
-                            description: Text("録画番組がある場合はここに表示されます")
-                        )
+                        ContentUnavailableView {
+                            Label("録画番組がありません", systemImage: "film.stack")
+                        } description: {
+                            Text("録画番組がある場合はここに表示されます")
+                        } actions: {
+                            reloadButton
+                        }
                     }
                 } else {
                     ScrollViewReader { proxy in
@@ -148,6 +144,16 @@ struct ServerRecordsView: View {
         .onDisappear {
             searchDebounceTask?.cancel()
             searchDebounceTask = nil
+        }
+    }
+
+    private var reloadButton: some View {
+        Button {
+            Task {
+                await refreshRecords()
+            }
+        } label: {
+            Text("再読み込み")
         }
     }
 

--- a/kiririn/Features/Services/ServiceListView.swift
+++ b/kiririn/Features/Services/ServiceListView.swift
@@ -63,10 +63,9 @@ struct ServiceListView: View {
         }
     }
 
-    private var serviceTypeFilteredServices: [TVService] {
+    private var sortedServices: [TVService] {
         let typeOrder = ["GR", "BS", "CS", "SKY"]
         return manager.services
-            .filter { $0.type == .digitalTelevision || $0.type == .uhdtv }
             .sorted { lhs, rhs in
                 let lt = lhs.channel?.type ?? "その他"
                 let rt = rhs.channel?.type ?? "その他"
@@ -295,7 +294,7 @@ struct ServiceListView: View {
 
     private var favoriteOrderingGroups: [FavoriteOrderingGroup] {
         buildServiceDisplayGroups(
-            from: serviceTypeFilteredServices.filter { manager.isFavorite($0) },
+            from: sortedServices.filter { manager.isFavorite($0) },
             usesFavoriteDisplayOrder: true
         )
         .map { group in
@@ -431,7 +430,7 @@ struct ServiceListView: View {
             return
         }
         let keyword = viewModel.searchText.normalizedForJapaneseSearch()
-        let currentServices = serviceTypeFilteredServices
+        let currentServices = sortedServices
         let favoriteServices = currentServices.filter { $0.favoritedAt != nil }
         let grouped = Dictionary(grouping: currentServices) { $0.channel?.type ?? "その他" }
         let order = ["お気に入り", "GR", "BS", "CS", "SKY"]

--- a/kiririn/Features/Settings/AboutAppView.swift
+++ b/kiririn/Features/Settings/AboutAppView.swift
@@ -7,6 +7,14 @@ import SwiftUI
 private struct AboutAppHeaderView: View {
     let buildInfo: AppBuildInfo
 
+    private var displayedVersionDescription: String {
+        #if os(macOS)
+            buildInfo.versionWithGitCommitHashDescription
+        #else
+            buildInfo.versionDescription
+        #endif
+    }
+
     var body: some View {
         VStack(spacing: 20) {
             Image("AppIconImage")
@@ -17,7 +25,7 @@ private struct AboutAppHeaderView: View {
             VStack(spacing: 6) {
                 Text("kiririn")
                     .font(.title2.bold())
-                Text("バージョン\(buildInfo.versionDescription)")
+                Text("バージョン\(displayedVersionDescription)")
                     .font(.subheadline)
                     .foregroundStyle(.primary.opacity(0.72))
             }

--- a/kiririn/Features/Settings/SettingsView.swift
+++ b/kiririn/Features/Settings/SettingsView.swift
@@ -78,6 +78,14 @@ struct SettingsView: View {
         appModel.cacheStore?.databaseFailureFeedback != nil
     }
 
+    private var displayedAppVersionDescription: String {
+        #if os(macOS)
+            buildInfo.appVersionWithGitCommitHashDescription
+        #else
+            buildInfo.appVersionDescription
+        #endif
+    }
+
     var body: some View {
         Form {
             if shouldShowCacheRecoverySection {
@@ -120,7 +128,7 @@ struct SettingsView: View {
                     Label("このアプリについて", systemImage: "info.circle")
                 }
             } footer: {
-                Text(buildInfo.appVersionDescription)
+                Text(displayedAppVersionDescription)
                     .font(.callout)
                     .foregroundStyle(.primary.opacity(0.72))
                     .frame(maxWidth: .infinity, alignment: .center)

--- a/kiririn/Shared/Models/AppBuildInfo.swift
+++ b/kiririn/Shared/Models/AppBuildInfo.swift
@@ -10,8 +10,16 @@ struct AppBuildInfo {
         "\(version) (\(buildNumber), \(gitCommitHash))"
     }
 
+    var versionWithGitCommitHashDescription: String {
+        "\(version) (\(gitCommitHash))"
+    }
+
     var appVersionDescription: String {
         "\(appName) \(versionDescription)"
+    }
+
+    var appVersionWithGitCommitHashDescription: String {
+        "\(appName) \(versionWithGitCommitHashDescription)"
     }
 
     static var current: AppBuildInfo {


### PR DESCRIPTION
Fixes #21 

This pull request introduces several improvements and refactorings across plugin extraction, service list handling, and version display logic. The most significant changes are the addition of a robust plugin extraction workflow, improved version display (including git commit hashes on macOS), and code cleanup for service list sorting and grouping.

**Plugin extraction and management improvements:**

* Added an `extract(to:fileManager:)` method to `PluginPackage`, enabling safe extraction of plugin archives to directories, with validation and directory creation.
* Refactored `PluginStore` to use a new extraction workflow: plugin archives are now extracted to a hashed temporary directory, with staging and atomic moves to prevent partial extraction. This also includes a new naming convention for extracted archives and improved cleanup logic. [[1]](diffhunk://#diff-b0eeabb1789a929b1e01a862cfc32fbc96960c6622e212c22038c8a605f0c98dR203) [[2]](diffhunk://#diff-b0eeabb1789a929b1e01a862cfc32fbc96960c6622e212c22038c8a605f0c98dL783-R785) [[3]](diffhunk://#diff-b0eeabb1789a929b1e01a862cfc32fbc96960c6622e212c22038c8a605f0c98dL1165-R1220) [[4]](diffhunk://#diff-b0eeabb1789a929b1e01a862cfc32fbc96960c6622e212c22038c8a605f0c98dL1203-R1258)
* Updated tests to cover the new extraction logic, ensuring plugins are correctly extracted to directories.

**Version display enhancements:**

* Updated version display in `AboutAppView` and `SettingsView` to include the git commit hash on macOS, improving traceability for builds. This includes new computed properties in `AppBuildInfo` for formatting version strings. [[1]](diffhunk://#diff-b9cb040d3f2154524ae6d44108852d58de350b57438991b483164085437b32f0R10-R17) [[2]](diffhunk://#diff-b9cb040d3f2154524ae6d44108852d58de350b57438991b483164085437b32f0L20-R28) [[3]](diffhunk://#diff-c4e1f3173042ffa6181c2eef05e1e1419cb06d82b47d977e01a785b16830f012R81-R88) [[4]](diffhunk://#diff-c4e1f3173042ffa6181c2eef05e1e1419cb06d82b47d977e01a785b16830f012L123-R131) [[5]](diffhunk://#diff-8b312fa92829b2274037e601ab0b3e2098e08722c0c3dd4db51f4bea282d3762R13-R24)

**Service list and program guide refactoring:**

* Simplified and unified service sorting and grouping logic by removing unnecessary filters and renaming variables for clarity in both `ServiceListView` and `ProgramGuideView`. [[1]](diffhunk://#diff-9051b722a79244438de103aec78a189f24c30ddca1c01d35b8873e81e65aed2fL66-L69) [[2]](diffhunk://#diff-9051b722a79244438de103aec78a189f24c30ddca1c01d35b8873e81e65aed2fL298-R297) [[3]](diffhunk://#diff-9051b722a79244438de103aec78a189f24c30ddca1c01d35b8873e81e65aed2fL434-R433) [[4]](diffhunk://#diff-658b49c00a189460569b74dddf083d95df4bc20ed1abc9087cd262e6b823b32dL717)

These changes improve plugin handling robustness, make versioning more informative for users and developers, and streamline service list code for maintainability.