### PR TITLE
feat: 番組表を拡大縮小出来るように (#14)

### DIFF
--- a/kiririn/Features/ProgramGuide/ProgramGuidePlatformModifiers.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuidePlatformModifiers.swift
@@ -39,13 +39,52 @@ import SwiftUI
         }
     }
 
-    private struct ProgramGuideSearchToolbarModifier: ViewModifier {
+    private struct ProgramGuideToolbarModifier: ViewModifier {
         let isSearchSheetPresented: Binding<Bool>
+        let onResetZoom: () -> Void
+        let selectedBroadcastType: Binding<String>
+        let broadcastFilterOptions: [(id: String, name: String)]
+        let timelineOffsetHours: Binding<Int>
+        let onScrollToNow: () -> Void
         @Environment(\.isTabActive) private var isTabActive
 
         func body(content: Content) -> some View {
             content.toolbar {
                 if isTabActive {
+                    ToolbarItem(placement: .automatic) {
+                        Picker("絞り込み", selection: selectedBroadcastType) {
+                            ForEach(broadcastFilterOptions, id: \.id) { option in
+                                Text(option.name).tag(option.id)
+                            }
+                        }
+                        .labelsHidden()
+                        .fixedSize()
+                        .help("放送種別を絞り込む")
+                    }
+
+                    ToolbarItem(placement: .automatic) {
+                        Button {
+                            onResetZoom()
+                        } label: {
+                            Label(
+                                "サイズリセット",
+                                systemImage: "arrow.down.and.line.horizontal.and.arrow.up")
+                        }
+                        .help("ズームサイズをリセット")
+                    }
+
+                    ToolbarItem(placement: .automatic) {
+                        Button {
+                            if timelineOffsetHours.wrappedValue != 0 {
+                                timelineOffsetHours.wrappedValue = 0
+                            }
+                            onScrollToNow()
+                        } label: {
+                            Label("現在", systemImage: "clock.arrow.circlepath")
+                        }
+                        .help("現在の時刻にスクロール")
+                    }
+
                     ToolbarItem(placement: .automatic) {
                         Button {
                             isSearchSheetPresented.wrappedValue = true
@@ -86,12 +125,23 @@ extension View {
         isSearchSheetPresented: Binding<Bool>,
         timelineOffsetHours: Binding<Int>,
         onScrollToNow: @escaping () -> Void,
+        onResetZoom: @escaping () -> Void,
+        selectedBroadcastType: Binding<String>,
+        broadcastFilterOptions: [(id: String, name: String)],
         glassNamespace: Namespace.ID
     ) -> some View {
         #if os(iOS)
             self.overlay(alignment: .bottomTrailing) {
                 let buttonsSpacing = if #available(iOS 26, *) { 0.0 } else { 12.0 }
                 let buttons = VStack(spacing: buttonsSpacing) {
+                    ProgramGuideFloatingActionButton(
+                        systemImage: "arrow.down.and.line.horizontal.and.arrow.up",
+                        help: "サイズをリセット",
+                        namespace: glassNamespace
+                    ) {
+                        onResetZoom()
+                    }
+
                     ProgramGuideFloatingActionButton(
                         systemImage: "clock.arrow.circlepath",
                         help: "現在の時刻にスクロール",
@@ -122,7 +172,13 @@ extension View {
             }
         #elseif os(macOS)
             self.modifier(
-                ProgramGuideSearchToolbarModifier(isSearchSheetPresented: isSearchSheetPresented))
+                ProgramGuideToolbarModifier(
+                    isSearchSheetPresented: isSearchSheetPresented,
+                    onResetZoom: onResetZoom,
+                    selectedBroadcastType: selectedBroadcastType,
+                    broadcastFilterOptions: broadcastFilterOptions,
+                    timelineOffsetHours: timelineOffsetHours,
+                    onScrollToNow: onScrollToNow))
         #else
             self
         #endif

--- a/kiririn/Features/ProgramGuide/ProgramGuideShiftScrollMonitor.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideShiftScrollMonitor.swift
@@ -1,0 +1,113 @@
+#if os(macOS)
+    import SwiftUI
+
+    struct ProgramGuideShiftScrollMonitor: NSViewRepresentable {
+        let isEnabled: Bool
+        let onLiveScale: (CGFloat, UnitPoint) -> Void
+        let onScaleCommit: (CGFloat, UnitPoint) -> Void
+
+        func makeCoordinator() -> Coordinator {
+            Coordinator(
+                isEnabled: isEnabled, onLiveScale: onLiveScale, onScaleCommit: onScaleCommit)
+        }
+
+        func makeNSView(context: Context) -> NSView {
+            let view = NSView()
+            context.coordinator.startMonitoring(view: view)
+            return view
+        }
+
+        func updateNSView(_ nsView: NSView, context: Context) {
+            context.coordinator.isEnabled = isEnabled
+            context.coordinator.onLiveScale = onLiveScale
+            context.coordinator.onScaleCommit = onScaleCommit
+        }
+
+        static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+            coordinator.stopMonitoring()
+        }
+
+        @MainActor
+        final class Coordinator {
+            var isEnabled: Bool
+            var onLiveScale: (CGFloat, UnitPoint) -> Void
+            var onScaleCommit: (CGFloat, UnitPoint) -> Void
+
+            private weak var view: NSView?
+            private var eventMonitor: Any?
+            private var accumulatedFactor: CGFloat = 1.0
+            private var lastAnchor: UnitPoint = .center
+            private var debounceWorkItem: DispatchWorkItem?
+
+            init(
+                isEnabled: Bool,
+                onLiveScale: @escaping (CGFloat, UnitPoint) -> Void,
+                onScaleCommit: @escaping (CGFloat, UnitPoint) -> Void
+            ) {
+                self.isEnabled = isEnabled
+                self.onLiveScale = onLiveScale
+                self.onScaleCommit = onScaleCommit
+            }
+
+            func startMonitoring(view: NSView) {
+                self.view = view
+                eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) {
+                    [weak self] event in
+                    self?.handleScrollEvent(event) ?? event
+                }
+            }
+
+            func stopMonitoring() {
+                guard let eventMonitor else { return }
+                NSEvent.removeMonitor(eventMonitor)
+                self.eventMonitor = nil
+                debounceWorkItem?.cancel()
+            }
+
+            private func handleScrollEvent(_ event: NSEvent) -> NSEvent? {
+                guard isEnabled,
+                    event.modifierFlags.contains(.shift),
+                    let view,
+                    event.window === view.window
+                else {
+                    return event
+                }
+
+                let location = view.convert(event.locationInWindow, from: nil)
+                guard view.bounds.contains(location), view.bounds.width > 0, view.bounds.height > 0
+                else {
+                    return event
+                }
+
+                let delta =
+                    abs(event.scrollingDeltaY) >= abs(event.scrollingDeltaX)
+                    ? event.scrollingDeltaY : event.scrollingDeltaX
+                guard delta != 0 else { return event }
+
+                let sensitivity: CGFloat = event.hasPreciseScrollingDeltas ? 0.006 : 0.08
+                let factor = min(max(1 + delta * sensitivity, 0.8), 1.2)
+                accumulatedFactor *= factor
+
+                let anchor = UnitPoint(
+                    x: min(max(location.x / view.bounds.width, 0), 1),
+                    y: min(max(1 - location.y / view.bounds.height, 0), 1)
+                )
+                lastAnchor = anchor
+                onLiveScale(accumulatedFactor, anchor)
+
+                debounceWorkItem?.cancel()
+                let committedFactor = accumulatedFactor
+                let committedAnchor = anchor
+                let workItem = DispatchWorkItem { [weak self] in
+                    guard let self else { return }
+                    self.onScaleCommit(committedFactor, committedAnchor)
+                    self.accumulatedFactor = 1.0
+                }
+                debounceWorkItem = workItem
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: workItem)
+
+                return nil
+            }
+        }
+    }
+#endif

--- a/kiririn/Features/ProgramGuide/ProgramGuideShiftScrollMonitor.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideShiftScrollMonitor.swift
@@ -21,6 +21,9 @@
             context.coordinator.isEnabled = isEnabled
             context.coordinator.onLiveScale = onLiveScale
             context.coordinator.onScaleCommit = onScaleCommit
+            if !isEnabled {
+                context.coordinator.invalidatePendingZoom()
+            }
         }
 
         static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
@@ -32,6 +35,10 @@
             var isEnabled: Bool
             var onLiveScale: (CGFloat, UnitPoint) -> Void
             var onScaleCommit: (CGFloat, UnitPoint) -> Void
+
+            private static let preciseSensitivity: CGFloat = 0.006
+            private static let coarseSensitivity: CGFloat = 0.08
+            private static let debounceDelay: TimeInterval = 0.3
 
             private weak var view: NSView?
             private var eventMonitor: Any?
@@ -50,6 +57,7 @@
             }
 
             func startMonitoring(view: NSView) {
+                guard eventMonitor == nil else { return }
                 self.view = view
                 eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) {
                     [weak self] event in
@@ -62,6 +70,12 @@
                 NSEvent.removeMonitor(eventMonitor)
                 self.eventMonitor = nil
                 debounceWorkItem?.cancel()
+            }
+
+            func invalidatePendingZoom() {
+                debounceWorkItem?.cancel()
+                debounceWorkItem = nil
+                accumulatedFactor = 1.0
             }
 
             private func handleScrollEvent(_ event: NSEvent) -> NSEvent? {
@@ -84,7 +98,9 @@
                     ? event.scrollingDeltaY : event.scrollingDeltaX
                 guard delta != 0 else { return event }
 
-                let sensitivity: CGFloat = event.hasPreciseScrollingDeltas ? 0.006 : 0.08
+                let sensitivity: CGFloat =
+                    event.hasPreciseScrollingDeltas
+                    ? Self.preciseSensitivity : Self.coarseSensitivity
                 let factor = min(max(1 + delta * sensitivity, 0.8), 1.2)
                 accumulatedFactor *= factor
 
@@ -104,7 +120,8 @@
                     self.accumulatedFactor = 1.0
                 }
                 debounceWorkItem = workItem
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: workItem)
+                DispatchQueue.main.asyncAfter(
+                    deadline: .now() + Self.debounceDelay, execute: workItem)
 
                 return nil
             }

--- a/kiririn/Features/ProgramGuide/ProgramGuideVerticalScaleModifier.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideVerticalScaleModifier.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+
+struct ProgramGuideVerticalScaleModifier: ViewModifier {
+    let currentMinuteHeight: CGFloat
+    let minuteHeightRange: ClosedRange<CGFloat>
+    let onScale: (CGFloat, UnitPoint) -> Void
+
+    #if os(iOS)
+        @GestureState private var magnificationState: (factor: CGFloat, anchor: UnitPoint) =
+            (1, .center)
+    #elseif os(macOS)
+        @Environment(\.isTabActive) private var isTabActive
+        @State private var liveScaleFactor: CGFloat = 1.0
+        @State private var liveScaleAnchor: UnitPoint = .center
+    #endif
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        #if os(iOS)
+            content
+                .scaleEffect(
+                    x: 1,
+                    y: magnificationState.factor,
+                    anchor: magnificationState.anchor
+                )
+                .simultaneousGesture(
+                    MagnifyGesture()
+                        .updating($magnificationState) { value, state, _ in
+                            state = (
+                                factor: clampedFactor(value.magnification),
+                                anchor: value.startAnchor
+                            )
+                        }
+                        .onEnded { value in
+                            onScale(clampedFactor(value.magnification), value.startAnchor)
+                        }
+                )
+                .accessibilityZoomAction(performAccessibilityZoom)
+        #elseif os(macOS)
+            content
+                .scaleEffect(x: 1, y: clampedFactor(liveScaleFactor), anchor: liveScaleAnchor)
+                .background {
+                    ProgramGuideShiftScrollMonitor(
+                        isEnabled: isTabActive,
+                        onLiveScale: { factor, anchor in
+                            liveScaleFactor = factor
+                            liveScaleAnchor = anchor
+                        },
+                        onScaleCommit: { factor, anchor in
+                            liveScaleFactor = 1.0
+                            liveScaleAnchor = .center
+                            onScale(factor, anchor)
+                        }
+                    )
+                }
+                .accessibilityZoomAction(performAccessibilityZoom)
+        #else
+            content
+        #endif
+    }
+
+    private func clampedFactor(_ factor: CGFloat) -> CGFloat {
+        guard currentMinuteHeight > 0 else { return 1 }
+        let updatedMinuteHeight = min(
+            max(currentMinuteHeight * factor, minuteHeightRange.lowerBound),
+            minuteHeightRange.upperBound
+        )
+        return updatedMinuteHeight / currentMinuteHeight
+    }
+
+    private func performAccessibilityZoom(_ action: AccessibilityZoomGestureAction) {
+        #if os(macOS)
+            liveScaleFactor = 1.0
+            liveScaleAnchor = .center
+        #endif
+        switch action.direction {
+        case .zoomIn:
+            onScale(1.2, action.location)
+        case .zoomOut:
+            onScale(1 / 1.2, action.location)
+        @unknown default:
+            break
+        }
+    }
+}
+
+extension View {
+    func programGuideVerticalScale(
+        currentMinuteHeight: CGFloat,
+        minuteHeightRange: ClosedRange<CGFloat>,
+        onScale: @escaping (CGFloat, UnitPoint) -> Void
+    ) -> some View {
+        modifier(
+            ProgramGuideVerticalScaleModifier(
+                currentMinuteHeight: currentMinuteHeight,
+                minuteHeightRange: minuteHeightRange,
+                onScale: onScale
+            )
+        )
+    }
+}

--- a/kiririn/Features/ProgramGuide/ProgramGuideView.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideView.swift
@@ -28,7 +28,7 @@ struct ProgramGuideView: View {
     @State private var viewportHeight: CGFloat = 600
     @State private var viewportWidth: CGFloat = 0
     @State private var verticalScrollOffset: CGFloat = 0
-    @State private var minuteHeight: CGFloat = 2.5  // defaultMinuteHeight と同期
+    @State private var minuteHeight: CGFloat
     @State private var offsetTracker = HorizontalOffsetTracker()
     @State private var horizontalScrollResetToken = 0
     @State private var horizontalScrollController = ProgramGuideHorizontalScrollController()
@@ -40,6 +40,7 @@ struct ProgramGuideView: View {
 
     private let channelColumnWidth: CGFloat = 220
     private let timeRulerWidth: CGFloat = 45
+    private let sectionHeaderHeight: CGFloat = 52
     private let minimumMinuteHeight: CGFloat = 2.5
     private let maximumMinuteHeight: CGFloat = 9
     private let defaultMinuteHeight: CGFloat = 2.5
@@ -114,6 +115,7 @@ struct ProgramGuideView: View {
     init(manager: ServerManager, playerState: PlayerState) {
         self.manager = manager
         self._playerState = State(initialValue: playerState)
+        self._minuteHeight = State(initialValue: defaultMinuteHeight)
     }
 
     var body: some View {
@@ -190,7 +192,6 @@ struct ProgramGuideView: View {
             },
             onResetZoom: {
                 guard minuteHeight != defaultMinuteHeight else { return }
-                let sectionHeaderHeight: CGFloat = 52
                 let previousTimelineHeight = CGFloat(timelineHours * 60) * minuteHeight
                 let visibleContentY =
                     verticalScrollOffset + (viewportHeight - sectionHeaderHeight) / 2
@@ -307,7 +308,7 @@ struct ProgramGuideView: View {
             // 左上角：「時刻」ラベル（水平方向のみ固定、垂直方向は Sticky）
             Rectangle()
                 .fill(Color.kiririnSecondarySystemBackground)
-                .frame(width: timeRulerWidth, height: 52)
+                .frame(width: timeRulerWidth, height: sectionHeaderHeight)
                 .overlay {
                     Text("時刻").font(.caption).foregroundStyle(.secondary)
                 }
@@ -329,7 +330,7 @@ struct ProgramGuideView: View {
             }
             // チャンネル数がビューポートを埋めない場合の右側余白
             Color.kiririnSecondarySystemBackground
-                .frame(width: max(0, viewportWidth - contentWidth), height: 52)
+                .frame(width: max(0, viewportWidth - contentWidth), height: sectionHeaderHeight)
         }
         .background(Color.kiririnSecondarySystemBackground)
     }
@@ -424,7 +425,7 @@ struct ProgramGuideView: View {
                 }
             #endif
         }
-        .frame(height: 52)
+        .frame(height: sectionHeaderHeight)
         .background(.ultraThinMaterial)
     }
 
@@ -515,7 +516,6 @@ struct ProgramGuideView: View {
             }
         }
 
-        let sectionHeaderHeight: CGFloat = 52
         if now >= timelineStart && now < timelineEnd {
             let targetY = max(0, sectionHeaderHeight + yOffset(for: now) - viewportHeight * 0.2)
             if animated {
@@ -549,7 +549,6 @@ struct ProgramGuideView: View {
             max(previousMinuteHeight * factor, minimumMinuteHeight), maximumMinuteHeight)
         guard updatedMinuteHeight != previousMinuteHeight else { return }
 
-        let sectionHeaderHeight: CGFloat = 52
         let previousTimelineHeight = CGFloat(timelineHours * 60) * previousMinuteHeight
         let anchoredTimelineY = min(
             max(previousTimelineHeight * anchor.y, 0),
@@ -687,7 +686,7 @@ struct ProgramGuideView: View {
             favoriteButton(for: service)
         }
         .padding(.horizontal, 10)
-        .frame(width: channelColumnWidth, height: 52, alignment: .leading)
+        .frame(width: channelColumnWidth, height: sectionHeaderHeight, alignment: .leading)
         .background(Color.kiririnSecondarySystemBackground)
         .overlay(alignment: .leading) {
             Rectangle()

--- a/kiririn/Features/ProgramGuide/ProgramGuideView.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideView.swift
@@ -27,6 +27,8 @@ struct ProgramGuideView: View {
     @State private var scrollPosition = ScrollPosition()
     @State private var viewportHeight: CGFloat = 600
     @State private var viewportWidth: CGFloat = 0
+    @State private var verticalScrollOffset: CGFloat = 0
+    @State private var minuteHeight: CGFloat = 2.5  // defaultMinuteHeight と同期
     @State private var offsetTracker = HorizontalOffsetTracker()
     @State private var horizontalScrollResetToken = 0
     @State private var horizontalScrollController = ProgramGuideHorizontalScrollController()
@@ -38,7 +40,9 @@ struct ProgramGuideView: View {
 
     private let channelColumnWidth: CGFloat = 220
     private let timeRulerWidth: CGFloat = 45
-    private let minuteHeight: CGFloat = 2.5
+    private let minimumMinuteHeight: CGFloat = 2.5
+    private let maximumMinuteHeight: CGFloat = 9
+    private let defaultMinuteHeight: CGFloat = 2.5
     private let timelineHours = 24
     private let minimumPastDays = -1
     private let maximumFutureDays = 7
@@ -184,6 +188,18 @@ struct ProgramGuideView: View {
             onScrollToNow: {
                 scrollToNow(animated: true)
             },
+            onResetZoom: {
+                guard minuteHeight != defaultMinuteHeight else { return }
+                let sectionHeaderHeight: CGFloat = 52
+                let previousTimelineHeight = CGFloat(timelineHours * 60) * minuteHeight
+                let visibleContentY =
+                    verticalScrollOffset + (viewportHeight - sectionHeaderHeight) / 2
+                let anchorY = min(max(visibleContentY / previousTimelineHeight, 0), 1)
+                let factor = defaultMinuteHeight / minuteHeight
+                scaleTimeline(by: factor, around: UnitPoint(x: 0.5, y: anchorY))
+            },
+            selectedBroadcastType: $selectedBroadcastType,
+            broadcastFilterOptions: broadcastFilterOptions,
             glassNamespace: glassNamespace
         )
         .sheet(
@@ -246,6 +262,13 @@ struct ProgramGuideView: View {
                     LazyVStack(alignment: .leading, spacing: 0, pinnedViews: .sectionHeaders) {
                         Section {
                             gridSectionContent
+                                .programGuideVerticalScale(
+                                    currentMinuteHeight: minuteHeight,
+                                    minuteHeightRange:
+                                        minimumMinuteHeight...maximumMinuteHeight
+                                ) { factor, anchor in
+                                    scaleTimeline(by: factor, around: anchor)
+                                }
                         } header: {
                             headerSectionContent
                         }
@@ -264,6 +287,11 @@ struct ProgramGuideView: View {
                     geo.contentOffset.x
                 } action: { _, new in
                     offsetTracker.horizontalOffset = new
+                }
+                .onScrollGeometryChange(for: CGFloat.self) { geo in
+                    geo.contentOffset.y
+                } action: { _, new in
+                    verticalScrollOffset = new
                 }
                 .onChange(of: horizontalScrollResetToken) { _, _ in
                     resetHorizontalScrollPosition(proxy: proxy)
@@ -374,25 +402,27 @@ struct ProgramGuideView: View {
                 }
             }
 
-            Divider()
-                .padding(.vertical, 10)
+            #if os(iOS)
+                Divider()
+                    .padding(.vertical, 10)
 
-            Picker("絞り込み", selection: $selectedBroadcastType) {
-                ForEach(broadcastFilterOptions, id: \.id) { option in
-                    Text(option.name).tag(option.id)
+                Picker("絞り込み", selection: $selectedBroadcastType) {
+                    ForEach(broadcastFilterOptions, id: \.id) { option in
+                        Text(option.name).tag(option.id)
+                    }
                 }
-            }
-            .labelsHidden()
-            .fixedSize()
-            .padding(.horizontal, 8)
-            .help("放送種別を絞り込む")
+                .labelsHidden()
+                .fixedSize()
+                .padding(.horizontal, 8)
+                .help("放送種別を絞り込む")
 
-            programGuideCurrentTimeControl(timelineOffsetHours: timelineOffsetHours) {
-                if timelineOffsetHours != 0 {
-                    timelineOffsetHours = 0
+                programGuideCurrentTimeControl(timelineOffsetHours: timelineOffsetHours) {
+                    if timelineOffsetHours != 0 {
+                        timelineOffsetHours = 0
+                    }
+                    scrollToNow(animated: true)
                 }
-                scrollToNow(animated: true)
-            }
+            #endif
         }
         .frame(height: 52)
         .background(.ultraThinMaterial)
@@ -511,6 +541,51 @@ struct ProgramGuideView: View {
                 proxy.scrollTo(horizontalScrollLeadingAnchorID)
             }
         #endif
+    }
+
+    private func scaleTimeline(by factor: CGFloat, around anchor: UnitPoint) {
+        let previousMinuteHeight = minuteHeight
+        let updatedMinuteHeight = min(
+            max(previousMinuteHeight * factor, minimumMinuteHeight), maximumMinuteHeight)
+        guard updatedMinuteHeight != previousMinuteHeight else { return }
+
+        let sectionHeaderHeight: CGFloat = 52
+        let previousTimelineHeight = CGFloat(timelineHours * 60) * previousMinuteHeight
+        let anchoredTimelineY = min(
+            max(previousTimelineHeight * anchor.y, 0),
+            previousTimelineHeight
+        )
+        let anchorViewportY = min(
+            max(
+                sectionHeaderHeight + anchoredTimelineY - verticalScrollOffset,
+                sectionHeaderHeight
+            ),
+            viewportHeight
+        )
+        let scale = updatedMinuteHeight / previousMinuteHeight
+        let updatedTimelineHeight = CGFloat(timelineHours * 60) * updatedMinuteHeight
+        let maximumVerticalOffset = max(
+            sectionHeaderHeight + updatedTimelineHeight - viewportHeight,
+            0
+        )
+        let updatedVerticalOffset = min(
+            max(sectionHeaderHeight + anchoredTimelineY * scale - anchorViewportY, 0),
+            maximumVerticalOffset
+        )
+
+        minuteHeight = updatedMinuteHeight
+        verticalScrollOffset = updatedVerticalOffset
+
+        let maximumHorizontalOffset = max(contentWidth - viewportWidth, 0)
+        let horizontalOffset = min(
+            max(offsetTracker.horizontalOffset, 0),
+            maximumHorizontalOffset
+        )
+        if maximumHorizontalOffset > 0 {
+            scrollPosition = ScrollPosition(x: horizontalOffset, y: updatedVerticalOffset)
+        } else {
+            scrollPosition = ScrollPosition(y: updatedVerticalOffset)
+        }
     }
 
     private func updateDisplayChannels() {


### PR DESCRIPTION
Fixes #14 

This pull request adds vertical zoom functionality to the program guide, allowing users to zoom in and out on the timeline using pinch gestures on iOS and Shift+Scroll on macOS. It also introduces a "reset zoom" feature and refines the toolbar and UI controls to support these new interactions. The implementation ensures smooth scaling and maintains the user's viewport position during zoom operations.

**Vertical Zoom Functionality**

* Introduced `ProgramGuideVerticalScaleModifier` to enable vertical scaling of the timeline on both iOS (pinch-to-zoom) and macOS (Shift+Scroll) platforms, with accessibility zoom support. (`ProgramGuideVerticalScaleModifier.swift`, `ProgramGuideShiftScrollMonitor.swift`, `ProgramGuideView.swift`) [[1]](diffhunk://#diff-33a054da8e87a715b0b5d6137d43b4f83c285059e98faa08965bc175856215c7R1-R101) [[2]](diffhunk://#diff-96f800830f02aef62821c9965807ee116679199cbf46e1f04503e1c6d47fbd94R1-R113) [[3]](diffhunk://#diff-658b49c00a189460569b74dddf083d95df4bc20ed1abc9087cd262e6b823b32dR265-R271)
* Added state management and logic in `ProgramGuideView` to handle zoom level (`minuteHeight`), enforce zoom limits, and keep the viewport centered on the anchor during scaling. (`ProgramGuideView.swift`) [[1]](diffhunk://#diff-658b49c00a189460569b74dddf083d95df4bc20ed1abc9087cd262e6b823b32dR30-R31) [[2]](diffhunk://#diff-658b49c00a189460569b74dddf083d95df4bc20ed1abc9087cd262e6b823b32dL41-R45) [[3]](diffhunk://#diff-658b49c00a189460569b74dddf083d95df4bc20ed1abc9087cd262e6b823b32dR546-R590)

**Toolbar and UI Enhancements**

* Updated the macOS toolbar to include a zoom reset button, a broadcast type filter, and a "scroll to now" button for improved usability. (`ProgramGuidePlatformModifiers.swift`) [[1]](diffhunk://#diff-5bc8ce6a62c701ab04026a91bf73a3007e2dbad66b402644a7eeff07f2c4730bL42-R87) [[2]](diffhunk://#diff-5bc8ce6a62c701ab04026a91bf73a3007e2dbad66b402644a7eeff07f2c4730bR128-R144) [[3]](diffhunk://#diff-5bc8ce6a62c701ab04026a91bf73a3007e2dbad66b402644a7eeff07f2c4730bL125-R181)
* Added a floating "reset zoom" action button on iOS for quick access. (`ProgramGuidePlatformModifiers.swift`)

**Scroll and Viewport Management**

* Tracked vertical scroll offset to maintain the user's position when zooming and to support accurate anchor-based scaling. (`ProgramGuideView.swift`) [[1]](diffhunk://#diff-658b49c00a189460569b74dddf083d95df4bc20ed1abc9087cd262e6b823b32dR30-R31) [[2]](diffhunk://#diff-658b49c00a189460569b74dddf083d95df4bc20ed1abc9087cd262e6b823b32dR291-R295)
* Refined the timeline scaling logic to adjust both zoom and scroll position, ensuring the anchor point remains in view after zooming. (`ProgramGuideView.swift`)

These changes collectively provide a more interactive and user-friendly program guide, especially for users who need to zoom in on specific time ranges or quickly reset the timeline view.

## Summary by Sourcery

Add vertical zoom support to the program guide timeline and update platform-specific controls to manage zoom, filtering, and "scroll to now" behavior.

New Features:
- Enable vertical zooming of the program guide timeline via pinch on iOS, Shift+Scroll on macOS, and accessibility zoom gestures.
- Add reset zoom actions on both iOS and macOS to quickly restore the default timeline scale.

Enhancements:
- Track vertical scroll offset and adjust scroll position during zoom to keep the anchored viewport area in view.
- Unify and expand the macOS toolbar and iOS floating controls to expose broadcast filtering and "scroll to now" alongside zoom reset.