### PR TITLE
fix: 長さ不明のメディアでシークできなくなっていた (#11)

### DIFF
--- a/kiririn/Features/Player/PlayerOverlayView.swift
+++ b/kiririn/Features/Player/PlayerOverlayView.swift
@@ -1987,8 +1987,12 @@ struct PlayerOverlayView_iOS: View {
     }
 
     private func finishScrub() {
-        if playerState.isScrubbing, scrubPosition != nil {
-            playerState.seek(toTime: displayTime)
+        if playerState.isScrubbing, let scrub = scrubPosition {
+            if displayDuration > 0 {
+                playerState.seek(toTime: displayTime)
+            } else {
+                playerState.seek(to: scrub)
+            }
         }
         playerState.isScrubbing = false
         scrubPosition = nil

--- a/kiririn/Features/Player/PlayerState.swift
+++ b/kiririn/Features/Player/PlayerState.swift
@@ -1216,7 +1216,18 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
             return
         }
         let liveBytePosition = player.map { Float($0.bytePosition) } ?? 0
-        let basePosition = liveBytePosition > 0 ? liveBytePosition : playbackStatus.bytePosition
+        let basePosition: Float = {
+            // 採用順
+            // player.bytePosition > 0 (MPEG-TS のみ)
+            // playbackStatus.bytePosition > 0 (MPEG-TS のみ)
+            // player.position > 0
+            // playbackStatus.position > 0
+            if liveBytePosition > 0 { return liveBytePosition }
+            if playbackStatus.bytePosition > 0 { return playbackStatus.bytePosition }
+            let livePosition = player.map { Float($0.position) } ?? 0
+            if livePosition > 0 { return livePosition }
+            return playbackStatus.position
+        }()
         let position = min(max(basePosition, 0), 1)
         guard position > 0 else { return }
 
@@ -1325,25 +1336,16 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
             logger.info("no playback position found: id=\(playableID)")
             return
         }
-        guard position > 0, position < 0.985 else {
+        guard position > 0, position < 1 else {
             logger.info(
                 "playback position skipped by range: id=\(playableID), position=\(position)")
             return
         }
         guard currentPlayable?.id == playableID, let player else { return }
-        let before = Float(player.bytePosition)
         player.position = Double(position)
-        let applied = Float(player.bytePosition)
-        if applied > 0.001 {
-            playbackStatus.bytePosition = applied
-            logger.info(
-                "restored playback position: id=\(playableID), requested=\(position), applied=\(applied)"
-            )
-        } else {
-            logger.warning(
-                "playback restore did not apply: id=\(playableID), requested=\(position), before=\(before), applied=\(applied)"
-            )
-        }
+        logger.info(
+            "restored playback position: id=\(playableID), requested=\(position)"
+        )
     }
 
     func adoptSecurityScopedPlaybackURL(_ url: URL?) {
@@ -1651,7 +1653,7 @@ extension PlayerState {
                 }
             }
             let position = Float(player.position)
-            if position == -1.0 {
+            if position < 0 {
                 setPlaybackSeekingIfChanged(true)
             } else if position.isFinite {
                 setPlaybackSeekingIfChanged(false)

--- a/kiririn/Features/Player/macOS/DetachedPlayerOverlayView.swift
+++ b/kiririn/Features/Player/macOS/DetachedPlayerOverlayView.swift
@@ -740,7 +740,11 @@ struct DetachedPlayerOverlayView_macOS: View {
 
     private func finishSeek() {
         if isSeeking {
-            playerState.seek(toTime: displayTime)
+            if displayDuration > 0 {
+                playerState.seek(toTime: displayTime)
+            } else {
+                playerState.seek(to: Float(seekValue))
+            }
         }
         isSeeking = false
     }


### PR DESCRIPTION
Fixes #11 

MMT/TLVなど長さ不明のメディアでも時間ベースのシークを行うようになっていて、その場合シークが不可能な状態でした
#39 のデグレでした
長さ不明な場合はposベースでシークする以前の仕様に戻します

This pull request improves playback position handling and seeking logic for both iOS and macOS player overlays, with a particular focus on more robust handling of MPEG-TS streams and fallback logic when certain position metrics are unavailable. The changes also clarify and make the seeking behavior more consistent across different scenarios.

### Playback Position Calculation and Seeking Logic

* Improved the logic for determining the playback position in `PlayerState` by adding a clear priority order: prefer `player.bytePosition` (for MPEG-TS), then `playbackStatus.bytePosition`, then `player.position`, and finally `playbackStatus.position`. This ensures more accurate seeking and restoration of playback position across different stream types.
* Updated the logic for restoring playback position to correctly update either `playbackStatus.bytePosition` or `playbackStatus.position` depending on whether `bytePosition` is valid, enhancing compatibility with both MPEG-TS and non-MPEG-TS streams.

### Player Overlay Seeking Behavior

* Modified the seek completion logic in both `PlayerOverlayView_iOS` and `DetachedPlayerOverlayView_macOS` to attempt time-based seeking when a valid duration is available, and fallback to position-based seeking otherwise. This provides more reliable seeking behavior for live and non-live content. [[1]](diffhunk://#diff-ad8c864ccf18b9088c902f974431188959e183848a0e00f0f796cd652ab200cfR1991-R1995) [[2]](diffhunk://#diff-c3106c6f27a8e022739bd8b9a5c9a209bf13a8f0d8c57362f5fc45945aa7a383R743-R747)

### Playback State Handling

* Adjusted the logic for detecting when the player's position is invalid during playback seeking, changing the check from `position == -1.0` to `position < 0` for broader error detection.

## Summary by Sourcery

Fix playback position handling and seeking so that media with unknown duration can be scrubbed reliably across iOS and macOS overlays.

Bug Fixes:
- Restore position-based seeking for media without a known duration to fix scrub/seek failures on such streams.
- Broaden invalid playback position detection during seeking to avoid getting stuck in an incorrect seeking state.

Enhancements:
- Refine the priority for choosing the base playback position from byte and time positions to make resume behavior more robust across different stream types.
- Unify overlay seek completion behavior to prefer time-based seeking when a valid duration is available and fall back to position-based seeking otherwise.