### PR TITLE
chore: VLCKit更新 (#11)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # VLCKit
 # https://github.com/neneka/vlckit/releases
-REVISION="202607110626"
+REVISION="202607120204"
 VLCKIT_URL="https://github.com/neneka/vlckit/releases/download/$REVISION/VLCKit-iOS-REPLACEWITHVERSION.dmg"
 VLCKIT_DEST="./Packages/VLCKit"
 FRAMEWORK_DEST="${VLCKIT_DEST}/VLCKit.xcframework"


### PR DESCRIPTION
Fixes #11 

https://github.com/neneka/vlckit/pull/53 の修正を取り込みます

## Summary by Sourcery

Build:
- Update VLCKit revision ID in setup.sh to fetch the newer VLCKit release.