### PR TITLE
chore: サーバー切断時もサービスを表示する

### DIFF
--- a/kiririn/Features/Server/EPGStationProvider.swift
+++ b/kiririn/Features/Server/EPGStationProvider.swift
@@ -32,6 +32,10 @@ final class EPGStationProvider: LiveServerProvider, RecordingServerProvider {
         return version
     }
 
+    func cancelInFlightRequests() {
+        client.cancelInFlightRequests()
+    }
+
     private func fetchVersion() async -> String? {
         do {
             let info: EPGStationVersionInfo = try await client.request(path: "api/version")

--- a/kiririn/Features/Server/GoogleDriveProvider.swift
+++ b/kiririn/Features/Server/GoogleDriveProvider.swift
@@ -37,6 +37,7 @@ private struct GoogleDriveCredentials {
 }
 
 final class GoogleDriveProvider: RecordingServerProvider {
+    private static let requestTimeout: TimeInterval = 60
     private let lock = NSLock()
     private var _configuration: ServerConfiguration
     var configuration: ServerConfiguration {
@@ -55,6 +56,7 @@ final class GoogleDriveProvider: RecordingServerProvider {
     var onConfigurationUpdated: (@Sendable (ServerConfiguration) -> Void)?
 
     private let logger = Logging.Logger(label: "GoogleDriveProvider")
+    private let session: URLSession
     private var _cachedFiles: [String: GoogleDriveFile] = [:]
     private var cachedFiles: [String: GoogleDriveFile] {
         get {
@@ -71,6 +73,10 @@ final class GoogleDriveProvider: RecordingServerProvider {
 
     init(configuration: ServerConfiguration) {
         self._configuration = configuration
+        let sessionConfiguration = URLSessionConfiguration.kiririnDefault
+        sessionConfiguration.timeoutIntervalForRequest = Self.requestTimeout
+        sessionConfiguration.timeoutIntervalForResource = Self.requestTimeout
+        self.session = URLSession(configuration: sessionConfiguration)
     }
 
     func checkConnection() async throws -> String? {
@@ -85,6 +91,10 @@ final class GoogleDriveProvider: RecordingServerProvider {
             headers["Authorization"] = "Bearer \(token)"
         }
         return headers
+    }
+
+    func cancelInFlightRequests() {
+        session.invalidateAndCancel()
     }
 
     private func getValidAccessToken() async throws -> String? {
@@ -131,6 +141,7 @@ final class GoogleDriveProvider: RecordingServerProvider {
         ]
 
         var request = URLRequest(url: components.url!)
+        request.timeoutInterval = Self.requestTimeout
         request.httpMethod = "POST"
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
 
@@ -138,7 +149,7 @@ final class GoogleDriveProvider: RecordingServerProvider {
         bodyComponents.queryItems = bodyItems
         request.httpBody = bodyComponents.query?.data(using: .utf8)
 
-        let (data, response) = try await URLSession.kiririnShared.data(for: request)
+        let (data, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse,
             (200...299).contains(httpResponse.statusCode)
         else {
@@ -321,11 +332,12 @@ final class GoogleDriveProvider: RecordingServerProvider {
 
         let resolvedURL = requestURL(url: url, queryItems: queryItems)
         var request = URLRequest(url: resolvedURL)
+        request.timeoutInterval = Self.requestTimeout
         for (key, value) in headers {
             request.setValue(value, forHTTPHeaderField: key)
         }
 
-        let (data, response) = try await URLSession.kiririnShared.data(for: request)
+        let (data, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw APIError.invalidResponse
@@ -436,6 +448,7 @@ private final class AuthenticationCoordinator: NSObject,
 }
 
 struct GoogleDriveAuthEditor: View {
+    private static let requestTimeout: TimeInterval = 60
     @Binding var auth: ServerAuth
     @Binding var name: String
 
@@ -538,6 +551,7 @@ struct GoogleDriveAuthEditor: View {
         ]
 
         var request = URLRequest(url: components.url!)
+        request.timeoutInterval = Self.requestTimeout
         request.httpMethod = "POST"
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
 

--- a/kiririn/Features/Server/GoogleDriveProvider.swift
+++ b/kiririn/Features/Server/GoogleDriveProvider.swift
@@ -94,7 +94,7 @@ final class GoogleDriveProvider: RecordingServerProvider {
     }
 
     func cancelInFlightRequests() {
-        session.invalidateAndCancel()
+        session.cancelAllTasks()
     }
 
     private func getValidAccessToken() async throws -> String? {

--- a/kiririn/Features/Server/KonomiTVProvider.swift
+++ b/kiririn/Features/Server/KonomiTVProvider.swift
@@ -20,6 +20,10 @@ final class KonomiTVProvider: RecordingServerProvider {
         return info.version
     }
 
+    func cancelInFlightRequests() {
+        client.cancelInFlightRequests()
+    }
+
     func fetchHeaders() async throws -> [String: String] {
         client.defaultHeaders
     }

--- a/kiririn/Features/Server/MirakurunProvider.swift
+++ b/kiririn/Features/Server/MirakurunProvider.swift
@@ -16,6 +16,10 @@ final class MirakurunProvider: LiveServerProvider {
         return status.version
     }
 
+    func cancelInFlightRequests() {
+        client.cancelInFlightRequests()
+    }
+
     func fetchHeaders() async throws -> [String: String] {
         client.defaultHeaders
     }

--- a/kiririn/Features/Server/PlaybackServerSelectionDialog.swift
+++ b/kiririn/Features/Server/PlaybackServerSelectionDialog.swift
@@ -4,6 +4,7 @@ private struct PlaybackServerSelectionDialogModifier: ViewModifier {
     let service: TVService
     @Binding var selectedService: TVService?
     let manager: ServerManager
+    let showsOnlyConnectedCandidates: Bool
     let onSelect: (TVService) -> Void
 
     func body(content: Content) -> some View {
@@ -18,11 +19,46 @@ private struct PlaybackServerSelectionDialogModifier: ViewModifier {
             ),
             titleVisibility: .visible
         ) {
-            let candidates = manager.playbackCandidates(for: service)
+            let candidates =
+                showsOnlyConnectedCandidates
+                ? manager.connectedPlaybackCandidates(for: service)
+                : manager.playbackCandidates(for: service)
             ForEach(candidates, id: \.serverId) { candidate in
                 Button(manager.serverFullDisplayName(candidate.serverId)) {
                     selectedService = nil
                     onSelect(candidate)
+                }
+            }
+            Button("キャンセル", role: .cancel) {
+                selectedService = nil
+            }
+        }
+    }
+}
+
+private struct ReconnectionServerSelectionDialogModifier: ViewModifier {
+    let service: TVService
+    @Binding var selectedService: TVService?
+    let manager: ServerManager
+    let onSelect: (String) -> Void
+
+    func body(content: Content) -> some View {
+        content.confirmationDialog(
+            "再接続するサーバーを選択",
+            isPresented: Binding(
+                get: { selectedService?.id == service.id },
+                set: { isPresented in
+                    guard !isPresented, selectedService?.id == service.id else { return }
+                    selectedService = nil
+                }
+            ),
+            titleVisibility: .visible
+        ) {
+            let candidates = manager.reconnectionCandidates(for: service)
+            ForEach(candidates, id: \.serverId) { candidate in
+                Button(manager.serverFullDisplayName(candidate.serverId)) {
+                    selectedService = nil
+                    onSelect(candidate.serverId)
                 }
             }
             Button("キャンセル", role: .cancel) {
@@ -37,10 +73,28 @@ extension View {
         service: TVService,
         selectedService: Binding<TVService?>,
         manager: ServerManager,
+        showsOnlyConnectedCandidates: Bool = false,
         onSelect: @escaping (TVService) -> Void
     ) -> some View {
         modifier(
             PlaybackServerSelectionDialogModifier(
+                service: service,
+                selectedService: selectedService,
+                manager: manager,
+                showsOnlyConnectedCandidates: showsOnlyConnectedCandidates,
+                onSelect: onSelect
+            )
+        )
+    }
+
+    func reconnectionServerSelectionDialog(
+        service: TVService,
+        selectedService: Binding<TVService?>,
+        manager: ServerManager,
+        onSelect: @escaping (String) -> Void
+    ) -> some View {
+        modifier(
+            ReconnectionServerSelectionDialogModifier(
                 service: service,
                 selectedService: selectedService,
                 manager: manager,

--- a/kiririn/Features/Server/ServerManager.swift
+++ b/kiririn/Features/Server/ServerManager.swift
@@ -312,6 +312,9 @@ class ServerManager {
             rebuildAggregatedData()
             return .skipped
         }
+        guard state.status != .connecting else {
+            return .skipped
+        }
 
         state.status = .connecting
         clearLastError(for: state)
@@ -366,7 +369,6 @@ class ServerManager {
 
             let fetchedLogos = await fetchLogoData(
                 for: fetchedServices,
-                serverId: serverId,
                 provider: provider
             )
             guard !isStaleOperation(serverId: serverId, generation: generation) else {
@@ -815,7 +817,6 @@ class ServerManager {
 
     private func fetchLogoData(
         for services: [TVService],
-        serverId: String,
         provider: any LiveServerProvider
     ) async
         -> [TVServiceLogo]

--- a/kiririn/Features/Server/ServerManager.swift
+++ b/kiririn/Features/Server/ServerManager.swift
@@ -50,6 +50,15 @@ nonisolated enum ProgramCatalogRefreshExecutionResult: Sendable, Equatable {
     case failed(String)
 }
 
+nonisolated struct PlaybackReconnectionState: Sendable, Equatable {
+    let needsReconnection: Bool
+    let hasConnectingCandidate: Bool
+
+    var isAwaitingReconnection: Bool {
+        needsReconnection && !hasConnectingCandidate
+    }
+}
+
 #if !os(macOS)
     nonisolated private enum ProgramFetchNetworkState: Sendable {
         case unresolved
@@ -952,9 +961,21 @@ class ServerManager {
         }
     }
 
+    func playbackReconnectionState(for service: TVService) -> PlaybackReconnectionState {
+        let connectedCandidates = connectedPlaybackCandidates(for: service)
+        let reconnectionCandidates = reconnectionCandidates(for: service)
+        let hasConnectingCandidate = reconnectionCandidates.contains {
+            connectionStates[$0.serverId]?.status == .connecting
+        }
+
+        return PlaybackReconnectionState(
+            needsReconnection: connectedCandidates.isEmpty && !reconnectionCandidates.isEmpty,
+            hasConnectingCandidate: hasConnectingCandidate
+        )
+    }
+
     func needsReconnectionForPlayback(_ service: TVService) -> Bool {
-        connectedPlaybackCandidates(for: service).isEmpty
-            && !reconnectionCandidates(for: service).isEmpty
+        playbackReconnectionState(for: service).needsReconnection
     }
 
     private func candidateServices(for service: TVService) -> [TVService] {

--- a/kiririn/Features/Server/ServerManager.swift
+++ b/kiririn/Features/Server/ServerManager.swift
@@ -74,6 +74,7 @@ class ServerManager {
 
     private var cacheStore: CacheStore!
     private var serviceVariantsByAggregatedServiceId: [String: [TVService]] = [:]
+    private var serviceListVariantsByAggregatedServiceId: [String: [TVService]] = [:]
     private var servicesByUniqueId: [String: TVService] = [:]
     private var cachedServicesByServer: [String: [TVService]] = [:]
     private var favoriteStatesByUnifiedKey: [String: FavoriteServiceState] = [:]
@@ -83,6 +84,8 @@ class ServerManager {
     private var pendingProgramFullFetchServerIDs: Set<String> = []
     @ObservationIgnored
     private var periodicProgramRefreshTask: Task<Void, Never>?
+    @ObservationIgnored
+    private var serverOperationGenerations: [String: Int] = [:]
     @ObservationIgnored
     private var isAutomaticProgramRefreshEvaluationRunning = false
     #if !os(macOS)
@@ -97,6 +100,7 @@ class ServerManager {
     #endif
 
     var isCacheReady = false
+    var serviceListServices: [TVService] = []
     var services: [TVService] = []
     var logos: [TVServiceLogo] = [] {
         didSet {
@@ -162,6 +166,7 @@ class ServerManager {
         for config in configStore.configurations {
             if providers[config.id] != nil {
                 if providerConfigurations[config.id] != config {
+                    cancelInFlightRequests(serverId: config.id)
                     providers[config.id] = createProvider(for: config)
                     providerConfigurations[config.id] = config
                     connectionStates[config.id]?.status = .disconnected
@@ -185,12 +190,14 @@ class ServerManager {
 
         let validIds = Set(configStore.configurations.map(\.id))
         for key in providers.keys where !validIds.contains(key) {
+            cancelInFlightRequests(serverId: key)
             providers.removeValue(forKey: key)
             providerConfigurations.removeValue(forKey: key)
             connectionStates.removeValue(forKey: key)
             cachedServicesByServer[key] = nil
             lastProgramFullFetchDatesByServer[key] = nil
             pendingProgramFullFetchServerIDs.remove(key)
+            serverOperationGenerations.removeValue(forKey: key)
         }
 
         serverSyncCount += 1
@@ -211,6 +218,19 @@ class ServerManager {
     private func noteCommunicationFailure(for error: Error) {
         guard !isCancellationError(error) else { return }
         communicationFailureCount += 1
+    }
+
+    private func cancelInFlightRequests(serverId: String) {
+        serverOperationGenerations[serverId, default: 0] += 1
+        providers[serverId]?.cancelInFlightRequests()
+    }
+
+    private func operationGeneration(for serverId: String) -> Int {
+        serverOperationGenerations[serverId] ?? 0
+    }
+
+    private func isStaleOperation(serverId: String, generation: Int) -> Bool {
+        operationGeneration(for: serverId) != generation
     }
 
     private func errorFeedback(for error: Error) -> (
@@ -281,6 +301,7 @@ class ServerManager {
         serverId: String,
         programRefreshPolicy: ProgramCatalogRefreshPolicy = .none
     ) async -> ProgramCatalogRefreshExecutionResult {
+        let generation = operationGeneration(for: serverId)
         guard let provider = providers[serverId],
             let state = connectionStates[serverId]
         else { return .skipped }
@@ -300,12 +321,18 @@ class ServerManager {
 
         do {
             let version = try await provider.checkConnection()
+            guard !isStaleOperation(serverId: serverId, generation: generation) else {
+                return .skipped
+            }
             state.status = .connected
             state.lastConnectedAt = Date()
             state.version = version
             return await refreshData(
                 serverId: serverId, programRefreshPolicy: programRefreshPolicy)
         } catch {
+            guard !isStaleOperation(serverId: serverId, generation: generation) else {
+                return .skipped
+            }
             state.status = .error
             let message = recordLastError(error, for: state)
             state.version = nil
@@ -320,6 +347,7 @@ class ServerManager {
         serverId: String,
         programRefreshPolicy: ProgramCatalogRefreshPolicy = .none
     ) async -> ProgramCatalogRefreshExecutionResult {
+        let generation = operationGeneration(for: serverId)
         guard let provider = liveProvider(for: serverId),
             let state = connectionStates[serverId],
             state.status == .connected
@@ -329,11 +357,21 @@ class ServerManager {
 
         do {
             let fetchedServices = try await provider.fetchServices()
+            guard !isStaleOperation(serverId: serverId, generation: generation) else {
+                return .skipped
+            }
             cachedServicesByServer[serverId] = fetchedServices
             await cacheStore.cacheServices(fetchedServices, serverId: serverId)
             rebuildAggregatedData()
 
-            let fetchedLogos = await fetchLogoData(for: fetchedServices, serverId: serverId)
+            let fetchedLogos = await fetchLogoData(
+                for: fetchedServices,
+                serverId: serverId,
+                provider: provider
+            )
+            guard !isStaleOperation(serverId: serverId, generation: generation) else {
+                return .skipped
+            }
             mergeLogos(fetchedLogos)
             await cacheStore.cacheLogos(fetchedLogos)
             rebuildAggregatedData()
@@ -349,6 +387,9 @@ class ServerManager {
             case .fetchNow:
                 do {
                     let fetchedPrograms = try await provider.fetchPrograms()
+                    guard !isStaleOperation(serverId: serverId, generation: generation) else {
+                        return .skipped
+                    }
                     await cacheStore.cachePrograms(fetchedPrograms, serverId: serverId)
                     clearLastError(for: state)
                     lastProgramFullFetchDatesByServer[serverId] = Date()
@@ -356,6 +397,9 @@ class ServerManager {
                     rebuildAggregatedData()
                     return .refreshed
                 } catch {
+                    guard !isStaleOperation(serverId: serverId, generation: generation) else {
+                        return .skipped
+                    }
                     state.status = .error
                     let message = recordLastError(error, for: state)
                     state.version = nil
@@ -368,6 +412,9 @@ class ServerManager {
                 }
             }
         } catch {
+            guard !isStaleOperation(serverId: serverId, generation: generation) else {
+                return .skipped
+            }
             state.status = .error
             let message = recordLastError(error, for: state)
             state.version = nil
@@ -639,12 +686,34 @@ class ServerManager {
     }
 
     private func rebuildAggregatedData() {
+        let playbackData = buildAggregatedServiceData(includesConnectionErrors: false)
+        let serviceListData = buildAggregatedServiceData(includesConnectionErrors: true)
+
+        serviceVariantsByAggregatedServiceId = playbackData.variantsByAggregatedServiceId
+        serviceListVariantsByAggregatedServiceId = serviceListData.variantsByAggregatedServiceId
+        servicesByUniqueId = playbackData.resolvedServicesByUniqueId
+        services = playbackData.services
+        serviceListServices = serviceListData.services
+    }
+
+    private struct AggregatedServiceData {
+        var services: [TVService]
+        var variantsByAggregatedServiceId: [String: [TVService]]
+        var resolvedServicesByUniqueId: [String: TVService]
+    }
+
+    private func buildAggregatedServiceData(includesConnectionErrors: Bool) -> AggregatedServiceData
+    {
         var variantsByMergedKey: [String: [TVService]] = [:]
         var variantsByAggregatedServiceId: [String: [TVService]] = [:]
         var resolvedServicesByUniqueId: [String: TVService] = [:]
 
         for config in configStore.configurations {
-            guard shouldIncludeServerInAggregation(serverId: config.id) else { continue }
+            let shouldInclude =
+                includesConnectionErrors
+                ? shouldIncludeServerInServiceListAggregation(serverId: config.id)
+                : shouldIncludeServerInAggregation(serverId: config.id)
+            guard shouldInclude else { continue }
 
             let cachedServices = cachedServicesByServer[config.id] ?? []
 
@@ -667,9 +736,11 @@ class ServerManager {
             variantsByAggregatedServiceId[preferred.id] = sortedVariants
         }
 
-        serviceVariantsByAggregatedServiceId = variantsByAggregatedServiceId
-        servicesByUniqueId = resolvedServicesByUniqueId
-        services = mergedServices
+        return AggregatedServiceData(
+            services: mergedServices,
+            variantsByAggregatedServiceId: variantsByAggregatedServiceId,
+            resolvedServicesByUniqueId: resolvedServicesByUniqueId
+        )
     }
 
     private func rebuildLogoCache() {
@@ -720,6 +791,11 @@ class ServerManager {
         return state.status != .error
     }
 
+    private func shouldIncludeServerInServiceListAggregation(serverId: String) -> Bool {
+        guard isServerEnabled(serverId) else { return false }
+        return serverSupports(.live, serverId: serverId)
+    }
+
     private func sortServicesByServerPriority(_ services: [TVService]) -> [TVService] {
         let order = Dictionary(
             uniqueKeysWithValues: configStore.configurations.enumerated().map { ($1.id, $0) })
@@ -737,11 +813,13 @@ class ServerManager {
         variants.first
     }
 
-    private func fetchLogoData(for services: [TVService], serverId: String) async
+    private func fetchLogoData(
+        for services: [TVService],
+        serverId: String,
+        provider: any LiveServerProvider
+    ) async
         -> [TVServiceLogo]
     {
-        guard let provider = providers[serverId] as? any LiveServerProvider else { return [] }
-
         return await withTaskGroup(of: TVServiceLogo?.self) { group in
             let oneweekago = Date().addingTimeInterval(-86400 * 7)
             var result: [TVServiceLogo] = []
@@ -858,6 +936,27 @@ class ServerManager {
     }
 
     func playbackCandidates(for service: TVService) -> [TVService] {
+        candidateServices(for: service)
+    }
+
+    func connectedPlaybackCandidates(for service: TVService) -> [TVService] {
+        candidateServices(for: service).filter {
+            connectionStates[$0.serverId]?.status == .connected
+        }
+    }
+
+    func reconnectionCandidates(for service: TVService) -> [TVService] {
+        serviceListCandidateServices(for: service).filter {
+            connectionStates[$0.serverId]?.status != .connected
+        }
+    }
+
+    func needsReconnectionForPlayback(_ service: TVService) -> Bool {
+        connectedPlaybackCandidates(for: service).isEmpty
+            && !reconnectionCandidates(for: service).isEmpty
+    }
+
+    private func candidateServices(for service: TVService) -> [TVService] {
         if let variants = serviceVariantsByAggregatedServiceId[service.id] {
             return sortServicesByServerPriority(variants).filter {
                 isServerEnabled($0.serverId) && serverSupports(.live, serverId: $0.serverId)
@@ -867,6 +966,15 @@ class ServerManager {
             serverSupports(.live, serverId: service.serverId)
         else { return [] }
         return [service]
+    }
+
+    private func serviceListCandidateServices(for service: TVService) -> [TVService] {
+        if let variants = serviceListVariantsByAggregatedServiceId[service.id] {
+            return sortServicesByServerPriority(variants).filter {
+                isServerEnabled($0.serverId) && serverSupports(.live, serverId: $0.serverId)
+            }
+        }
+        return candidateServices(for: service)
     }
 
     func serverDisplayName(_ serverId: String) -> String {

--- a/kiririn/Features/Server/ServerProvider.swift
+++ b/kiririn/Features/Server/ServerProvider.swift
@@ -3,6 +3,7 @@ import Foundation
 protocol ServerProvider {
     func checkConnection() async throws -> String?
     func fetchHeaders() async throws -> [String: String]
+    func cancelInFlightRequests()
 }
 
 protocol LiveServerProvider: ServerProvider {

--- a/kiririn/Features/Services/ServiceListView.swift
+++ b/kiririn/Features/Services/ServiceListView.swift
@@ -221,11 +221,7 @@ struct ServiceListView: View {
 
     @ViewBuilder
     private func serviceRow(for item: ServiceListItem) -> some View {
-        let needsReconnection = manager.needsReconnectionForPlayback(item.service)
-        let hasConnectingCandidate = manager.reconnectionCandidates(for: item.service).contains {
-            manager.connectionStates[$0.serverId]?.status == .connecting
-        }
-        let dimsForReconnection = needsReconnection && !hasConnectingCandidate
+        let reconnectionState = manager.playbackReconnectionState(for: item.service)
 
         ServiceRowView(
             service: item.service,
@@ -235,7 +231,7 @@ struct ServiceListView: View {
             isFavorite: manager.isFavorite(item.service),
             logoImage: manager.logoImage(for: item.service)
         ) {
-            if needsReconnection {
+            if reconnectionState.needsReconnection {
                 serviceSelectionForReconnection = item.service
             } else {
                 Task { await playService(item.service) }
@@ -243,7 +239,7 @@ struct ServiceListView: View {
         } onToggleFavorite: {
             Task { await manager.toggleFavorite(item.service) }
         }
-        .opacity(dimsForReconnection ? 0.45 : 1)
+        .opacity(reconnectionState.isAwaitingReconnection ? 0.45 : 1)
         .playbackServerSelectionDialog(
             service: item.service,
             selectedService: $serviceSelectionForPlayback,

--- a/kiririn/Features/Services/ServiceListView.swift
+++ b/kiririn/Features/Services/ServiceListView.swift
@@ -21,6 +21,7 @@ struct ServiceListView: View {
         @Environment(\.openWindow) private var openWindow
     #endif
     @State private var serviceSelectionForPlayback: TVService?
+    @State private var serviceSelectionForReconnection: TVService?
     @State private var showingFavoriteOrderingSheet = false
     @State private var viewModel = ServiceListViewModel()
     @State private var minuteRefreshTick = Date()
@@ -65,7 +66,7 @@ struct ServiceListView: View {
 
     private var sortedServices: [TVService] {
         let typeOrder = ["GR", "BS", "CS", "SKY"]
-        return manager.services
+        return manager.serviceListServices
             .sorted { lhs, rhs in
                 let lt = lhs.channel?.type ?? "その他"
                 let rt = rhs.channel?.type ?? "その他"
@@ -83,7 +84,7 @@ struct ServiceListView: View {
     var body: some View {
         VStack(spacing: 0) {
             Group {
-                if manager.isCacheReady && manager.services.isEmpty {
+                if manager.isCacheReady && manager.serviceListServices.isEmpty {
                     emptyStateView
                 } else if groupedServices.isEmpty {
                     if isBuildingList {
@@ -114,7 +115,7 @@ struct ServiceListView: View {
             guard isReady else { return }
             triggerRebuild()
         }
-        .onChange(of: manager.services) {
+        .onChange(of: manager.serviceListServices) {
             triggerRebuild()
         }
         .sheet(isPresented: $showingFavoriteOrderingSheet) {
@@ -220,6 +221,12 @@ struct ServiceListView: View {
 
     @ViewBuilder
     private func serviceRow(for item: ServiceListItem) -> some View {
+        let needsReconnection = manager.needsReconnectionForPlayback(item.service)
+        let hasConnectingCandidate = manager.reconnectionCandidates(for: item.service).contains {
+            manager.connectionStates[$0.serverId]?.status == .connecting
+        }
+        let dimsForReconnection = needsReconnection && !hasConnectingCandidate
+
         ServiceRowView(
             service: item.service,
             currentProgram: item.currentProgram,
@@ -228,16 +235,29 @@ struct ServiceListView: View {
             isFavorite: manager.isFavorite(item.service),
             logoImage: manager.logoImage(for: item.service)
         ) {
-            Task { await playService(item.service) }
+            if needsReconnection {
+                serviceSelectionForReconnection = item.service
+            } else {
+                Task { await playService(item.service) }
+            }
         } onToggleFavorite: {
             Task { await manager.toggleFavorite(item.service) }
         }
+        .opacity(dimsForReconnection ? 0.45 : 1)
         .playbackServerSelectionDialog(
             service: item.service,
             selectedService: $serviceSelectionForPlayback,
-            manager: manager
+            manager: manager,
+            showsOnlyConnectedCandidates: true
         ) { candidate in
             Task { await playCandidate(candidate) }
+        }
+        .reconnectionServerSelectionDialog(
+            service: item.service,
+            selectedService: $serviceSelectionForReconnection,
+            manager: manager
+        ) { serverId in
+            Task { await manager.connect(serverId: serverId) }
         }
     }
 
@@ -266,12 +286,17 @@ struct ServiceListView: View {
     }
 
     private func playService(_ service: TVService) async {
-        let candidates = manager.playbackCandidates(for: service)
+        let candidates = manager.connectedPlaybackCandidates(for: service)
+        guard !candidates.isEmpty else {
+            serviceSelectionForReconnection = service
+            return
+        }
         if candidates.count > 1 {
             serviceSelectionForPlayback = service
             return
         }
-        await playCandidate(candidates.first ?? service)
+        guard let candidate = candidates.first else { return }
+        await playCandidate(candidate)
     }
 
     private func playCandidate(_ service: TVService) async {

--- a/kiririn/Shared/Infrastructure/APIClient.swift
+++ b/kiririn/Shared/Infrastructure/APIClient.swift
@@ -2,6 +2,7 @@ import Foundation
 import Logging
 
 nonisolated final class APIClient: Sendable {
+    private static let requestTimeout: TimeInterval = 60
     let baseURL: URL?
     let defaultHeaders: [String: String]
     private let session: URLSession
@@ -33,8 +34,13 @@ nonisolated final class APIClient: Sendable {
         self.defaultHeaders = headers
 
         let config = URLSessionConfiguration.kiririnDefault
-        config.timeoutIntervalForRequest = 15
+        config.timeoutIntervalForRequest = Self.requestTimeout
+        config.timeoutIntervalForResource = Self.requestTimeout
         self.session = URLSession(configuration: config)
+    }
+
+    func cancelInFlightRequests() {
+        session.invalidateAndCancel()
     }
 
     func request<T: Decodable & Sendable>(
@@ -45,6 +51,7 @@ nonisolated final class APIClient: Sendable {
             throw APIError.invalidURL
         }
         var request = URLRequest(url: url)
+        request.timeoutInterval = Self.requestTimeout
         for (key, value) in defaultHeaders {
             request.setValue(value, forHTTPHeaderField: key)
         }
@@ -111,6 +118,7 @@ nonisolated final class APIClient: Sendable {
             throw APIError.invalidURL
         }
         var request = URLRequest(url: url)
+        request.timeoutInterval = Self.requestTimeout
         for (key, value) in defaultHeaders {
             request.setValue(value, forHTTPHeaderField: key)
         }

--- a/kiririn/Shared/Infrastructure/APIClient.swift
+++ b/kiririn/Shared/Infrastructure/APIClient.swift
@@ -40,7 +40,7 @@ nonisolated final class APIClient: Sendable {
     }
 
     func cancelInFlightRequests() {
-        session.invalidateAndCancel()
+        session.cancelAllTasks()
     }
 
     func request<T: Decodable & Sendable>(

--- a/kiririn/Shared/Infrastructure/URLSessionUserAgent.swift
+++ b/kiririn/Shared/Infrastructure/URLSessionUserAgent.swift
@@ -33,4 +33,12 @@ extension URLSession {
     static let kiririnShared: URLSession = {
         URLSession(configuration: .kiririnDefault)
     }()
+
+    nonisolated func cancelAllTasks() {
+        getAllTasks { tasks in
+            for task in tasks {
+                task.cancel()
+            }
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces several improvements to server management, focusing on better cancellation and isolation of in-flight network requests, enhanced timeout handling, and new UI options for selecting servers. The main changes ensure that when a server is reconfigured or removed, any ongoing network operations are properly cancelled and stale results are not applied. Additionally, the Google Drive provider now uses its own session with consistent timeouts, and new dialog options are added for selecting connected or reconnection server candidates.

**Server operation cancellation and isolation:**

* Added `cancelInFlightRequests()` to all server providers and integrated it into `ServerManager` so that ongoing requests are cancelled when a server is reconfigured or removed. Introduced operation generations to prevent stale async results from affecting state. [[1]](diffhunk://#diff-f7c3d951e6fdf6fffa72c22fd0860db837ae8bd0e5c95401ab1d34ee1ec595a6R169) [[2]](diffhunk://#diff-f7c3d951e6fdf6fffa72c22fd0860db837ae8bd0e5c95401ab1d34ee1ec595a6R193-R200) [[3]](diffhunk://#diff-f7c3d951e6fdf6fffa72c22fd0860db837ae8bd0e5c95401ab1d34ee1ec595a6R223-R235) [[4]](diffhunk://#diff-f7c3d951e6fdf6fffa72c22fd0860db837ae8bd0e5c95401ab1d34ee1ec595a6R304) [[5]](diffhunk://#diff-f7c3d951e6fdf6fffa72c22fd0860db837ae8bd0e5c95401ab1d34ee1ec595a6R324-R335) [[6]](diffhunk://#diff-f7c3d951e6fdf6fffa72c22fd0860db837ae8bd0e5c95401ab1d34ee1ec595a6R350) [[7]](diffhunk://#diff-f7c3d951e6fdf6fffa72c22fd0860db837ae8bd0e5c95401ab1d34ee1ec595a6R360-R374) [[8]](diffhunk://#diff-f7c3d951e6fdf6fffa72c22fd0860db837ae8bd0e5c95401ab1d34ee1ec595a6R390-R402) [[9]](diffhunk://#diff-f7c3d951e6fdf6fffa72c22fd0860db837ae8bd0e5c95401ab1d34ee1ec595a6R415-R417) [[10]](diffhunk://#diff-0b7083ec7dc201291318ca520d355f939bee73e998720636798261112a8ef71aR35-R38) [[11]](diffhunk://#diff-3423ef6168d1501f40fd6eff15ff6f4c66501bea7cef5518d4ef675c76b4c71fR23-R26) [[12]](diffhunk://#diff-1631a261c39c45fb3852351b3b8ba0573e81e55e36183585cd02e4a15600a439R19-R22)

**Google Drive provider improvements:**

* Added a dedicated `URLSession` with a consistent 60-second timeout for all requests, and ensured all network calls use this session. Provided a `cancelInFlightRequests()` implementation that cancels all ongoing requests. [[1]](diffhunk://#diff-9fd06137d0ceb3721160340ae10f703bb0afd0037e48d744ec65944ecad748bdR40) [[2]](diffhunk://#diff-9fd06137d0ceb3721160340ae10f703bb0afd0037e48d744ec65944ecad748bdR59) [[3]](diffhunk://#diff-9fd06137d0ceb3721160340ae10f703bb0afd0037e48d744ec65944ecad748bdR76-R79) [[4]](diffhunk://#diff-9fd06137d0ceb3721160340ae10f703bb0afd0037e48d744ec65944ecad748bdR96-R99) [[5]](diffhunk://#diff-9fd06137d0ceb3721160340ae10f703bb0afd0037e48d744ec65944ecad748bdR144-R152) [[6]](diffhunk://#diff-9fd06137d0ceb3721160340ae10f703bb0afd0037e48d744ec65944ecad748bdR335-R340)
* Ensured all relevant `URLRequest` calls in both the provider and the authentication editor use the new timeout value. [[1]](diffhunk://#diff-9fd06137d0ceb3721160340ae10f703bb0afd0037e48d744ec65944ecad748bdR451) [[2]](diffhunk://#diff-9fd06137d0ceb3721160340ae10f703bb0afd0037e48d744ec65944ecad748bdR554)

**UI: Server selection dialogs:**

* Added new `showsOnlyConnectedCandidates` option for playback server selection dialogs, and introduced a new reconnection server selection dialog for choosing a server to reconnect to. [[1]](diffhunk://#diff-5d1883614546e54a263ee42001e685d1c78223b25d8efcf60aee91bb9b2d4b7bR7) [[2]](diffhunk://#diff-5d1883614546e54a263ee42001e685d1c78223b25d8efcf60aee91bb9b2d4b7bL21-R25) [[3]](diffhunk://#diff-5d1883614546e54a263ee42001e685d1c78223b25d8efcf60aee91bb9b2d4b7bR39-R97)

**Internal data structures:**

* Added new properties to `ServerManager` for tracking service variants and operation generations, and to support the new selection dialogs and operation isolation. [[1]](diffhunk://#diff-f7c3d951e6fdf6fffa72c22fd0860db837ae8bd0e5c95401ab1d34ee1ec595a6R77) [[2]](diffhunk://#diff-f7c3d951e6fdf6fffa72c22fd0860db837ae8bd0e5c95401ab1d34ee1ec595a6R88-R89) [[3]](diffhunk://#diff-f7c3d951e6fdf6fffa72c22fd0860db837ae8bd0e5c95401ab1d34ee1ec595a6R103)

These changes collectively improve the robustness of server operations and enhance the flexibility and reliability of the user interface for server selection.

## Summary by Sourcery

Improve robustness of server operations by cancelling in-flight requests on reconfiguration/removal, isolating stale async results via per-server operation generations, and refining service aggregation for playback versus service list views.

New Features:
- Add separate aggregated service list distinct from playback services to support service-list-specific behavior and UI.
- Introduce playback server selection options for showing only currently connected candidates and a dedicated reconnection server selection dialog.
- Provide reconnection flow from the service list that prompts server selection and initiates reconnect before playback.

Bug Fixes:
- Avoid applying stale results from long-running server operations after servers are reconfigured or removed by tracking per-server operation generations.
- Prevent concurrent or repeated connection attempts from interfering with server state by skipping operations when a server is already connecting.

Enhancements:
- Add cancelInFlightRequests capability to all server providers and integrate it into ServerManager lifecycle to ensure network operations are stopped when servers change.
- Unify network timeout handling by using 60-second request/resource timeouts across the shared API client and Google Drive provider, and applying them to all relevant URLRequests.
- Refactor aggregated service rebuilding into a reusable data builder that supports different inclusion rules for playback and service list aggregation.