### PR TITLE
chore: 仮マーケティングバージョンを導入しv0.1.2に設定

### DIFF
--- a/kiririn.xcodeproj/project.pbxproj
+++ b/kiririn.xcodeproj/project.pbxproj
@@ -582,6 +582,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 18.4;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				KIRIRIN_TEMPORARY_MARKETING_VERSION = 0.1.2;
 				MACOSX_DEPLOYMENT_TARGET = 15.4;
 				MARKETING_VERSION = 0.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.pronama.kiririn;
@@ -654,6 +655,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 18.4;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				KIRIRIN_TEMPORARY_MARKETING_VERSION = 0.1.2;
 				MACOSX_DEPLOYMENT_TARGET = 15.4;
 				MARKETING_VERSION = 0.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.pronama.kiririn;

--- a/kiririn/Info.plist
+++ b/kiririn/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>KiririnTemporaryMarketingVersion</key>
+	<string>$(KIRIRIN_TEMPORARY_MARKETING_VERSION)</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>ローカルネットワーク上のサーバーと通信します。</string>
 	<key>CFBundleDocumentTypes</key>

--- a/kiririn/Shared/Models/AppBuildInfo.swift
+++ b/kiririn/Shared/Models/AppBuildInfo.swift
@@ -3,15 +3,20 @@ import Foundation
 struct AppBuildInfo {
     let appName: String
     let version: String
+    let temporaryMarketingVersion: String?
     let buildNumber: String
     let gitCommitHash: String
 
+    private var displayedVersion: String {
+        temporaryMarketingVersion ?? version
+    }
+
     var versionDescription: String {
-        "\(version) (\(buildNumber), \(gitCommitHash))"
+        "\(displayedVersion) (\(buildNumber), \(gitCommitHash))"
     }
 
     var versionWithGitCommitHashDescription: String {
-        "\(version) (\(gitCommitHash))"
+        "\(displayedVersion) (\(gitCommitHash))"
     }
 
     var appVersionDescription: String {
@@ -29,6 +34,10 @@ struct AppBuildInfo {
     init(bundle: Bundle) {
         appName = Self.infoValue("CFBundleDisplayName", from: bundle, fallback: "kiririn")
         version = Self.infoValue("CFBundleShortVersionString", from: bundle)
+        temporaryMarketingVersion = Self.optionalInfoValue(
+            "KiririnTemporaryMarketingVersion",
+            from: bundle
+        )
         buildNumber = Self.infoValue("CFBundleVersion", from: bundle)
         gitCommitHash = Self.infoValue("KiririnGitCommitHash", from: bundle)
     }
@@ -38,6 +47,14 @@ struct AppBuildInfo {
     {
         guard let value = bundle.object(forInfoDictionaryKey: key) as? String, !value.isEmpty else {
             return fallback
+        }
+
+        return value
+    }
+
+    private static func optionalInfoValue(_ key: String, from bundle: Bundle) -> String? {
+        guard let value = bundle.object(forInfoDictionaryKey: key) as? String, !value.isEmpty else {
+            return nil
         }
 
         return value


### PR DESCRIPTION
TestFlightにてマーケティングバージョンをコロコロ上げるのは微妙な運用のようなので、表示上のバージョンだけ上げる運用とします。TestFlight上の表示と差異が生じますが許容する。

## Summary by Sourcery

Update Xcode project configuration for the kiririn app for the v0.1.2 release.