### PR TITLE
fix: 再生位置復旧修正 (#41)

### DIFF
--- a/kiririn/AppShell/kiririnApp.swift
+++ b/kiririn/AppShell/kiririnApp.swift
@@ -310,7 +310,12 @@ private struct AppCommands: Commands {
                 }
             }
 
-            CommandGroup(after: .windowArrangement) {
+            CommandGroup(replacing: .singleWindowList) {
+                Button("kiririn") {
+                    openWindow(id: AppWindowID.main.rawValue)
+                }
+                .keyboardShortcut("k", modifiers: .command)
+
                 Button("字幕履歴") {
                     openWindow(id: AppWindowID.caption.rawValue)
                 }

--- a/kiririn/Features/Player/PlayerState.swift
+++ b/kiririn/Features/Player/PlayerState.swift
@@ -108,6 +108,7 @@ nonisolated struct PlayerPlaybackStatus: Sendable, Codable, Equatable {
     var isPlaying: Bool
     var time: Double
     var position: Float
+    var bytePosition: Float = 0
     var rate: Float = 1.0
 }
 
@@ -276,7 +277,9 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
     private var aribSubtitleTrackID: String?
     private var selectedTextTrackID: String?
     private var securityScopedPlaybackURL: URL?
-    private var lastSavedPlaybackPosition: Float = -1
+    private var playbackPositionBuffers: (Float, Float) = (-1, -1)
+    private var playbackPositionLastRotationTime: Double?
+    private var playbackPositionActiveBuffer: Int = 0
     private var didStartPlayback = false
     private var didApplyInitialPlaybackRestore = false
     private var didObservePlayingForRestore = false
@@ -372,7 +375,9 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
         }
         playbackStatus.playableID = playableForPlayback.id
         playbackStatus.rate = playbackRate
-        lastSavedPlaybackPosition = -1
+        playbackPositionBuffers = (-1, -1)
+        playbackPositionLastRotationTime = nil
+        playbackPositionActiveBuffer = 0
         didApplyInitialPlaybackRestore = false
         didStartPlayback = false
         didObservePlayingForRestore = false
@@ -1133,7 +1138,7 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
     }
 
     func close() {
-        savePlaybackPositionIfNeeded(force: true)
+        savePlaybackPositionIfNeeded()
         cleanup(releasePlayer: true, releaseSecurityScope: true)
         currentPlayable = nil
         nextProgram = nil
@@ -1153,12 +1158,15 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
     }
 
     func cleanup(releasePlayer: Bool = false, releaseSecurityScope: Bool = false) {
-        savePlaybackPositionIfNeeded(force: true)
+        savePlaybackPositionIfNeeded()
         restoreAfterPlayingTask?.cancel()
         restoreAfterPlayingTask = nil
         didObservePlayingForRestore = false
         didStartPlayback = false
         didObservePlaybackProgressForRestore = false
+        playbackPositionBuffers = (-1, -1)
+        playbackPositionLastRotationTime = nil
+        playbackPositionActiveBuffer = 0
         refreshTimer?.invalidate()
         refreshTimer = nil
         programBootstrapRefreshTask?.cancel()
@@ -1200,25 +1208,52 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
         }
     }
 
