### PR TITLE
fix: リストア位置が前方には更新されなかった (#41)

### DIFF
--- a/kiririn/Features/Player/PlayerState.swift
+++ b/kiririn/Features/Player/PlayerState.swift
@@ -1248,8 +1248,8 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
             return
         }
 
-        // 前回timeから10秒以上進んでいればローテーション
-        guard time - lastRotationTime >= 10 else { return }
+        // 前回timeから10秒以上変化していればローテーション
+        guard abs(time - lastRotationTime) >= 10 else { return }
 
         // 古いposを復元位置として記録する
         let staleBuffer = playbackPositionActiveBuffer == 0 ? 1 : 0


### PR DESCRIPTION
Fixes #41 

This pull request makes a small but important change to the logic for rotating playback position in the `PlayerState` class. The condition now checks if the playback time has changed by at least 10 seconds in either direction (forward or backward), instead of only forward.

- Playback position rotation logic updated: The guard condition now uses `abs(time - lastRotationTime) >= 10` to trigger rotation when the playback time changes by 10 seconds or more in either direction, improving robustness for both forward and backward seeks.

## Summary by Sourcery

バグ修正:
- 再生時間が前後いずれの方向にも少なくとも10秒変化した場合に再生位置のローテーションがトリガーされるようにし、前方に移動したときのみ動作していた問題を修正しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure playback position rotation triggers when playback time changes by at least 10 seconds in either direction, not only when moving forward.

</details>