-    private func savePlaybackPositionIfNeeded(force: Bool = false) {
+    private func savePlaybackPositionIfNeeded() {
         guard let playable = currentPlayable,
             playable.source.isRestorablePositionSource
         else { return }
         guard didApplyInitialPlaybackRestore else {
             return
         }
-        let livePosition = player.map { Float($0.position) } ?? 0
-        let basePosition = livePosition > 0 ? livePosition : playbackStatus.position
+        let liveBytePosition = player.map { Float($0.bytePosition) } ?? 0
+        let basePosition = liveBytePosition > 0 ? liveBytePosition : playbackStatus.bytePosition
         let position = min(max(basePosition, 0), 1)
         guard position > 0 else { return }
 
-        if !force && abs(position - lastSavedPlaybackPosition) < 0.01 {
+        // timeが0の場合はバッファへの記録ごとスキップ
+        let time = playbackStatus.time
+        guard time > 0 else { return }
+
+        // 現在posをアクティブバッファに記録する
+        if playbackPositionActiveBuffer == 0 {
+            playbackPositionBuffers.0 = position
+        } else {
+            playbackPositionBuffers.1 = position
+        }
+
+        // 初回はtimeを記録して終了
+        guard let lastRotationTime = playbackPositionLastRotationTime else {
+            playbackPositionLastRotationTime = time
             return
         }
-        lastSavedPlaybackPosition = position
-        Task {
-            await cacheStore?.savePlaybackPosition(playableID: playable.id, position: position)
+
+        // 前回timeから10秒以上進んでいればローテーション
+        guard time - lastRotationTime >= 10 else { return }
+
+        // 古いposを復元位置として記録する
+        let staleBuffer = playbackPositionActiveBuffer == 0 ? 1 : 0
+        let stalePosition =
+            staleBuffer == 0 ? playbackPositionBuffers.0 : playbackPositionBuffers.1
+        if stalePosition > 0 {
+            Task {
+                await cacheStore?.savePlaybackPosition(
+                    playableID: playable.id, position: stalePosition)
+            }
         }
+
+        // バッファをローテーション
+        playbackPositionActiveBuffer = staleBuffer
+        playbackPositionLastRotationTime = time
     }
 
     private func startProgramBootstrapRefreshLoop() {
@@ -1296,12 +1331,11 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
             return
         }
         guard currentPlayable?.id == playableID, let player else { return }
-        let before = Float(player.position)
+        let before = Float(player.bytePosition)
         player.position = Double(position)
-        let applied = Float(player.position)
+        let applied = Float(player.bytePosition)
         if applied > 0.001 {
-            playbackStatus.position = applied
-            lastSavedPlaybackPosition = applied
+            playbackStatus.bytePosition = applied
             logger.info(
                 "restored playback position: id=\(playableID), requested=\(position), applied=\(applied)"
             )
@@ -1562,7 +1596,7 @@ extension PlayerState {
             // @Observable は同値でも代入のたびに通知するため、値が変わるときだけ書き込む。
             // （.buffering はライブ視聴中に高頻度で発火する）
             switch state {
-            case .opening, .buffering:
+            case .opening:
                 setPlaybackLoadingIfChanged(!didStartPlayback)
             case .playing:
                 didStartPlayback = true
@@ -1581,6 +1615,9 @@ extension PlayerState {
             case .paused, .stopped, .stopping:
                 setPlaybackLoadingIfChanged(false)
                 setPlayingIfChanged(false)
+                if state == .paused {
+                    savePlaybackPositionIfNeeded()
+                }
             default:
                 break
             }
@@ -1594,6 +1631,9 @@ extension PlayerState {
     nonisolated func mediaPlayerTimeChanged(_ notification: Notification) {
         Task { @MainActor in
             guard let player = player else { return }
+            logger.debug(
+                "playback time changed: position=\(player.position), bytePosition=\(player.bytePosition), time=\(player.time.intValue), duration=\(currentPlayable?.length ?? -1)"
+            )
             let time = max(0, Double(player.time.intValue) / 1000.0)
             let duration = max(0, currentPlayable?.length ?? 0)
             // @Observable は同値でも代入のたびに通知するため、値が変わるときだけ書き込む。
@@ -1603,9 +1643,13 @@ extension PlayerState {
                     playbackStatus.time = time
                 }
             }
-            logger.debug(
-                "playback time changed: position=\(player.position), time=\(time), duration=\(duration)"
-            )
+            let bytePosition = Float(player.bytePosition)
+            if bytePosition.isFinite {
+                let clampedBytePosition = min(max(bytePosition, 0), 1)
+                if playbackStatus.bytePosition != clampedBytePosition {
+                    playbackStatus.bytePosition = clampedBytePosition
+                }
+            }
             let position = Float(player.position)
             if position == -1.0 {
                 setPlaybackSeekingIfChanged(true)
@@ -1692,6 +1736,7 @@ extension PlayerState {
     }
 
     nonisolated func mediaPlayerLengthChanged(_ length: Int64) {
+        logger.debug("media player length changed: length=\(length)")
         Task { @MainActor in
             if length > 0 {
                 currentPlayable?.length = Double(length) / 1000.0

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # VLCKit
 # https://github.com/neneka/vlckit/releases
-REVISION="202607151204"
+REVISION="202607180216"
 VLCKIT_URL="https://github.com/neneka/vlckit/releases/download/$REVISION/VLCKit-iOS-REPLACEWITHVERSION.dmg"
 VLCKIT_DEST="./Packages/VLCKit"
 FRAMEWORK_DEST="${VLCKIT_DEST}/VLCKit.xcframework"


### PR DESCRIPTION
Fixes #41 

#39 で時間ベースposが帰ってくるようになったことで復元が狂っていましたが、VLCKitから生バイトposを返してもらい、復元にはそれを使用するようにします。
また、生バイトposについてはダブルバッファで持ち、若干前の時間から再生が始まるようにします。

This pull request introduces several improvements to the playback position saving logic and user interface commands, as well as updates to the VLCKit dependency. The most significant changes are the implementation of a dual-buffered playback position saving mechanism, enhancements to how and when playback position is saved, and the addition of a new main window command in the app shell. These updates aim to make playback restoration more robust and improve the user experience.

**Playback Position Buffering and Restoration:**

* Replaced the single `lastSavedPlaybackPosition` with a dual-buffer system (`playbackPositionBuffers`) to store and rotate between two recent playback positions, saving the older buffer every 10 seconds of playback. This approach increases the reliability of restoring playback positions, especially in cases of unexpected app closure. [[1]](diffhunk://#diff-6e542a5ae1df8afbdd50d517081013e391e3a52164aee727ab889eba96a38698L279-R282) [[2]](diffhunk://#diff-6e542a5ae1df8afbdd50d517081013e391e3a52164aee727ab889eba96a38698L375-R380) [[3]](diffhunk://#diff-6e542a5ae1df8afbdd50d517081013e391e3a52164aee727ab889eba96a38698L1203-R1258)
* Updated the logic to save playback position only when playback is paused or at certain intervals, and to use a new `bytePosition` field for more accurate tracking. [[1]](diffhunk://#diff-6e542a5ae1df8afbdd50d517081013e391e3a52164aee727ab889eba96a38698R111) [[2]](diffhunk://#diff-6e542a5ae1df8afbdd50d517081013e391e3a52164aee727ab889eba96a38698L1136-R1141) [[3]](diffhunk://#diff-6e542a5ae1df8afbdd50d517081013e391e3a52164aee727ab889eba96a38698L1156-R1169) [[4]](diffhunk://#diff-6e542a5ae1df8afbdd50d517081013e391e3a52164aee727ab889eba96a38698R1618-R1620)

**Player State and Status Enhancements:**

* Added `bytePosition` to `PlayerPlaybackStatus` and updated all relevant logic to use this value for more precise position tracking and restoration. [[1]](diffhunk://#diff-6e542a5ae1df8afbdd50d517081013e391e3a52164aee727ab889eba96a38698R111) [[2]](diffhunk://#diff-6e542a5ae1df8afbdd50d517081013e391e3a52164aee727ab889eba96a38698L1299-L1304) [[3]](diffhunk://#diff-6e542a5ae1df8afbdd50d517081013e391e3a52164aee727ab889eba96a38698L1606-R1652)
* Improved debug logging for playback time and media length changes to facilitate troubleshooting and monitoring. [[1]](diffhunk://#diff-6e542a5ae1df8afbdd50d517081013e391e3a52164aee727ab889eba96a38698R1634-R1636) [[2]](diffhunk://#diff-6e542a5ae1df8afbdd50d517081013e391e3a52164aee727ab889eba96a38698R1739)

**User Interface and Commands:**

* Changed the app shell command group to add a new main window command (`kiririn`) with a keyboard shortcut, improving accessibility for users.

**Dependency Update:**

* Updated the VLCKit revision in `setup.sh` to a newer release, ensuring the project uses the latest version of the media framework.

## Summary by Sourcery

Improve playback position restoration reliability by switching to byte-based tracking, buffering recent positions, and updating UI commands and VLCKit dependency.

New Features:
- Introduce a dual-buffer mechanism for periodically saving playback positions to improve restoration after unexpected closures.
- Add a dedicated main window command with a keyboard shortcut in the app shell command group.

Bug Fixes:
- Fix incorrect playback position restoration caused by relying on time-based position instead of byte-based position from VLCKit.

Enhancements:
- Extend player playback status with a byte-based position field and update related state handling for more accurate tracking.
- Refine when playback position is saved, including on pause events, to better capture the user’s last viewing point.
- Improve debug logging for playback time and media length changes to aid monitoring and troubleshooting.

Build:
- Update the VLCKit revision in the setup script to use a newer media framework release.