### PR TITLE
fix: プラグインのメモリリークを修正

### DIFF
--- a/kiririn.xcodeproj/project.pbxproj
+++ b/kiririn.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 				Features/Plugin/macOS/PluginSelectionList.swift = (macos, );
 				Features/Plugin/macOS/PluginWindowView.swift = (macos, );
 				Shared/UI/macOS/WindowConfigurator.swift = (macos, );
+				Shared/UI/macOS/WindowReference.swift = (macos, );
 			};
 			target = 105FC5792E9EAD3100EA8BCF /* kiririn */;
 		};

--- a/kiririn/Features/Player/macOS/DetachedPlayerOverlayView.swift
+++ b/kiririn/Features/Player/macOS/DetachedPlayerOverlayView.swift
@@ -12,7 +12,7 @@
         let appModel: AppModel
         let pluginStore: PluginStore
         @Binding var isAlwaysOnTop: Bool
-        let playerWindow: NSWindow?
+        let playerWindowReference: WindowReference_macOS
         let onToggleFullscreen: () -> Void
         let onControlsVisibilityChanged: (Bool) -> Void
 
@@ -40,6 +40,10 @@
         @State private var playbackErrorAlertMessage = ""
         @State private var bmlKeyMonitor: BMLKeyMonitor?
         @State private var bmlRemotePanel: BMLRemotePanelController?
+
+        private var playerWindow: NSWindow? {
+            playerWindowReference.window
+        }
 
         private var displayDuration: Double { playerState.currentPlayable?.length ?? 0 }
         private var displayProgress: Double {
@@ -1207,7 +1211,7 @@
                 appModel: appModel,
                 pluginStore: appModel.pluginStore,
                 isAlwaysOnTop: $isAlwaysOnTop,
-                playerWindow: nil,
+                playerWindowReference: WindowReference_macOS(),
                 onToggleFullscreen: {},
                 onControlsVisibilityChanged: { _ in }
             )

--- a/kiririn/Features/Player/macOS/PlayerWindowView.swift
+++ b/kiririn/Features/Player/macOS/PlayerWindowView.swift
@@ -13,7 +13,7 @@
         @Environment(AppModel.self) private var appModel
         @Environment(\.dismiss) private var dismiss
         @State private var playerState = PlayerState()
-        @State private var playerWindow: NSWindow?
+        @State private var playerWindowReference = WindowReference_macOS()
         @State private var isAlwaysOnTop = false
         @State private var isOverlayVisible = true
         @State private var restorationWaitTask: Task<Void, Never>?
@@ -26,7 +26,7 @@
                         appModel: appModel,
                         pluginStore: appModel.pluginStore,
                         isAlwaysOnTop: $isAlwaysOnTop,
-                        playerWindow: playerWindow,
+                        playerWindowReference: playerWindowReference,
                         onToggleFullscreen: {
                             playerWindow?.toggleFullScreen(nil)
                         },
@@ -124,15 +124,20 @@
                 }
                 restorationWaitTask?.cancel()
                 restorationWaitTask = nil
+                playerWindowReference.window = nil
                 if playerState.currentPlayable != nil {
                     playerState.close()
                 }
             }
         }
 
+        private var playerWindow: NSWindow? {
+            playerWindowReference.window
+        }
+
         private func configureWindow(_ window: NSWindow) {
             if playerWindow !== window {
-                playerWindow = window
+                playerWindowReference.window = window
             }
             applyWindowTitle(window: window)
             applyWindowSizing(window: window)

--- a/kiririn/Features/Plugin/ExtensionPluginContextConfiguration.swift
+++ b/kiririn/Features/Plugin/ExtensionPluginContextConfiguration.swift
@@ -1,0 +1,108 @@
+import WebKit
+
+enum ExtensionPluginContextConfiguration {
+    private static let errorDomain = "PluginRuntime"
+    private static let baseURLScheme = "webkit-extension"
+
+    static func uniqueIdentifier(for manifestID: String) -> String {
+        manifestID
+    }
+
+    private static func baseURL(forHost host: String, identity: String) throws -> URL {
+        var components = URLComponents()
+        components.scheme = baseURLScheme
+        components.host = host
+        components.path = "/"
+
+        guard let baseURL = components.url else {
+            throw NSError(
+                domain: errorDomain,
+                code: 3,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "プラグインの base URL が不正です: \(identity)"
+                ]
+            )
+        }
+
+        return baseURL
+    }
+
+    private static func host(from baseURL: URL, identity: String) throws -> String {
+        guard let host = baseURL.host, !host.isEmpty else {
+            throw NSError(
+                domain: errorDomain,
+                code: 4,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "プラグインの host を解決できませんでした: \(identity)"
+                ]
+            )
+        }
+
+        return host
+    }
+
+    static func baseURL(for pluginID: UUID) throws -> URL {
+        try baseURL(forHost: pluginID.uuidString.lowercased(), identity: pluginID.uuidString)
+    }
+
+    static func host(for pluginID: UUID) throws -> String {
+        try host(from: baseURL(for: pluginID), identity: pluginID.uuidString)
+    }
+
+    static func websiteDataHost(for pluginID: UUID) throws -> String {
+        try host(for: pluginID)
+    }
+
+    @MainActor
+    static func makeContext(
+        for webExtension: WKWebExtension,
+        pluginID: UUID,
+        manifestID: String,
+        requestedPermissions: [String],
+        requestedHostPermissions: [String]
+    ) throws -> WKWebExtensionContext {
+        let context = WKWebExtensionContext(for: webExtension)
+        try applyStableIdentity(to: context, pluginID: pluginID, manifestID: manifestID)
+        applyRequestedPermissions(requestedPermissions, to: context)
+        applyRequestedHostPermissions(requestedHostPermissions, to: context)
+        return context
+    }
+
+    @MainActor
+    static func applyStableIdentity(
+        to context: WKWebExtensionContext,
+        pluginID: UUID,
+        manifestID: String
+    ) throws {
+        context.uniqueIdentifier = uniqueIdentifier(for: manifestID)
+        context.baseURL = try baseURL(for: pluginID)
+    }
+
+    @MainActor
+    private static func applyRequestedPermissions(
+        _ requestedPermissions: [String],
+        to context: WKWebExtensionContext
+    ) {
+        for permission in requestedPermissions {
+            context.setPermissionStatus(
+                .grantedExplicitly,
+                for: WKWebExtension.Permission(permission)
+            )
+        }
+    }
+
+    @MainActor
+    private static func applyRequestedHostPermissions(
+        _ hostPermissions: [String],
+        to context: WKWebExtensionContext
+    ) {
+        for pattern in hostPermissions {
+            guard let matchPattern = try? WKWebExtension.MatchPattern(string: pattern) else {
+                continue
+            }
+            context.setPermissionStatus(.grantedExplicitly, for: matchPattern)
+        }
+    }
+}

--- a/kiririn/Features/Plugin/ExtensionPluginRuntime.swift
+++ b/kiririn/Features/Plugin/ExtensionPluginRuntime.swift
@@ -33,7 +33,6 @@ final class ExtensionPluginRuntime {
     let webExtension: WKWebExtension
     let context: WKWebExtensionContext
     let controller: WKWebExtensionController
-    let webViewConfiguration: WKWebViewConfiguration
     private let controllerDelegate: PluginExtensionControllerDelegate
     private let logger = Logger(label: "ExtensionPluginRuntime")
     private var isInvalidated = false
@@ -67,14 +66,18 @@ final class ExtensionPluginRuntime {
         let controller = WKWebExtensionController()
         controller.delegate = delegate
         try controller.load(context)
-        guard let webViewConfiguration = context.webViewConfiguration else {
-            do {
-                try controller.unload(context)
-            } catch {
-                Logger(label: "ExtensionPluginRuntime").error(
-                    "Failed to unload incomplete plugin runtime: \(error)"
-                )
-            }
+
+        self.pluginID = plugin.id
+        self.manifest = manifest
+        self.resourceBaseURL = normalizedResourceBaseURL
+        self.webExtension = webExtension
+        self.context = context
+        self.controllerDelegate = delegate
+        self.controller = controller
+    }
+
+    func makeWebViewConfiguration() throws -> WKWebViewConfiguration {
+        guard !isInvalidated, let configuration = context.webViewConfiguration else {
             throw NSError(
                 domain: "PluginRuntime",
                 code: 5,
@@ -84,15 +87,7 @@ final class ExtensionPluginRuntime {
                 ]
             )
         }
-
-        self.pluginID = plugin.id
-        self.manifest = manifest
-        self.resourceBaseURL = normalizedResourceBaseURL
-        self.webExtension = webExtension
-        self.context = context
-        self.controllerDelegate = delegate
-        self.controller = controller
-        self.webViewConfiguration = webViewConfiguration
+        return configuration
     }
 
     func pageURL(for area: PluginDisplayArea) -> URL? {

--- a/kiririn/Features/Plugin/ExtensionPluginRuntime.swift
+++ b/kiririn/Features/Plugin/ExtensionPluginRuntime.swift
@@ -1,0 +1,114 @@
+import KppxKit
+import Logging
+import WebKit
+
+@MainActor
+private final class PluginExtensionControllerDelegate: NSObject, WKWebExtensionControllerDelegate {
+    func webExtensionController(
+        _ controller: WKWebExtensionController,
+        promptForPermissions permissions: Set<WKWebExtension.Permission>,
+        in tab: (any WKWebExtensionTab)?,
+        for extensionContext: WKWebExtensionContext,
+        completionHandler: @escaping (Set<WKWebExtension.Permission>, Date?) -> Void
+    ) {
+        completionHandler(permissions, nil)
+    }
+
+    func webExtensionController(
+        _ controller: WKWebExtensionController,
+        promptForPermissionMatchPatterns matchPatterns: Set<WKWebExtension.MatchPattern>,
+        in tab: (any WKWebExtensionTab)?,
+        for extensionContext: WKWebExtensionContext,
+        completionHandler: @escaping (Set<WKWebExtension.MatchPattern>, Date?) -> Void
+    ) {
+        completionHandler(matchPatterns, nil)
+    }
+}
+
+@MainActor
+final class ExtensionPluginRuntime {
+    let pluginID: UUID
+    let manifest: ExtensionPluginManifest
+    let resourceBaseURL: URL
+    let webExtension: WKWebExtension
+    let context: WKWebExtensionContext
+    let controller: WKWebExtensionController
+    let webViewConfiguration: WKWebViewConfiguration
+    private let controllerDelegate: PluginExtensionControllerDelegate
+    private let logger = Logger(label: "ExtensionPluginRuntime")
+    private var isInvalidated = false
+
+    init(
+        plugin: PluginDefinition,
+        manifest: ExtensionPluginManifest,
+        resourceBaseURL: URL
+    ) async throws {
+        let normalizedResourceBaseURL = resourceBaseURL.standardizedFileURL
+        guard normalizedResourceBaseURL.isFileURL else {
+            throw NSError(
+                domain: "PluginRuntime",
+                code: 2,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "プラグインのリソース URL が不正です: \(resourceBaseURL.absoluteString)"
+                ]
+            )
+        }
+        let webExtension = try await WKWebExtension(resourceBaseURL: normalizedResourceBaseURL)
+        let context = try ExtensionPluginContextConfiguration.makeContext(
+            for: webExtension,
+            pluginID: plugin.id,
+            manifestID: plugin.manifestID,
+            requestedPermissions: manifest.requestedPermissions,
+            requestedHostPermissions: manifest.requestedHostPermissions
+        )
+        context.isInspectable = true
+        let delegate = PluginExtensionControllerDelegate()
+        let controller = WKWebExtensionController()
+        controller.delegate = delegate
+        try controller.load(context)
+        guard let webViewConfiguration = context.webViewConfiguration else {
+            do {
+                try controller.unload(context)
+            } catch {
+                Logger(label: "ExtensionPluginRuntime").error(
+                    "Failed to unload incomplete plugin runtime: \(error)"
+                )
+            }
+            throw NSError(
+                domain: "PluginRuntime",
+                code: 5,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "プラグインの WebView configuration を取得できませんでした"
+                ]
+            )
+        }
+
+        self.pluginID = plugin.id
+        self.manifest = manifest
+        self.resourceBaseURL = normalizedResourceBaseURL
+        self.webExtension = webExtension
+        self.context = context
+        self.controllerDelegate = delegate
+        self.controller = controller
+        self.webViewConfiguration = webViewConfiguration
+    }
+
+    func pageURL(for area: PluginDisplayArea) -> URL? {
+        guard let pagePath = manifest.pagePath(for: area) else {
+            return nil
+        }
+        return context.baseURL.appending(path: pagePath)
+    }
+
+    func invalidate() {
+        guard !isInvalidated else { return }
+        isInvalidated = true
+        do {
+            try controller.unload(context)
+        } catch {
+            logger.error("Failed to unload plugin runtime: \(error)")
+        }
+    }
+}

--- a/kiririn/Features/Plugin/ExtensionPluginRuntimeRegistry.swift
+++ b/kiririn/Features/Plugin/ExtensionPluginRuntimeRegistry.swift
@@ -16,6 +16,11 @@ final class ExtensionPluginRuntimeRegistry {
         var useCount: Int
     }
 
+    private struct PendingWaiterState {
+        let isCurrentGeneration: Bool
+        let hasRemainingWaiters: Bool
+    }
+
     private var runtimeEntries: [UUID: RuntimeEntry] = [:]
     private var pendingLoads: [UUID: PendingRuntimeLoad] = [:]
 
@@ -80,8 +85,8 @@ final class ExtensionPluginRuntimeRegistry {
             return
         }
 
-        if runtime.manifest.isBackgroundExists {
-            // background content の実行期間は表示中の WebView の有無から独立させる。
+        if runtime.manifest.isBackgroundExists || pendingLoads[runtime.pluginID] != nil {
+            // background content と未解決の待機者は表示中の WebView の有無から独立して保持する。
             entry.useCount = 0
             runtimeEntries[runtime.pluginID] = entry
             return
@@ -124,32 +129,62 @@ final class ExtensionPluginRuntimeRegistry {
             throw error
         }
 
+        let waiterState = finishPendingWaiter(pendingLoad, pluginID: plugin.id)
+        if Task.isCancelled {
+            if !waiterState.hasRemainingWaiters {
+                discardRuntimeIfUnused(runtime)
+            }
+            throw CancellationError()
+        }
+
         if var existingEntry = runtimeEntries[plugin.id] {
-            if existingEntry.runtime === runtime {
-                return existingEntry.runtime
+            if existingEntry.runtime !== runtime {
+                runtime.invalidate()
             }
 
-            runtime.invalidate()
-            try Task.checkCancellation()
             existingEntry.useCount += 1
             runtimeEntries[plugin.id] = existingEntry
             return existingEntry.runtime
         }
 
-        guard let currentPendingLoad = pendingLoads[plugin.id],
-            currentPendingLoad.token == pendingLoad.token
-        else {
+        guard waiterState.isCurrentGeneration else {
             runtime.invalidate()
-            try Task.checkCancellation()
             return try await acquireRuntime(for: plugin, store: store)
         }
 
-        pendingLoads[plugin.id] = nil
-        // 全待機者の利用権を先に予約し、先にキャンセルされた待機者の解放から保護する。
-        runtimeEntries[plugin.id] = RuntimeEntry(
-            runtime: runtime,
-            useCount: currentPendingLoad.waiterCount
-        )
+        runtimeEntries[plugin.id] = RuntimeEntry(runtime: runtime, useCount: 1)
         return runtime
+    }
+
+    private func finishPendingWaiter(
+        _ pendingLoad: PendingRuntimeLoad,
+        pluginID: UUID
+    ) -> PendingWaiterState {
+        guard var currentPendingLoad = pendingLoads[pluginID],
+            currentPendingLoad.token == pendingLoad.token
+        else {
+            return PendingWaiterState(
+                isCurrentGeneration: false,
+                hasRemainingWaiters: false
+            )
+        }
+
+        currentPendingLoad.waiterCount -= 1
+        let hasRemainingWaiters = currentPendingLoad.waiterCount > 0
+        pendingLoads[pluginID] = hasRemainingWaiters ? currentPendingLoad : nil
+        return PendingWaiterState(
+            isCurrentGeneration: true,
+            hasRemainingWaiters: hasRemainingWaiters
+        )
+    }
+
+    private func discardRuntimeIfUnused(_ runtime: ExtensionPluginRuntime) {
+        guard let entry = runtimeEntries[runtime.pluginID], entry.runtime === runtime else {
+            runtime.invalidate()
+            return
+        }
+        guard entry.useCount == 0, !runtime.manifest.isBackgroundExists else { return }
+        runtimeEntries[runtime.pluginID] = nil
+        runtime.invalidate()
     }
 }

--- a/kiririn/Features/Plugin/ExtensionPluginRuntimeRegistry.swift
+++ b/kiririn/Features/Plugin/ExtensionPluginRuntimeRegistry.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KppxKit
 
 @MainActor
 final class ExtensionPluginRuntimeRegistry {
@@ -7,6 +8,7 @@ final class ExtensionPluginRuntimeRegistry {
     private struct PendingRuntimeLoad {
         let token: UUID
         let task: Task<ExtensionPluginRuntime, Error>
+        var waiterCount: Int
     }
 
     private struct RuntimeEntry {
@@ -17,15 +19,14 @@ final class ExtensionPluginRuntimeRegistry {
     private var runtimeEntries: [UUID: RuntimeEntry] = [:]
     private var pendingLoads: [UUID: PendingRuntimeLoad] = [:]
 
-    private func makeRuntime(for plugin: PluginDefinition, store: PluginStore) async throws
-        -> ExtensionPluginRuntime
-    {
-        if let entry = runtimeEntries[plugin.id] {
-            return entry.runtime
-        }
-
-        if let pendingLoad = pendingLoads[plugin.id] {
-            return try await resolvePendingLoad(pendingLoad, for: plugin)
+    private func pendingRuntimeLoad(
+        for plugin: PluginDefinition,
+        store: PluginStore
+    ) -> PendingRuntimeLoad {
+        if var pendingLoad = pendingLoads[plugin.id] {
+            pendingLoad.waiterCount += 1
+            pendingLoads[plugin.id] = pendingLoad
+            return pendingLoad
         }
 
         let pendingLoad = PendingRuntimeLoad(
@@ -42,23 +43,28 @@ final class ExtensionPluginRuntimeRegistry {
                     manifest: manifest,
                     resourceBaseURL: resourceBaseURL
                 )
-            }
+            },
+            waiterCount: 1
         )
         pendingLoads[plugin.id] = pendingLoad
-        return try await resolvePendingLoad(pendingLoad, for: plugin)
+        return pendingLoad
     }
 
     func acquireRuntime(for plugin: PluginDefinition, store: PluginStore) async throws
         -> ExtensionPluginRuntime
     {
-        let runtime = try await makeRuntime(for: plugin, store: store)
-        guard var entry = runtimeEntries[plugin.id], entry.runtime === runtime else {
-            runtime.invalidate()
-            throw CancellationError()
+        if var entry = runtimeEntries[plugin.id] {
+            entry.useCount += 1
+            runtimeEntries[plugin.id] = entry
+            return entry.runtime
         }
-        entry.useCount += 1
-        runtimeEntries[plugin.id] = entry
-        return runtime
+
+        let pendingLoad = pendingRuntimeLoad(for: plugin, store: store)
+        return try await resolvePendingLoad(
+            pendingLoad,
+            for: plugin,
+            store: store
+        )
     }
 
     func releaseRuntime(_ runtime: ExtensionPluginRuntime) {
@@ -66,8 +72,17 @@ final class ExtensionPluginRuntimeRegistry {
             return
         }
 
+        guard entry.useCount > 0 else { return }
+
         if entry.useCount > 1 {
             entry.useCount -= 1
+            runtimeEntries[runtime.pluginID] = entry
+            return
+        }
+
+        if runtime.manifest.isBackgroundExists {
+            // background content の実行期間は表示中の WebView の有無から独立させる。
+            entry.useCount = 0
             runtimeEntries[runtime.pluginID] = entry
             return
         }
@@ -96,36 +111,45 @@ final class ExtensionPluginRuntimeRegistry {
 
     private func resolvePendingLoad(
         _ pendingLoad: PendingRuntimeLoad,
-        for plugin: PluginDefinition
+        for plugin: PluginDefinition,
+        store: PluginStore
     ) async throws -> ExtensionPluginRuntime {
+        let runtime: ExtensionPluginRuntime
         do {
-            let runtime = try await pendingLoad.task.value
-
-            if let existingEntry = runtimeEntries[plugin.id], existingEntry.runtime === runtime {
-                return existingEntry.runtime
-            }
-
-            guard pendingLoads[plugin.id]?.token == pendingLoad.token else {
-                runtime.invalidate()
-                throw CancellationError()
-            }
-
-            pendingLoads[plugin.id] = nil
-
-            if let existingEntry = runtimeEntries[plugin.id] {
-                if existingEntry.runtime !== runtime {
-                    runtime.invalidate()
-                }
-                return existingEntry.runtime
-            }
-
-            runtimeEntries[plugin.id] = RuntimeEntry(runtime: runtime, useCount: 0)
-            return runtime
+            runtime = try await pendingLoad.task.value
         } catch {
             if pendingLoads[plugin.id]?.token == pendingLoad.token {
                 pendingLoads[plugin.id] = nil
             }
             throw error
         }
+
+        if var existingEntry = runtimeEntries[plugin.id] {
+            if existingEntry.runtime === runtime {
+                return existingEntry.runtime
+            }
+
+            runtime.invalidate()
+            try Task.checkCancellation()
+            existingEntry.useCount += 1
+            runtimeEntries[plugin.id] = existingEntry
+            return existingEntry.runtime
+        }
+
+        guard let currentPendingLoad = pendingLoads[plugin.id],
+            currentPendingLoad.token == pendingLoad.token
+        else {
+            runtime.invalidate()
+            try Task.checkCancellation()
+            return try await acquireRuntime(for: plugin, store: store)
+        }
+
+        pendingLoads[plugin.id] = nil
+        // 全待機者の利用権を先に予約し、先にキャンセルされた待機者の解放から保護する。
+        runtimeEntries[plugin.id] = RuntimeEntry(
+            runtime: runtime,
+            useCount: currentPendingLoad.waiterCount
+        )
+        return runtime
     }
 }

--- a/kiririn/Features/Plugin/ExtensionPluginRuntimeRegistry.swift
+++ b/kiririn/Features/Plugin/ExtensionPluginRuntimeRegistry.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+@MainActor
+final class ExtensionPluginRuntimeRegistry {
+    static let shared = ExtensionPluginRuntimeRegistry()
+
+    private struct PendingRuntimeLoad {
+        let token: UUID
+        let task: Task<ExtensionPluginRuntime, Error>
+    }
+
+    private struct RuntimeEntry {
+        let runtime: ExtensionPluginRuntime
+        var useCount: Int
+    }
+
+    private var runtimeEntries: [UUID: RuntimeEntry] = [:]
+    private var pendingLoads: [UUID: PendingRuntimeLoad] = [:]
+
+    private func makeRuntime(for plugin: PluginDefinition, store: PluginStore) async throws
+        -> ExtensionPluginRuntime
+    {
+        if let entry = runtimeEntries[plugin.id] {
+            return entry.runtime
+        }
+
+        if let pendingLoad = pendingLoads[plugin.id] {
+            return try await resolvePendingLoad(pendingLoad, for: plugin)
+        }
+
+        let pendingLoad = PendingRuntimeLoad(
+            token: UUID(),
+            task: Task { @MainActor in
+                let resourceBaseURL = try await store.resourceBaseURL(for: plugin)
+                try Task.checkCancellation()
+                let manifest = try store.resolvedManifest(
+                    for: plugin,
+                    resourceBaseURL: resourceBaseURL
+                )
+                return try await ExtensionPluginRuntime(
+                    plugin: plugin,
+                    manifest: manifest,
+                    resourceBaseURL: resourceBaseURL
+                )
+            }
+        )
+        pendingLoads[plugin.id] = pendingLoad
+        return try await resolvePendingLoad(pendingLoad, for: plugin)
+    }
+
+    func acquireRuntime(for plugin: PluginDefinition, store: PluginStore) async throws
+        -> ExtensionPluginRuntime
+    {
+        let runtime = try await makeRuntime(for: plugin, store: store)
+        guard var entry = runtimeEntries[plugin.id], entry.runtime === runtime else {
+            runtime.invalidate()
+            throw CancellationError()
+        }
+        entry.useCount += 1
+        runtimeEntries[plugin.id] = entry
+        return runtime
+    }
+
+    func releaseRuntime(_ runtime: ExtensionPluginRuntime) {
+        guard var entry = runtimeEntries[runtime.pluginID], entry.runtime === runtime else {
+            return
+        }
+
+        if entry.useCount > 1 {
+            entry.useCount -= 1
+            runtimeEntries[runtime.pluginID] = entry
+            return
+        }
+
+        runtimeEntries[runtime.pluginID] = nil
+        runtime.invalidate()
+    }
+
+    func invalidate(pluginID: UUID) {
+        pendingLoads.removeValue(forKey: pluginID)?.task.cancel()
+        runtimeEntries.removeValue(forKey: pluginID)?.runtime.invalidate()
+    }
+
+    func invalidateAll() {
+        let activeRuntimes = runtimeEntries.values.map(\.runtime)
+        let activeLoads = Array(pendingLoads.values)
+        runtimeEntries = [:]
+        pendingLoads = [:]
+        for pendingLoad in activeLoads {
+            pendingLoad.task.cancel()
+        }
+        for runtime in activeRuntimes {
+            runtime.invalidate()
+        }
+    }
+
+    private func resolvePendingLoad(
+        _ pendingLoad: PendingRuntimeLoad,
+        for plugin: PluginDefinition
+    ) async throws -> ExtensionPluginRuntime {
+        do {
+            let runtime = try await pendingLoad.task.value
+
+            if let existingEntry = runtimeEntries[plugin.id], existingEntry.runtime === runtime {
+                return existingEntry.runtime
+            }
+
+            guard pendingLoads[plugin.id]?.token == pendingLoad.token else {
+                runtime.invalidate()
+                throw CancellationError()
+            }
+
+            pendingLoads[plugin.id] = nil
+
+            if let existingEntry = runtimeEntries[plugin.id] {
+                if existingEntry.runtime !== runtime {
+                    runtime.invalidate()
+                }
+                return existingEntry.runtime
+            }
+
+            runtimeEntries[plugin.id] = RuntimeEntry(runtime: runtime, useCount: 0)
+            return runtime
+        } catch {
+            if pendingLoads[plugin.id]?.token == pendingLoad.token {
+                pendingLoads[plugin.id] = nil
+            }
+            throw error
+        }
+    }
+}

--- a/kiririn/Features/Plugin/PluginOverlaySnapshotRegistry.swift
+++ b/kiririn/Features/Plugin/PluginOverlaySnapshotRegistry.swift
@@ -5,16 +5,31 @@ import WebKit
 final class PluginOverlaySnapshotRegistry {
     static let shared = PluginOverlaySnapshotRegistry()
 
-    private var registry: [String: WKWebView] = [:]
+    private struct SnapshotKey: Hashable {
+        let playerID: String
+        let pluginID: String
+    }
+
+    private final class WebViewReference {
+        weak var webView: WKWebView?
+
+        init(_ webView: WKWebView) {
+            self.webView = webView
+        }
+    }
+
+    private var registry: [SnapshotKey: WebViewReference] = [:]
 
     private init() {}
 
     func register(_ webView: WKWebView, playerID: String, pluginID: String) {
-        registry[registryKey(playerID: playerID, pluginID: pluginID)] = webView
+        registry[SnapshotKey(playerID: playerID, pluginID: pluginID)] = WebViewReference(webView)
     }
 
-    func unregister(playerID: String, pluginID: String) {
-        registry.removeValue(forKey: registryKey(playerID: playerID, pluginID: pluginID))
+    func unregister(_ webView: WKWebView, playerID: String, pluginID: String) {
+        let key = SnapshotKey(playerID: playerID, pluginID: pluginID)
+        guard registry[key]?.webView === webView else { return }
+        registry.removeValue(forKey: key)
     }
 
     func takeCompositeSnapshot(
@@ -23,10 +38,10 @@ final class PluginOverlaySnapshotRegistry {
         targetAspectRatio: Double,
         targetFrame: CGRect? = nil
     ) async -> CGImage? {
-        let webViews =
-            registry
-            .filter { $0.key.hasPrefix("\(playerID):") }
-            .values
+        registry = registry.filter { $0.value.webView != nil }
+        let webViews = registry.compactMap { key, reference in
+            key.playerID == playerID ? reference.webView : nil
+        }
         guard !webViews.isEmpty else { return nil }
 
         let normalizedAspectRatio =
@@ -110,9 +125,5 @@ final class PluginOverlaySnapshotRegistry {
         }
 
         return image.cropping(to: cropRect)
-    }
-
-    private func registryKey(playerID: String, pluginID: String) -> String {
-        "\(playerID):\(pluginID)"
     }
 }

--- a/kiririn/Features/Plugin/PluginOverlayView.swift
+++ b/kiririn/Features/Plugin/PluginOverlayView.swift
@@ -1,14 +1,6 @@
 import Combine
 import KppxKit
-import Logging
 import SwiftUI
-import WebKit
-
-#if os(macOS)
-    import AppKit
-#else
-    import UIKit
-#endif
 
 extension PluginDisplayArea {
     var localizedName: String {
@@ -38,390 +30,13 @@ struct PluginSafeAreaInsets: Sendable, Equatable {
     }
 }
 
-enum ExtensionPluginContextConfiguration {
-    private static let errorDomain = "PluginRuntime"
-    private static let baseURLScheme = "webkit-extension"
-
-    static func uniqueIdentifier(for manifestID: String) -> String {
-        manifestID
-    }
-
-    private static func baseURL(forHost host: String, identity: String) throws -> URL {
-        var components = URLComponents()
-        components.scheme = baseURLScheme
-        components.host = host
-        components.path = "/"
-
-        guard let baseURL = components.url else {
-            throw NSError(
-                domain: errorDomain,
-                code: 3,
-                userInfo: [
-                    NSLocalizedDescriptionKey:
-                        "プラグインの base URL が不正です: \(identity)"
-                ]
-            )
-        }
-
-        return baseURL
-    }
-
-    private static func host(from baseURL: URL, identity: String) throws -> String {
-        guard let host = baseURL.host, !host.isEmpty else {
-            throw NSError(
-                domain: errorDomain,
-                code: 4,
-                userInfo: [
-                    NSLocalizedDescriptionKey:
-                        "プラグインの host を解決できませんでした: \(identity)"
-                ]
-            )
-        }
-
-        return host
-    }
-
-    static func baseURL(for pluginID: UUID) throws -> URL {
-        try baseURL(forHost: pluginID.uuidString.lowercased(), identity: pluginID.uuidString)
-    }
-
-    static func host(for pluginID: UUID) throws -> String {
-        try host(from: baseURL(for: pluginID), identity: pluginID.uuidString)
-    }
-
-    static func websiteDataHost(for pluginID: UUID) throws -> String {
-        try host(for: pluginID)
-    }
-
-    @MainActor
-    static func makeContext(
-        for webExtension: WKWebExtension,
-        pluginID: UUID,
-        manifestID: String,
-        requestedPermissions: [String],
-        requestedHostPermissions: [String]
-    ) throws -> WKWebExtensionContext {
-        let context = WKWebExtensionContext(for: webExtension)
-        try applyStableIdentity(to: context, pluginID: pluginID, manifestID: manifestID)
-        applyRequestedPermissions(requestedPermissions, to: context)
-        applyRequestedHostPermissions(requestedHostPermissions, to: context)
-        return context
-    }
-
-    @MainActor
-    static func applyStableIdentity(
-        to context: WKWebExtensionContext,
-        pluginID: UUID,
-        manifestID: String
-    ) throws {
-        context.uniqueIdentifier = uniqueIdentifier(for: manifestID)
-        context.baseURL = try baseURL(for: pluginID)
-    }
-
-    @MainActor
-    private static func applyRequestedPermissions(
-        _ requestedPermissions: [String],
-        to context: WKWebExtensionContext
-    ) {
-        for permission in requestedPermissions {
-            context.setPermissionStatus(
-                .grantedExplicitly,
-                for: WKWebExtension.Permission(permission)
-            )
-        }
-    }
-
-    @MainActor
-    private static func applyRequestedHostPermissions(
-        _ hostPermissions: [String],
-        to context: WKWebExtensionContext
-    ) {
-        for pattern in hostPermissions {
-            guard let matchPattern = try? WKWebExtension.MatchPattern(string: pattern) else {
-                continue
-            }
-            context.setPermissionStatus(.grantedExplicitly, for: matchPattern)
-        }
-    }
-}
-
-@MainActor
-enum PluginWebsiteDataStore {
-    private static let extensionDataTypes = WKWebExtensionController.allExtensionDataTypes
-    private static let websiteDataTypes = WKWebsiteDataStore.allWebsiteDataTypes()
-
-    static func unregisterServiceWorkers(for plugin: PluginDefinition) async {
-        guard let host = try? ExtensionPluginContextConfiguration.websiteDataHost(for: plugin.id)
-        else { return }
-        let swTypes: Set<String> = [WKWebsiteDataTypeServiceWorkerRegistrations]
-        let dataStore = WKWebsiteDataStore.default()
-        let records = await matchingRecords(forHost: host, dataStore: dataStore)
-        guard !records.isEmpty else { return }
-        await withCheckedContinuation { continuation in
-            dataStore.removeData(ofTypes: swTypes, for: records) {
-                continuation.resume(returning: ())
-            }
-        }
-    }
-
-    @MainActor
-    static func removeAllData(for plugin: PluginDefinition, store: PluginStore) async throws
-        -> Bool
-    {
-        let removedWebsiteData = try await removeWebsiteData(for: plugin)
-
-        do {
-            let runtime = try await ExtensionPluginRuntimeRegistry.shared.makeRuntime(
-                for: plugin,
-                store: store
-            )
-            let removedExtensionData = await removeExtensionData(for: runtime)
-            return removedExtensionData || removedWebsiteData
-        } catch {
-            if removedWebsiteData {
-                return true
-            }
-            throw error
-        }
-    }
-
-    private static func removeExtensionData(for runtime: ExtensionPluginRuntime) async -> Bool {
-        guard
-            let record = await runtime.controller.dataRecord(
-                ofTypes: extensionDataTypes,
-                for: runtime.context
-            )
-        else {
-            return false
-        }
-
-        let removableTypes = record.containedDataTypes.intersection(extensionDataTypes)
-        guard !removableTypes.isEmpty else { return false }
-
-        await runtime.controller.removeData(ofTypes: removableTypes, from: [record])
-        return true
-    }
-
-    private static func removeWebsiteData(for plugin: PluginDefinition) async throws -> Bool {
-        let host = try ExtensionPluginContextConfiguration.websiteDataHost(for: plugin.id)
-        return await removeWebsiteData(forHost: host)
-    }
-
-    private static func removeWebsiteData(forHost host: String) async -> Bool {
-        let dataStore = WKWebsiteDataStore.default()
-        let records = await matchingRecords(forHost: host, dataStore: dataStore)
-        guard !records.isEmpty else { return false }
-
-        await withCheckedContinuation { continuation in
-            dataStore.removeData(ofTypes: websiteDataTypes, for: records) {
-                continuation.resume(returning: ())
-            }
-        }
-
-        return true
-    }
-
-    private static func matchingRecords(forHost host: String, dataStore: WKWebsiteDataStore) async
-        -> [WKWebsiteDataRecord]
-    {
-        let normalizedHost = host.lowercased()
-
-        return await withCheckedContinuation { continuation in
-            dataStore.fetchDataRecords(ofTypes: websiteDataTypes) { records in
-                continuation.resume(
-                    returning: records.filter {
-                        let displayName = $0.displayName.lowercased()
-                        return displayName == normalizedHost
-                            || displayName.hasSuffix(".\(normalizedHost)")
-                    })
-            }
-        }
-    }
-}
-
-@MainActor
-private final class PluginExtensionControllerDelegate: NSObject, WKWebExtensionControllerDelegate {
-    func webExtensionController(
-        _ controller: WKWebExtensionController,
-        promptForPermissions permissions: Set<WKWebExtension.Permission>,
-        in tab: (any WKWebExtensionTab)?,
-        for extensionContext: WKWebExtensionContext,
-        completionHandler: @escaping (Set<WKWebExtension.Permission>, Date?) -> Void
-    ) {
-        completionHandler(permissions, nil)
-    }
-
-    func webExtensionController(
-        _ controller: WKWebExtensionController,
-        promptForPermissionMatchPatterns matchPatterns: Set<WKWebExtension.MatchPattern>,
-        in tab: (any WKWebExtensionTab)?,
-        for extensionContext: WKWebExtensionContext,
-        completionHandler: @escaping (Set<WKWebExtension.MatchPattern>, Date?) -> Void
-    ) {
-        completionHandler(matchPatterns, nil)
-    }
-}
-
-@MainActor
-final class ExtensionPluginRuntime {
-    let pluginID: UUID
-    let manifest: ExtensionPluginManifest
-    let resourceBaseURL: URL
-    let webExtension: WKWebExtension
-    let context: WKWebExtensionContext
-    let controller: WKWebExtensionController
-    private let controllerDelegate: PluginExtensionControllerDelegate
-    private var isInvalidated = false
-
-    init(
-        plugin: PluginDefinition,
-        manifest: ExtensionPluginManifest,
-        resourceBaseURL: URL
-    ) async throws {
-        let normalizedResourceBaseURL = resourceBaseURL.standardizedFileURL
-        guard normalizedResourceBaseURL.isFileURL else {
-            throw NSError(
-                domain: "PluginRuntime",
-                code: 2,
-                userInfo: [
-                    NSLocalizedDescriptionKey:
-                        "プラグインのリソース URL が不正です: \(resourceBaseURL.absoluteString)"
-                ]
-            )
-        }
-        self.pluginID = plugin.id
-        self.manifest = manifest
-        self.resourceBaseURL = normalizedResourceBaseURL
-        self.webExtension = try await WKWebExtension(
-            resourceBaseURL: normalizedResourceBaseURL)
-        self.context = try ExtensionPluginContextConfiguration.makeContext(
-            for: webExtension,
-            pluginID: plugin.id,
-            manifestID: plugin.manifestID,
-            requestedPermissions: manifest.requestedPermissions,
-            requestedHostPermissions: manifest.requestedHostPermissions
-        )
-        self.context.isInspectable = true
-        let delegate = PluginExtensionControllerDelegate()
-        self.controllerDelegate = delegate
-        self.controller = WKWebExtensionController()
-        self.controller.delegate = delegate
-        try controller.load(context)
-    }
-
-    func pageURL(for area: PluginDisplayArea) -> URL? {
-        guard let pagePath = manifest.pagePath(for: area) else {
-            return nil
-        }
-        return context.baseURL.appending(path: pagePath)
-    }
-
-    func invalidate() {
-        guard !isInvalidated else { return }
-        isInvalidated = true
-        try? controller.unload(context)
-    }
-}
-
-@MainActor
-final class ExtensionPluginRuntimeRegistry {
-    static let shared = ExtensionPluginRuntimeRegistry()
-
-    private struct PendingRuntimeLoad {
-        let token: UUID
-        let task: Task<ExtensionPluginRuntime, Error>
-    }
-
-    private var runtimes: [UUID: ExtensionPluginRuntime] = [:]
-    private var pendingLoads: [UUID: PendingRuntimeLoad] = [:]
-
-    func makeRuntime(for plugin: PluginDefinition, store: PluginStore) async throws
-        -> ExtensionPluginRuntime
-    {
-        if let runtime = runtimes[plugin.id] {
-            return runtime
-        }
-
-        if let pendingLoad = pendingLoads[plugin.id] {
-            return try await resolvePendingLoad(pendingLoad, for: plugin, store: store)
-        }
-
-        let resourceBaseURL = try await store.resourceBaseURL(for: plugin)
-        let manifest = try store.resolvedManifest(
-            for: plugin,
-            resourceBaseURL: resourceBaseURL
-        )
-        let pendingLoad = PendingRuntimeLoad(
-            token: UUID(),
-            task: Task { @MainActor in
-                try await ExtensionPluginRuntime(
-                    plugin: plugin,
-                    manifest: manifest,
-                    resourceBaseURL: resourceBaseURL
-                )
-            }
-        )
-        pendingLoads[plugin.id] = pendingLoad
-        return try await resolvePendingLoad(pendingLoad, for: plugin, store: store)
-    }
-
-    func invalidate(pluginID: UUID) {
-        pendingLoads.removeValue(forKey: pluginID)?.task.cancel()
-        runtimes.removeValue(forKey: pluginID)?.invalidate()
-    }
-
-    func invalidateAll() {
-        let activeRuntimes = Array(runtimes.values)
-        let activeLoads = Array(pendingLoads.values)
-        runtimes = [:]
-        pendingLoads = [:]
-        for pendingLoad in activeLoads {
-            pendingLoad.task.cancel()
-        }
-        for runtime in activeRuntimes {
-            runtime.invalidate()
-        }
-    }
-
-    private func resolvePendingLoad(
-        _ pendingLoad: PendingRuntimeLoad,
-        for plugin: PluginDefinition,
-        store: PluginStore
-    ) async throws -> ExtensionPluginRuntime {
-        do {
-            let runtime = try await pendingLoad.task.value
-
-            if let existingRuntime = runtimes[plugin.id], existingRuntime === runtime {
-                return existingRuntime
-            }
-
-            guard pendingLoads[plugin.id]?.token == pendingLoad.token else {
-                runtime.invalidate()
-                try Task.checkCancellation()
-                return try await makeRuntime(for: plugin, store: store)
-            }
-
-            pendingLoads[plugin.id] = nil
-
-            if let existingRuntime = runtimes[plugin.id] {
-                if existingRuntime !== runtime {
-                    runtime.invalidate()
-                }
-                return existingRuntime
-            }
-
-            runtimes[plugin.id] = runtime
-            return runtime
-        } catch {
-            if pendingLoads[plugin.id]?.token == pendingLoad.token {
-                pendingLoads[plugin.id] = nil
-            }
-            throw error
-        }
-    }
-}
-
 struct PluginOverlayView: View {
+    private struct RuntimeLoadKey: Hashable {
+        let pluginID: UUID
+        let reloadKey: PluginReloadKey
+        let resourceBasePath: String
+    }
+
     let pluginDefinition: PluginDefinition
     let appModel: AppModel
     let reloadToken: Int
@@ -450,7 +65,20 @@ struct PluginOverlayView: View {
     @State private var isDetailsExpanded = false
     @State private var pendingDeeplinkURL: URL?
     @State private var deeplinkToken = 0
+    @State private var manualReloadToken = 0
     @State private var extensionRuntime: ExtensionPluginRuntime?
+
+    private var reloadKey: PluginReloadKey {
+        PluginReloadKey(external: reloadToken, manual: manualReloadToken)
+    }
+
+    private var runtimeLoadKey: RuntimeLoadKey {
+        RuntimeLoadKey(
+            pluginID: pluginDefinition.id,
+            reloadKey: reloadKey,
+            resourceBasePath: pluginDefinition.resourceBasePath
+        )
+    }
 
     var body: some View {
         // アクティブな全プレイヤーの状態を追跡するハッシュを生成し、これを元に再描画と同期をトリガーさせる。
@@ -460,22 +88,19 @@ struct PluginOverlayView: View {
                 "\($0.id):\($0.currentPlayable?.id ?? "none"):\($0.playbackStatus.isPlaying):\($0.currentPlayable?.isSeekable ?? false)"
             }.joined(separator: "|") + (appModel.focusedPlayerID ?? "")
         ZStack {
-            if extensionRuntime != nil {
+            if let extensionRuntime {
                 PluginWebView(
                     pluginDefinition: pluginDefinition,
                     extensionRuntime: extensionRuntime,
                     appModel: appModel,
-                    reloadToken: reloadToken,
+                    reloadKey: reloadKey,
                     displayArea: displayArea,
                     playerID: playerID,
                     safeAreaInsets: safeAreaInsets,
                     deeplinkURL: pendingDeeplinkURL,
                     deeplinkToken: deeplinkToken,
                     stateHash: stateHash,
-                    onCrash: {
-                        isDetailsExpanded = false
-                        isCrashed = true
-                    }
+                    onCrash: handleWebContentProcessCrash
                 )
                 .allowsHitTesting(!isCrashed)
             } else if displayArea != .overlay {
@@ -487,10 +112,7 @@ struct PluginOverlayView: View {
             }
         }
         .onChange(of: reloadToken) {
-            isCrashed = false
-            lastError = nil
-            ExtensionPluginRuntimeRegistry.shared.invalidate(pluginID: pluginDefinition.id)
-            extensionRuntime = nil
+            handleExternalReload()
         }
         .onDisappear {
             releaseExtensionRuntime()
@@ -530,27 +152,25 @@ struct PluginOverlayView: View {
         deeplinkToken += 1
     }
 
-    private var runtimeLoadKey: String {
-        return
-            "\(pluginDefinition.id.uuidString)-\(reloadToken)-\(pluginDefinition.resourceBasePath)"
-    }
-
     @MainActor
     private func loadExtensionRuntime() async {
         let expectedLoadKey = runtimeLoadKey
 
         do {
-            let runtime = try await ExtensionPluginRuntimeRegistry.shared.makeRuntime(
+            let runtime = try await ExtensionPluginRuntimeRegistry.shared.acquireRuntime(
                 for: pluginDefinition,
                 store: appModel.pluginStore
             )
-            guard !Task.isCancelled, runtimeLoadKey == expectedLoadKey else { return }
-            extensionRuntime = runtime
+            guard !Task.isCancelled, runtimeLoadKey == expectedLoadKey else {
+                ExtensionPluginRuntimeRegistry.shared.releaseRuntime(runtime)
+                return
+            }
+            replaceExtensionRuntime(with: runtime)
         } catch {
             guard !Task.isCancelled, runtimeLoadKey == expectedLoadKey else {
                 return
             }
-            extensionRuntime = nil
+            releaseExtensionRuntime()
             lastError = error.localizedDescription
             if displayArea != .overlay {
                 isCrashed = true
@@ -560,7 +180,48 @@ struct PluginOverlayView: View {
 
     @MainActor
     private func releaseExtensionRuntime() {
+        guard let runtime = extensionRuntime else { return }
         extensionRuntime = nil
+        ExtensionPluginRuntimeRegistry.shared.releaseRuntime(runtime)
+    }
+
+    @MainActor
+    private func replaceExtensionRuntime(with runtime: ExtensionPluginRuntime) {
+        if extensionRuntime === runtime {
+            ExtensionPluginRuntimeRegistry.shared.releaseRuntime(runtime)
+            return
+        }
+
+        let previousRuntime = extensionRuntime
+        extensionRuntime = runtime
+        if let previousRuntime {
+            ExtensionPluginRuntimeRegistry.shared.releaseRuntime(previousRuntime)
+        }
+    }
+
+    @MainActor
+    private func handleExternalReload() {
+        resetCrashState()
+        releaseExtensionRuntime()
+        ExtensionPluginRuntimeRegistry.shared.invalidate(pluginID: pluginDefinition.id)
+    }
+
+    @MainActor
+    private func reloadAfterCrash() {
+        resetCrashState()
+        releaseExtensionRuntime()
+        manualReloadToken += 1
+    }
+
+    private func handleWebContentProcessCrash() {
+        isDetailsExpanded = false
+        isCrashed = true
+    }
+
+    private func resetCrashState() {
+        isCrashed = false
+        lastError = nil
+        isDetailsExpanded = false
     }
 
     @ViewBuilder
@@ -619,18 +280,8 @@ struct PluginOverlayView: View {
                         .frame(maxWidth: 400)
                     }
 
-                    Button("再読み込み") {
-                        isCrashed = false
-                        lastError = nil
-                        isDetailsExpanded = false
-                        ExtensionPluginRuntimeRegistry.shared.invalidate(
-                            pluginID: pluginDefinition.id)
-                        extensionRuntime = nil
-                        Task {
-                            await loadExtensionRuntime()
-                        }
-                    }
-                    .buttonStyle(.borderedProminent)
+                    Button("再読み込み", action: reloadAfterCrash)
+                        .buttonStyle(.borderedProminent)
                 }
                 .padding(.horizontal, 20)
                 .padding(.vertical, 24)
@@ -646,924 +297,5 @@ struct PluginOverlayView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-    }
-}
-
-#if os(macOS)
-    private typealias PluginWebViewRepresentable = NSViewRepresentable
-#else
-    private typealias PluginWebViewRepresentable = UIViewRepresentable
-#endif
-
-private struct PluginWebView: PluginWebViewRepresentable {
-    let pluginDefinition: PluginDefinition
-    let extensionRuntime: ExtensionPluginRuntime?
-    let appModel: AppModel
-    let reloadToken: Int
-    let displayArea: PluginDisplayArea
-    let playerID: String?
-    let safeAreaInsets: PluginSafeAreaInsets
-    let deeplinkURL: URL?
-    let deeplinkToken: Int
-    let stateHash: String
-    let onCrash: @MainActor () -> Void
-    private let logger = Logging.Logger(label: "PluginWebView")
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(parent: self, onCrash: onCrash)
-    }
-
-    private func makePlatformWebView(context: Context) -> WKWebView {
-        let config: WKWebViewConfiguration = {
-            if let existingConfig = extensionRuntime?.context.webViewConfiguration {
-                return existingConfig
-            } else {
-                logger.error("Failed to get web view configuration. Using default.")
-                return WKWebViewConfiguration()
-            }
-        }()
-        config.applicationNameForUserAgent = makeApplicationNameForUserAgent()
-        let contentController = WKUserContentController()
-
-        let bridgeScript = WKUserScript(
-            source: makeBridgeJS(),
-            injectionTime: .atDocumentStart,
-            forMainFrameOnly: true
-        )
-        contentController.addUserScript(bridgeScript)
-
-        // WKUserContentController holds a strong reference to the handler.
-        // Use a weak proxy to avoid a retain cycle between the Coordinator and the WebView.
-        let weakHandler = LeakAversionScriptMessageHandler(handler: context.coordinator)
-        contentController.add(weakHandler, name: "kiririn")
-
-        config.userContentController = contentController
-
-        let webView = WKWebView(frame: .zero, configuration: config)
-        webView.isInspectable = true
-        #if os(macOS)
-            webView.setValue(false, forKey: "drawsBackground")
-            webView.allowsMagnification = false
-        #else
-            webView.isOpaque = false
-            webView.backgroundColor = .clear
-            webView.scrollView.backgroundColor = .clear
-            webView.scrollView.isScrollEnabled = displayArea != .overlay
-            webView.scrollView.contentInsetAdjustmentBehavior = .never
-        #endif
-        webView.uiDelegate = context.coordinator
-        webView.navigationDelegate = context.coordinator
-        context.coordinator.webView = webView
-        context.coordinator.lastLoadedPageURL = currentPageURLString()
-        context.coordinator.lastReloadToken = reloadToken
-        context.coordinator.isPageReady = false
-
-        if displayArea == .overlay, let pid = playerID {
-            let wv = webView
-            let pid = pid
-            let plugID = pluginDefinition.id.uuidString
-            Task { @MainActor in
-                PluginOverlaySnapshotRegistry.shared.register(wv, playerID: pid, pluginID: plugID)
-            }
-        }
-
-        Task { @MainActor in
-            self.loadPluginPage(into: webView)
-        }
-        return webView
-    }
-
-    #if os(macOS)
-        func makeNSView(context: Context) -> WKWebView {
-            makePlatformWebView(context: context)
-        }
-    #else
-        func makeUIView(context: Context) -> WKWebView {
-            makePlatformWebView(context: context)
-        }
-    #endif
-
-    private func updatePlatformWebView(_ webView: WKWebView, context: Context) {
-        let pageChanged = context.coordinator.lastLoadedPageURL != currentPageURLString()
-        let tokenChanged = context.coordinator.lastReloadToken != reloadToken
-
-        if pageChanged || tokenChanged {
-            context.coordinator.lastLoadedPageURL = currentPageURLString()
-            context.coordinator.lastReloadToken = reloadToken
-            context.coordinator.lastInjectedPlayablesJson = nil
-            context.coordinator.lastInjectedStatusesJson = nil
-            context.coordinator.lastInjectedFocusedPlayerID = nil
-            context.coordinator.lastInjectedPlayerIDs = nil
-            context.coordinator.wantsCaptureEvents = false
-            context.coordinator.isPageReady = false
-            Task { @MainActor in
-                self.loadPluginPage(into: webView)
-            }
-        }
-        if context.coordinator.lastInjectedDeeplinkToken != deeplinkToken {
-            context.coordinator.lastInjectedDeeplinkToken = deeplinkToken
-            if let deeplinkURL {
-                context.coordinator.queueDeeplinkEvent(deeplinkURL)
-            }
-        }
-        injectAllStates(into: webView, coordinator: context.coordinator)
-    }
-
-    private func injectAllStates(
-        into webView: WKWebView, coordinator: Coordinator, force: Bool = false
-    ) {
-        injectPlayables(into: webView, coordinator: coordinator, force: force)
-        injectStatuses(into: webView, coordinator: coordinator, force: force)
-        injectFocus(into: webView, coordinator: coordinator, force: force)
-    }
-
-    #if os(macOS)
-        func updateNSView(_ webView: WKWebView, context: Context) {
-            updatePlatformWebView(webView, context: context)
-        }
-    #else
-        func updateUIView(_ webView: WKWebView, context: Context) {
-            updatePlatformWebView(webView, context: context)
-        }
-    #endif
-
-    private static func dismantlePlatformWebView(_ uiView: WKWebView, coordinator: Coordinator) {
-        uiView.stopLoading()
-        uiView.loadHTMLString("", baseURL: nil)
-        coordinator.captureEventCancellable?.cancel()
-        coordinator.captureEventCancellable = nil
-        uiView.configuration.userContentController.removeAllUserScripts()
-        uiView.configuration.userContentController.removeScriptMessageHandler(forName: "kiririn")
-        uiView.uiDelegate = nil
-        uiView.navigationDelegate = nil
-
-        if let parent = coordinator.parent,
-            parent.displayArea == .overlay,
-            let playerID = parent.playerID
-        {
-            let pluginID = parent.pluginDefinition.id.uuidString
-            Task { @MainActor in
-                PluginOverlaySnapshotRegistry.shared.unregister(
-                    playerID: playerID, pluginID: pluginID)
-            }
-        }
-
-        coordinator.webView = nil
-    }
-
-    #if os(macOS)
-        static func dismantleNSView(_ uiView: WKWebView, coordinator: Coordinator) {
-            dismantlePlatformWebView(uiView, coordinator: coordinator)
-        }
-    #else
-        static func dismantleUIView(_ uiView: WKWebView, coordinator: Coordinator) {
-            dismantlePlatformWebView(uiView, coordinator: coordinator)
-        }
-    #endif
-
-    private func makeRuntimeInfoContext() -> [String: Any] {
-        let bundle = Bundle.main
-        let appVersion =
-            bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-        let buildVersion =
-            (bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String) ?? "1"
-        let runtimePlayerID: Any = {
-            if displayArea == .overlay {
-                return playerID ?? NSNull()
-            }
-            return NSNull()
-        }()
-
-        return [
-            "platform": {
-                #if os(macOS)
-                    "macOS"
-                #else
-                    "iOS"
-                #endif
-            }(),
-            "osVersion": ProcessInfo.processInfo.operatingSystemVersionString,
-            "appVersion": appVersion ?? NSNull(),
-            "buildVersion": buildVersion,
-            "bundleIdentifier": bundle.bundleIdentifier ?? NSNull(),
-            "bridgeVersion": 3,
-            "displayAreaType": displayArea.rawValue,
-            "playerID": runtimePlayerID,
-        ]
-    }
-
-    private func makeApplicationNameForUserAgent() -> String {
-        let appVersion =
-            (Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String)
-            ?? "1"
-        return "kiririn/\(appVersion)"
-    }
-
-    private func injectPlayables(
-        into webView: WKWebView, coordinator: Coordinator, force: Bool = false
-    ) {
-        let currentIDs = Set(appModel.activePlayerStates.map { $0.id })
-        if let lastIDs = coordinator.lastInjectedPlayerIDs {
-            let removedIDs = lastIDs.subtracting(currentIDs)
-            for removedID in removedIDs {
-                let js =
-                    "if(window.kiririn && window.kiririn._onPlayerClosed) window.kiririn._onPlayerClosed(\"\(removedID)\");"
-                webView.evaluateJavaScript(js)
-            }
-        }
-        coordinator.lastInjectedPlayerIDs = currentIDs
-
-        let playables = appModel.activePlayerStates.compactMap { state -> [String: Any]? in
-            guard var schema = state.currentPlayable?.toPluginSchema() else { return nil }
-            schema["playerID"] = state.id
-            return schema
-        }
-        guard
-            let data = try? JSONSerialization.data(
-                withJSONObject: playables, options: [.sortedKeys]),
-            let json = String(data: data, encoding: .utf8)
-        else { return }
-
-        if !force, let last = coordinator.lastInjectedPlayablesJson, last == json {
-            return
-        }
-        coordinator.lastInjectedPlayablesJson = json
-
-        let js =
-            "if(window.kiririn && window.kiririn._onPlayablesChange) window.kiririn._onPlayablesChange(\(json));"
-        webView.evaluateJavaScript(js)
-    }
-
-    private func loadPluginPage(into webView: WKWebView) {
-        if let extensionRuntime,
-            let extensionPageURL = extensionRuntime.pageURL(for: displayArea)
-        {
-            webView.load(URLRequest(url: extensionPageURL))
-        }
-    }
-
-    private func currentPageURLString() -> String? {
-        extensionRuntime?.pageURL(for: displayArea)?.absoluteString
-    }
-
-    private func injectStatuses(
-        into webView: WKWebView, coordinator: Coordinator, force: Bool = false
-    ) {
-        let statuses = appModel.activePlayerStates.compactMap { state -> [String: Any]? in
-            guard let s = state.playbackStatus as PlayerPlaybackStatus?,
-                state.currentPlayable != nil
-            else { return nil }
-            return [
-                "playerID": state.id,
-                "playableID": s.playableID ?? "",
-                "isPlaying": s.isPlaying,
-                "time": s.time,
-                "position": s.position,
-                "rate": s.rate,
-            ]
-        }
-        guard
-            let data = try? JSONSerialization.data(
-                withJSONObject: statuses, options: [.sortedKeys]),
-            let json = String(data: data, encoding: .utf8)
-        else { return }
-
-        if !force, let last = coordinator.lastInjectedStatusesJson, last == json {
-            return
-        }
-        coordinator.lastInjectedStatusesJson = json
-
-        let js =
-            "if(window.kiririn && window.kiririn._onPlayerStatusesChange) window.kiririn._onPlayerStatusesChange(\(json));"
-        webView.evaluateJavaScript(js)
-    }
-
-    private func injectFocus(into webView: WKWebView, coordinator: Coordinator, force: Bool = false)
-    {
-        let activeIDs = Set(appModel.activePlayerStates.map(\.id))
-        let normalizedFocusedID = appModel.focusedPlayerID.flatMap {
-            activeIDs.contains($0) ? $0 : nil
-        }
-        let focusedID = normalizedFocusedID ?? ""
-
-        if !force, let last = coordinator.lastInjectedFocusedPlayerID, last == focusedID {
-            return
-        }
-        coordinator.lastInjectedFocusedPlayerID = focusedID
-
-        let js =
-            "if(window.kiririn && window.kiririn._onFocusedPlayerIDChange) window.kiririn._onFocusedPlayerIDChange(\(focusedID.isEmpty ? "null" : "\"\(focusedID)\""));"
-        webView.evaluateJavaScript(js)
-    }
-
-    private func makeBridgeJS() -> String {
-        let playables = appModel.activePlayerStates.compactMap { state -> [String: Any]? in
-            guard var schema = state.currentPlayable?.toPluginSchema() else { return nil }
-            schema["playerID"] = state.id
-            return schema
-        }
-        let statuses = appModel.activePlayerStates.compactMap { state -> [String: Any]? in
-            guard let s = state.playbackStatus as PlayerPlaybackStatus?,
-                state.currentPlayable != nil
-            else { return nil }
-            return [
-                "playerID": state.id,
-                "playableID": s.playableID ?? "",
-                "isPlaying": s.isPlaying,
-                "time": s.time,
-                "position": s.position,
-                "rate": s.rate,
-            ]
-        }
-        let activeIDs = Set(appModel.activePlayerStates.map(\.id))
-        let focusedID = appModel.focusedPlayerID.flatMap { activeIDs.contains($0) ? $0 : nil } ?? ""
-
-        let playablesJson =
-            (try? JSONSerialization.data(withJSONObject: playables, options: [.sortedKeys])).flatMap
-        { String(data: $0, encoding: .utf8) } ?? "[]"
-        let statusJson =
-            (try? JSONSerialization.data(withJSONObject: statuses, options: [.sortedKeys])).flatMap
-        { String(data: $0, encoding: .utf8) } ?? "[]"
-
-        guard
-            let runtimeInfoData = try? JSONSerialization.data(
-                withJSONObject: makeRuntimeInfoContext(), options: [.sortedKeys]),
-            let runtimeInfoString = String(data: runtimeInfoData, encoding: .utf8)
-        else {
-            return "window.kiririn = {};"
-        }
-
-        let safeAreaInsetsString =
-            (try? JSONSerialization.data(
-                withJSONObject: safeAreaInsets.asDictionary,
-                options: [.sortedKeys]
-            )).flatMap { String(data: $0, encoding: .utf8) }
-            ?? #"{"bottom":0,"left":0,"right":0,"top":0}"#
-
-        return """
-            window.kiririn = {
-                _playables: \(playablesJson),
-                _playablesListeners: [],
-                _statuses: \(statusJson),
-                _statusesListeners: [],
-                _focusedPlayerID: \(focusedID.isEmpty ? "null" : "\"\(focusedID)\""),
-                _focusedPlayerIDListeners: [],
-                _playerClosedListeners: [],
-                _runtimeInfo: \(runtimeInfoString),
-                _safeAreaInsets: \(safeAreaInsetsString),
-                _deeplinkOpenedListeners: [],
-                _captureTakenListeners: [],
-                _captureBlobResolvers: Object.create(null),
-                _captureEventsSubscribed: false,
-
-                getPlayables: function() { return this._playables; },
-                onPlayablesChange: function(callback) { this._playablesListeners.push(callback); },
-                _onPlayablesChange: function(playables) {
-                    this._playables = playables;
-                    this._playablesListeners.forEach(function(cb) { try { cb(playables); } catch(e) {} });
-                },
-
-                getPlayerStatuses: function() { return this._statuses; },
-                onPlayerStatusesChange: function(callback) { this._statusesListeners.push(callback); },
-                _onPlayerStatusesChange: function(statuses) {
-                    this._statuses = statuses;
-                    this._statusesListeners.forEach(function(cb) { try { cb(statuses); } catch(e) {} });
-                },
-
-                getFocusedPlayerID: function() { return this._focusedPlayerID; },
-                onFocusedPlayerIDChange: function(callback) { this._focusedPlayerIDListeners.push(callback); },
-                _onFocusedPlayerIDChange: function(id) {
-                    this._focusedPlayerID = id;
-                    this._focusedPlayerIDListeners.forEach(function(cb) { try { cb(id); } catch(e) {} });
-                },
-
-                onPlayerClosed: function(callback) { this._playerClosedListeners.push(callback); },
-                _onPlayerClosed: function(playerID) {
-                    if (this._focusedPlayerID === playerID) {
-                        this._focusedPlayerID = null;
-                        this._focusedPlayerIDListeners.forEach(function(cb) { try { cb(null); } catch(e) {} });
-                    }
-                    this._playerClosedListeners.forEach(function(cb) { try { cb(playerID); } catch(e) {} });
-                },
-
-                getPlayable: function(playerID) {
-                    return this.getPlayables().find(p => p.playerID === playerID) || null;
-                },
-
-                getPlayerStatus: function(playerID) {
-                    return this.getPlayerStatuses().find(s => s.playerID === playerID) || null;
-                },
-
-                getRuntimeInfo: function() { return this._runtimeInfo; },
-
-                _applySafeAreaInsetsToCSS: function() {
-                    if (!this._safeAreaInsets) { return; }
-                    const insets = this._safeAreaInsets;
-                    const root = document.documentElement;
-                    if (!root || !root.style) { return; }
-                    root.style.setProperty('--kiririn-safe-area-inset-top', String(insets.top) + 'px');
-                    root.style.setProperty('--kiririn-safe-area-inset-right', String(insets.right) + 'px');
-                    root.style.setProperty('--kiririn-safe-area-inset-bottom', String(insets.bottom) + 'px');
-                    root.style.setProperty('--kiririn-safe-area-inset-left', String(insets.left) + 'px');
-                },
-
-                onDeeplinkOpened: function(callback) { this._deeplinkOpenedListeners.push(callback); },
-                _emitDeeplinkOpened: function(payload) {
-                    this._deeplinkOpenedListeners.forEach(function(cb) { try { cb(payload); } catch(e) {} });
-                },
-
-                onCaptureTaken: function(callback) {
-                    this._captureTakenListeners.push(callback);
-                    if (!this._captureEventsSubscribed && window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.kiririn) {
-                        this._captureEventsSubscribed = true;
-                        window.webkit.messageHandlers.kiririn.postMessage({type: '_captureTakenSubscribe'});
-                    }
-                },
-                _emitCaptureTaken: function(payload) {
-                    const normalizedPayload = payload ? Object.assign({}, payload, {
-                        capturedAt: new Date(payload.capturedAt * 1000),
-                        variants: Array.isArray(payload.variants) ? payload.variants : []
-                    }) : payload;
-                    this._captureTakenListeners.forEach(function(cb) { try { cb(normalizedPayload); } catch(e) {} });
-                },
-
-                sendMessage: function(type, data) {
-                    window.webkit.messageHandlers.kiririn.postMessage({type: type, data: data});
-                },
-
-                play: function(playerID) {
-                    window.webkit.messageHandlers.kiririn.postMessage({type: 'player:play', data: {playerID: playerID || null}});
-                },
-
-                pause: function(playerID) {
-                    window.webkit.messageHandlers.kiririn.postMessage({type: 'player:pause', data: {playerID: playerID || null}});
-                },
-
-                togglePlayPause: function(playerID) {
-                    window.webkit.messageHandlers.kiririn.postMessage({type: 'player:togglePlayPause', data: {playerID: playerID || null}});
-                },
-
-                seek: function(position, playerID) {
-                    window.webkit.messageHandlers.kiririn.postMessage({type: 'player:seek', data: {position: position, playerID: playerID || null}});
-                },
-
-                seekToTime: function(time, playerID) {
-                    window.webkit.messageHandlers.kiririn.postMessage({type: 'player:seekToTime', data: {time: time, playerID: playerID || null}});
-                },
-
-                getCaptureBlob: function(captureID, variant) {
-                    return this._performCaptureBlobRequest(captureID, variant);
-                },
-
-                _resolveCaptureBlob: function(requestID, payload) {
-                    const pending = this._captureBlobResolvers[requestID];
-                    if (!pending) { return; }
-                    delete this._captureBlobResolvers[requestID];
-
-                    if (!payload || typeof payload.bodyBase64 !== 'string') {
-                        pending.resolve(null);
-                        return;
-                    }
-
-                    try {
-                        const binary = atob(payload.bodyBase64);
-                        const buffer = new Uint8Array(binary.length);
-                        for (let index = 0; index < binary.length; index += 1) {
-                            buffer[index] = binary.charCodeAt(index);
-                        }
-                        pending.resolve(new Blob([buffer], {
-                            type: payload.mimeType || 'application/octet-stream'
-                        }));
-                    } catch (error) {
-                        pending.reject(error);
-                    }
-                },
-
-                _rejectCaptureBlob: function(requestID, message) {
-                    const pending = this._captureBlobResolvers[requestID];
-                    if (!pending) { return; }
-                    delete this._captureBlobResolvers[requestID];
-                    pending.reject(new TypeError(message || 'Capture blob request failed'));
-                }
-            };
-
-            (function() {
-                let nextCaptureBlobRequestID = 0;
-                window.kiririn._performCaptureBlobRequest = function(captureID, variant) {
-                    if (typeof captureID !== 'string' || captureID.length === 0 || (variant !== 'original' && variant !== 'composite')) {
-                        return Promise.reject(new TypeError('Invalid capture request'));
-                    }
-
-                    if (!window.webkit || !window.webkit.messageHandlers || !window.webkit.messageHandlers.kiririn) {
-                        return Promise.reject(new TypeError('Kiririn bridge is unavailable'));
-                    }
-
-                    return new Promise(function(resolve, reject) {
-                        const requestID = 'capture-blob-' + (++nextCaptureBlobRequestID);
-                        window.kiririn._captureBlobResolvers[requestID] = {
-                            resolve: resolve,
-                            reject: reject
-                        };
-                        window.webkit.messageHandlers.kiririn.postMessage({
-                            type: '_captureBlobRequest',
-                            data: {
-                                requestID: requestID,
-                                captureID: captureID,
-                                variant: variant
-                            }
-                        });
-                    });
-                };
-            })();
-
-            window.kiririn._applySafeAreaInsetsToCSS();
-
-            // Logging interception
-            (function() {
-                function presentUnhandledPluginError(message) {
-                    window.alert(message);
-                }
-
-                window.onerror = function(message) {
-                    presentUnhandledPluginError(String(message));
-                };
-
-                window.onunhandledrejection = function(event) {
-                    presentUnhandledPluginError(String(event.reason));
-                };
-            })();
-            """
-    }
-
-    class Coordinator: NSObject, WKScriptMessageHandler, WKUIDelegate, WKNavigationDelegate {
-        var parent: PluginWebView?
-        weak var webView: WKWebView?
-        var lastLoadedPageURL: String?
-        var lastReloadToken: Int = 0
-        var lastInjectedPlayablesJson: String?
-        var lastInjectedStatusesJson: String?
-        var lastInjectedFocusedPlayerID: String?
-        var lastInjectedPlayerIDs: Set<String>?
-        var lastInjectedDeeplinkToken: Int = 0
-        var isPageReady = false
-        var wantsCaptureEvents = false
-        var pendingDeeplinkEvents: [URL] = []
-        var announcedCaptureEvents: [String: PluginCaptureEvent] = [:]
-        var captureEventCancellable: AnyCancellable?
-        let onCrash: @MainActor () -> Void
-        private let logger = Logger(label: "PluginBridge")
-
-        init(parent: PluginWebView, onCrash: @escaping @MainActor () -> Void) {
-            self.parent = parent
-            self.onCrash = onCrash
-        }
-
-        nonisolated func userContentController(
-            _ userContentController: WKUserContentController,
-            didReceive message: WKScriptMessage
-        ) {
-            Task { @MainActor in
-                guard let body = message.body as? [String: Any],
-                    let type = body["type"] as? String
-                else { return }
-
-                if type == "_captureTakenSubscribe" {
-                    wantsCaptureEvents = true
-                    subscribeToCaptureEventsIfNeeded()
-                } else if type == "_captureBlobRequest" {
-                    guard let data = body["data"] as? [String: Any] else { return }
-                    await handleCaptureBlobRequest(data)
-                } else if type == "player:play" || type == "player:pause"
-                    || type == "player:togglePlayPause" || type == "player:seek"
-                    || type == "player:seekToTime"
-                {
-                    let data = body["data"] as? [String: Any]
-                    let requestedPlayerID = data?["playerID"] as? String
-                    let propPlayerID = self.parent?.playerID
-                    let focusedPlayerID = self.parent?.appModel.focusedPlayerID
-                    let firstPlayerID = self.parent?.appModel.activePlayerStates.first?.id
-                    let resolvedID =
-                        requestedPlayerID ?? propPlayerID ?? focusedPlayerID ?? firstPlayerID
-                    guard let resolvedID,
-                        let target = self.parent?.appModel.activePlayerStates.first(where: {
-                            $0.id == resolvedID
-                        })
-                    else { return }
-                    switch type {
-                    case "player:play":
-                        if !target.isPlaying { target.togglePlayPause() }
-                    case "player:pause":
-                        if target.isPlaying { target.togglePlayPause() }
-                    case "player:togglePlayPause":
-                        target.togglePlayPause()
-                    case "player:seek":
-                        if let rawPosition = data?["position"] as? Double {
-                            target.seek(to: Float(max(0.0, min(1.0, rawPosition))))
-                        }
-                    case "player:seekToTime":
-                        if let time = data?["time"] as? Double {
-                            target.seek(toTime: time)
-                        }
-                    default:
-                        break
-                    }
-                }
-            }
-        }
-
-        @MainActor
-        private func subscribeToCaptureEventsIfNeeded() {
-            guard captureEventCancellable == nil else { return }
-
-            captureEventCancellable = CaptureService.shared.didCaptureForPlugin.sink {
-                [weak self] event in
-                guard let self else { return }
-                guard self.wantsCaptureEvents,
-                    self.isPageReady,
-                    self.canReceiveCaptureEvent(for: event.playerID)
-                else {
-                    return
-                }
-
-                self.dispatchPluginCaptureEvent(event)
-            }
-        }
-
-        @MainActor
-        private func canReceiveCaptureEvent(for playerID: String) -> Bool {
-            guard let contextPlayerID = parent?.playerID else {
-                // Standalone plugin screens do not carry a bound playerID.
-                // Treat them as global capture observers once they opt in.
-                return true
-            }
-            return contextPlayerID == playerID
-        }
-
-        @MainActor
-        private func dispatchPluginCaptureEvent(_ event: PluginCaptureEvent) {
-            announcedCaptureEvents[event.captureID] = event
-            let payload: [String: Any] = [
-                "playerID": event.playerID,
-                "captureID": event.captureID,
-                "capturedAt": event.capturedAt.timeIntervalSince1970,
-                "variants": event.variants.map { Self.captureVariantObject(from: $0) },
-            ]
-
-            guard let payloadLiteral = Self.javaScriptObjectLiteral(payload) else { return }
-            evaluateJavaScript(
-                "if (window.kiririn && window.kiririn._emitCaptureTaken) { window.kiririn._emitCaptureTaken(\(payloadLiteral)); }"
-            )
-        }
-
-        @MainActor
-        private func handleCaptureBlobRequest(_ data: [String: Any]) async {
-            guard let requestID = data["requestID"] as? String else { return }
-            guard let captureID = data["captureID"] as? String,
-                let variantRawValue = data["variant"] as? String,
-                let variant = PluginCaptureVariant(rawValue: variantRawValue)
-            else {
-                rejectCaptureBlob(requestID: requestID, message: "キャプチャ要求が不正です")
-                return
-            }
-
-            guard let announcedEvent = announcedCaptureEvents[captureID] else {
-                rejectCaptureBlob(requestID: requestID, message: "このコンテキストでは対象のキャプチャを取得できません")
-                return
-            }
-
-            guard canReceiveCaptureEvent(for: announcedEvent.playerID) else {
-                rejectCaptureBlob(requestID: requestID, message: "このコンテキストでは対象のキャプチャを取得できません")
-                return
-            }
-
-            guard announcedEvent.variants.contains(where: { $0.type == variant }) else {
-                rejectCaptureBlob(requestID: requestID, message: "このコンテキストでは対象のキャプチャを取得できません")
-                return
-            }
-
-            guard
-                let blob = await CaptureService.shared.captureBlob(
-                    captureID: captureID,
-                    variant: variant
-                )
-            else {
-                resolveCaptureBlob(requestID: requestID, payload: nil)
-                return
-            }
-
-            resolveCaptureBlob(
-                requestID: requestID,
-                payload: [
-                    "bodyBase64": blob.data.base64EncodedString(),
-                    "mimeType": blob.mimeType,
-                ]
-            )
-        }
-
-        func queueDeeplinkEvent(_ url: URL) {
-            pendingDeeplinkEvents.append(url)
-            flushDeeplinkEventsIfPossible()
-        }
-
-        private func flushDeeplinkEventsIfPossible() {
-            guard isPageReady else { return }
-            while !pendingDeeplinkEvents.isEmpty {
-                let url = pendingDeeplinkEvents.removeFirst()
-                guard let payloadLiteral = Self.javaScriptObjectLiteral(["url": url.absoluteString])
-                else { continue }
-                evaluateJavaScript(
-                    "if (window.kiririn && window.kiririn._emitDeeplinkOpened) { window.kiririn._emitDeeplinkOpened(\(payloadLiteral)); }"
-                )
-            }
-        }
-
-        private func resolveCaptureBlob(requestID: String, payload: [String: Any]?) {
-            guard let requestIDLiteral = Self.javaScriptStringLiteral(requestID) else { return }
-            let payloadLiteral = payload.flatMap(Self.javaScriptObjectLiteral) ?? "null"
-
-            evaluateJavaScript(
-                "if (window.kiririn && window.kiririn._resolveCaptureBlob) { window.kiririn._resolveCaptureBlob(\(requestIDLiteral), \(payloadLiteral)); }"
-            )
-        }
-
-        private func rejectCaptureBlob(requestID: String, message: String) {
-            guard let requestIDLiteral = Self.javaScriptStringLiteral(requestID),
-                let messageLiteral = Self.javaScriptStringLiteral(message)
-            else { return }
-
-            evaluateJavaScript(
-                "if (window.kiririn && window.kiririn._rejectCaptureBlob) { window.kiririn._rejectCaptureBlob(\(requestIDLiteral), \(messageLiteral)); }"
-            )
-        }
-
-        private func evaluateJavaScript(_ script: String) {
-            let webView = self.webView
-            Task { @MainActor in
-                try? await webView?.evaluateJavaScript(script)
-            }
-        }
-
-        nonisolated private static func javaScriptStringLiteral(_ value: String) -> String? {
-            guard let data = try? JSONSerialization.data(withJSONObject: [value], options: []),
-                let json = String(data: data, encoding: .utf8)
-            else {
-                return nil
-            }
-
-            return String(json.dropFirst().dropLast())
-        }
-
-        nonisolated private static func javaScriptObjectLiteral(_ value: [String: Any]) -> String? {
-            guard JSONSerialization.isValidJSONObject(value),
-                let data = try? JSONSerialization.data(
-                    withJSONObject: value, options: [.sortedKeys]),
-                let json = String(data: data, encoding: .utf8)
-            else {
-                return nil
-            }
-
-            return json
-        }
-
-        nonisolated private static func captureVariantObject(
-            from variant: PluginCaptureVariantMetadata
-        ) -> [String: Any] {
-            [
-                "type": variant.type.rawValue,
-                "overlayPluginManifestIDs": variant.overlayPluginManifestIDs,
-            ]
-        }
-
-        // MARK: - WKNavigationDelegate
-
-        func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
-            Task { @MainActor in
-                onCrash()
-            }
-        }
-
-        // MARK: - WKUIDelegate
-
-        @MainActor
-        func webView(
-            _ webView: WKWebView, runJavaScriptAlertPanelWithMessage message: String,
-            initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping () -> Void
-        ) {
-            #if os(macOS)
-                let alert = NSAlert()
-                alert.messageText = message
-                alert.addButton(withTitle: "OK")
-                if let window = webView.window ?? NSApp.mainWindow {
-                    alert.beginSheetModal(for: window) { _ in completionHandler() }
-                } else {
-                    _ = alert.runModal()
-                    completionHandler()
-                }
-            #else
-                let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-                alert.addAction(
-                    UIAlertAction(title: "OK", style: .default) { _ in completionHandler() })
-                findParentViewController(of: webView)?.present(alert, animated: true)
-            #endif
-        }
-
-        @MainActor
-        func webView(
-            _ webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String,
-            initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping (Bool) -> Void
-        ) {
-            #if os(macOS)
-                let alert = NSAlert()
-                alert.messageText = message
-                alert.addButton(withTitle: "OK")
-                alert.addButton(withTitle: "キャンセル")
-                if let window = webView.window ?? NSApp.mainWindow {
-                    alert.beginSheetModal(for: window) { response in
-                        completionHandler(response == .alertFirstButtonReturn)
-                    }
-                } else {
-                    completionHandler(alert.runModal() == .alertFirstButtonReturn)
-                }
-            #else
-                let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-                alert.addAction(
-                    UIAlertAction(title: "キャンセル", style: .cancel) { _ in completionHandler(false) })
-                alert.addAction(
-                    UIAlertAction(title: "OK", style: .default) { _ in completionHandler(true) })
-                findParentViewController(of: webView)?.present(alert, animated: true)
-            #endif
-        }
-
-        @MainActor
-        func webView(
-            _ webView: WKWebView, runJavaScriptTextInputPanelWithPrompt prompt: String,
-            defaultText: String?, initiatedByFrame frame: WKFrameInfo,
-            completionHandler: @escaping (String?) -> Void
-        ) {
-            #if os(macOS)
-                let alert = NSAlert()
-                alert.messageText = prompt
-                let input = NSTextField(string: defaultText ?? "")
-                input.frame = NSRect(x: 0, y: 0, width: 280, height: 24)
-                alert.accessoryView = input
-                alert.addButton(withTitle: "OK")
-                alert.addButton(withTitle: "キャンセル")
-                if let window = webView.window ?? NSApp.mainWindow {
-                    alert.beginSheetModal(for: window) { response in
-                        completionHandler(
-                            response == .alertFirstButtonReturn ? input.stringValue : nil)
-                    }
-                } else {
-                    let response = alert.runModal()
-                    completionHandler(response == .alertFirstButtonReturn ? input.stringValue : nil)
-                }
-            #else
-                let alert = UIAlertController(title: nil, message: prompt, preferredStyle: .alert)
-                alert.addTextField { textField in
-                    textField.text = defaultText
-                }
-                alert.addAction(
-                    UIAlertAction(title: "キャンセル", style: .cancel) { _ in completionHandler(nil) })
-                alert.addAction(
-                    UIAlertAction(title: "OK", style: .default) { _ in
-                        completionHandler(alert.textFields?.first?.text)
-                    })
-                findParentViewController(of: webView)?.present(alert, animated: true)
-            #endif
-        }
-
-        #if !os(macOS)
-            private func findParentViewController(of view: UIView) -> UIViewController? {
-                var parentResponder: UIResponder? = view
-                while parentResponder != nil {
-                    parentResponder = parentResponder?.next
-                    if let viewController = parentResponder as? UIViewController {
-                        return viewController
-                    }
-                }
-                return nil
-            }
-        #endif
-
-        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            isPageReady = true
-            flushDeeplinkEventsIfPossible()
-            // キャッシュをリセットした直後の reload 完了後に、改めて全状態を注入する
-            parent?.injectAllStates(into: webView, coordinator: self, force: true)
-        }
-    }
-}
-
-private class LeakAversionScriptMessageHandler: NSObject, WKScriptMessageHandler {
-    weak var handler: WKScriptMessageHandler?
-
-    init(handler: WKScriptMessageHandler) {
-        self.handler = handler
-    }
-
-    func userContentController(
-        _ userContentController: WKUserContentController, didReceive message: WKScriptMessage
-    ) {
-        handler?.userContentController(userContentController, didReceive: message)
     }
 }

--- a/kiririn/Features/Plugin/PluginOverlayView.swift
+++ b/kiririn/Features/Plugin/PluginOverlayView.swift
@@ -207,6 +207,7 @@ struct PluginOverlayView: View {
     @MainActor
     private func replaceLoadedRuntime(with newRuntime: LoadedRuntime) {
         if loadedRuntime?.runtime === newRuntime.runtime {
+            // 同じ View が追加取得した分だけを解放し、既存の利用権は維持する。
             ExtensionPluginRuntimeRegistry.shared.releaseRuntime(newRuntime.runtime)
             return
         }

--- a/kiririn/Features/Plugin/PluginOverlayView.swift
+++ b/kiririn/Features/Plugin/PluginOverlayView.swift
@@ -222,7 +222,6 @@ struct PluginOverlayView: View {
     private func handleExternalReload() {
         resetCrashState()
         releaseExtensionRuntime()
-        ExtensionPluginRuntimeRegistry.shared.invalidate(pluginID: pluginDefinition.id)
     }
 
     @MainActor

--- a/kiririn/Features/Plugin/PluginOverlayView.swift
+++ b/kiririn/Features/Plugin/PluginOverlayView.swift
@@ -1,6 +1,7 @@
 import Combine
 import KppxKit
 import SwiftUI
+import WebKit
 
 extension PluginDisplayArea {
     var localizedName: String {
@@ -37,6 +38,11 @@ struct PluginOverlayView: View {
         let resourceBasePath: String
     }
 
+    private struct LoadedRuntime {
+        let runtime: ExtensionPluginRuntime
+        let webViewConfiguration: WKWebViewConfiguration
+    }
+
     let pluginDefinition: PluginDefinition
     let appModel: AppModel
     let reloadToken: Int
@@ -66,7 +72,7 @@ struct PluginOverlayView: View {
     @State private var pendingDeeplinkURL: URL?
     @State private var deeplinkToken = 0
     @State private var manualReloadToken = 0
-    @State private var extensionRuntime: ExtensionPluginRuntime?
+    @State private var loadedRuntime: LoadedRuntime?
 
     private var reloadKey: PluginReloadKey {
         PluginReloadKey(external: reloadToken, manual: manualReloadToken)
@@ -88,10 +94,11 @@ struct PluginOverlayView: View {
                 "\($0.id):\($0.currentPlayable?.id ?? "none"):\($0.playbackStatus.isPlaying):\($0.currentPlayable?.isSeekable ?? false)"
             }.joined(separator: "|") + (appModel.focusedPlayerID ?? "")
         ZStack {
-            if let extensionRuntime {
+            if let loadedRuntime {
                 PluginWebView(
                     pluginDefinition: pluginDefinition,
-                    extensionRuntime: extensionRuntime,
+                    extensionRuntime: loadedRuntime.runtime,
+                    webViewConfiguration: loadedRuntime.webViewConfiguration,
                     appModel: appModel,
                     reloadKey: reloadKey,
                     displayArea: displayArea,
@@ -161,11 +168,23 @@ struct PluginOverlayView: View {
                 for: pluginDefinition,
                 store: appModel.pluginStore
             )
+            let webViewConfiguration: WKWebViewConfiguration
+            do {
+                webViewConfiguration = try runtime.makeWebViewConfiguration()
+            } catch {
+                ExtensionPluginRuntimeRegistry.shared.releaseRuntime(runtime)
+                throw error
+            }
             guard !Task.isCancelled, runtimeLoadKey == expectedLoadKey else {
                 ExtensionPluginRuntimeRegistry.shared.releaseRuntime(runtime)
                 return
             }
-            replaceExtensionRuntime(with: runtime)
+            replaceLoadedRuntime(
+                with: LoadedRuntime(
+                    runtime: runtime,
+                    webViewConfiguration: webViewConfiguration
+                )
+            )
         } catch {
             guard !Task.isCancelled, runtimeLoadKey == expectedLoadKey else {
                 return
@@ -180,22 +199,22 @@ struct PluginOverlayView: View {
 
     @MainActor
     private func releaseExtensionRuntime() {
-        guard let runtime = extensionRuntime else { return }
-        extensionRuntime = nil
-        ExtensionPluginRuntimeRegistry.shared.releaseRuntime(runtime)
+        guard let loadedRuntime else { return }
+        self.loadedRuntime = nil
+        ExtensionPluginRuntimeRegistry.shared.releaseRuntime(loadedRuntime.runtime)
     }
 
     @MainActor
-    private func replaceExtensionRuntime(with runtime: ExtensionPluginRuntime) {
-        if extensionRuntime === runtime {
-            ExtensionPluginRuntimeRegistry.shared.releaseRuntime(runtime)
+    private func replaceLoadedRuntime(with newRuntime: LoadedRuntime) {
+        if loadedRuntime?.runtime === newRuntime.runtime {
+            ExtensionPluginRuntimeRegistry.shared.releaseRuntime(newRuntime.runtime)
             return
         }
 
-        let previousRuntime = extensionRuntime
-        extensionRuntime = runtime
+        let previousRuntime = loadedRuntime
+        loadedRuntime = newRuntime
         if let previousRuntime {
-            ExtensionPluginRuntimeRegistry.shared.releaseRuntime(previousRuntime)
+            ExtensionPluginRuntimeRegistry.shared.releaseRuntime(previousRuntime.runtime)
         }
     }
 

--- a/kiririn/Features/Plugin/PluginReloadKey.swift
+++ b/kiririn/Features/Plugin/PluginReloadKey.swift
@@ -1,0 +1,4 @@
+struct PluginReloadKey: Hashable {
+    let external: Int
+    let manual: Int
+}

--- a/kiririn/Features/Plugin/PluginWebView.swift
+++ b/kiririn/Features/Plugin/PluginWebView.swift
@@ -20,6 +20,7 @@ import WebKit
 struct PluginWebView: PluginWebViewRepresentable {
     let pluginDefinition: PluginDefinition
     let extensionRuntime: ExtensionPluginRuntime
+    let webViewConfiguration: WKWebViewConfiguration
     let appModel: AppModel
     let reloadKey: PluginReloadKey
     let displayArea: PluginDisplayArea
@@ -34,7 +35,7 @@ struct PluginWebView: PluginWebViewRepresentable {
     }
 
     private func makePlatformWebView(context: Context) -> WKWebView {
-        let config = extensionRuntime.webViewConfiguration
+        let config = webViewConfiguration
         config.applicationNameForUserAgent = makeApplicationNameForUserAgent()
         let contentController = WKUserContentController()
 

--- a/kiririn/Features/Plugin/PluginWebView.swift
+++ b/kiririn/Features/Plugin/PluginWebView.swift
@@ -138,8 +138,6 @@ struct PluginWebView: PluginWebViewRepresentable {
 
     private static func dismantlePlatformWebView(_ uiView: WKWebView, coordinator: Coordinator) {
         uiView.stopLoading()
-        uiView.configuration.userContentController.removeAllUserScripts()
-        uiView.configuration.userContentController.removeScriptMessageHandler(forName: "kiririn")
         uiView.uiDelegate = nil
         uiView.navigationDelegate = nil
 

--- a/kiririn/Features/Plugin/PluginWebView.swift
+++ b/kiririn/Features/Plugin/PluginWebView.swift
@@ -1,0 +1,937 @@
+import Combine
+import KppxKit
+import Logging
+import SwiftUI
+import WebKit
+
+#if os(macOS)
+    import AppKit
+#else
+    import UIKit
+#endif
+
+#if os(macOS)
+    typealias PluginWebViewRepresentable = NSViewRepresentable
+#else
+    typealias PluginWebViewRepresentable = UIViewRepresentable
+#endif
+
+@MainActor
+struct PluginWebView: PluginWebViewRepresentable {
+    let pluginDefinition: PluginDefinition
+    let extensionRuntime: ExtensionPluginRuntime
+    let appModel: AppModel
+    let reloadKey: PluginReloadKey
+    let displayArea: PluginDisplayArea
+    let playerID: String?
+    let safeAreaInsets: PluginSafeAreaInsets
+    let deeplinkURL: URL?
+    let deeplinkToken: Int
+    let stateHash: String
+    let onCrash: @MainActor () -> Void
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self, onCrash: onCrash)
+    }
+
+    private func makePlatformWebView(context: Context) -> WKWebView {
+        let config = extensionRuntime.webViewConfiguration
+        config.applicationNameForUserAgent = makeApplicationNameForUserAgent()
+        let contentController = WKUserContentController()
+
+        let bridgeScript = WKUserScript(
+            source: makeBridgeJS(),
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        )
+        contentController.addUserScript(bridgeScript)
+
+        // WKUserContentController holds a strong reference to the handler.
+        // Use a weak proxy to avoid a retain cycle between the Coordinator and the WebView.
+        let weakHandler = LeakAversionScriptMessageHandler(handler: context.coordinator)
+        contentController.add(weakHandler, name: "kiririn")
+
+        config.userContentController = contentController
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.isInspectable = true
+        #if os(macOS)
+            webView.setValue(false, forKey: "drawsBackground")
+            webView.allowsMagnification = false
+        #else
+            webView.isOpaque = false
+            webView.backgroundColor = .clear
+            webView.scrollView.backgroundColor = .clear
+            webView.scrollView.isScrollEnabled = displayArea != .overlay
+            webView.scrollView.contentInsetAdjustmentBehavior = .never
+        #endif
+        webView.uiDelegate = context.coordinator
+        webView.navigationDelegate = context.coordinator
+        context.coordinator.webView = webView
+        context.coordinator.prepareForPageLoad(
+            pageURL: currentPageURLString(),
+            reloadKey: reloadKey
+        )
+
+        if displayArea == .overlay, let pid = playerID {
+            PluginOverlaySnapshotRegistry.shared.register(
+                webView,
+                playerID: pid,
+                pluginID: pluginDefinition.id.uuidString
+            )
+        }
+
+        loadPluginPage(into: webView)
+        return webView
+    }
+
+    #if os(macOS)
+        func makeNSView(context: Context) -> WKWebView {
+            makePlatformWebView(context: context)
+        }
+    #else
+        func makeUIView(context: Context) -> WKWebView {
+            makePlatformWebView(context: context)
+        }
+    #endif
+
+    private func updatePlatformWebView(_ webView: WKWebView, context: Context) {
+        let pageChanged = context.coordinator.lastLoadedPageURL != currentPageURLString()
+        context.coordinator.parent = self
+        context.coordinator.onCrash = onCrash
+
+        let tokenChanged = context.coordinator.lastReloadKey != reloadKey
+
+        if pageChanged || tokenChanged {
+            context.coordinator.prepareForPageLoad(
+                pageURL: currentPageURLString(),
+                reloadKey: reloadKey
+            )
+            loadPluginPage(into: webView)
+        }
+        if context.coordinator.lastInjectedDeeplinkToken != deeplinkToken {
+            context.coordinator.lastInjectedDeeplinkToken = deeplinkToken
+            if let deeplinkURL {
+                context.coordinator.queueDeeplinkEvent(deeplinkURL)
+            }
+        }
+        injectAllStates(into: webView, coordinator: context.coordinator)
+    }
+
+    private func injectAllStates(
+        into webView: WKWebView, coordinator: Coordinator, force: Bool = false
+    ) {
+        injectPlayables(into: webView, coordinator: coordinator, force: force)
+        injectStatuses(into: webView, coordinator: coordinator, force: force)
+        injectFocus(into: webView, coordinator: coordinator, force: force)
+    }
+
+    #if os(macOS)
+        func updateNSView(_ webView: WKWebView, context: Context) {
+            updatePlatformWebView(webView, context: context)
+        }
+    #else
+        func updateUIView(_ webView: WKWebView, context: Context) {
+            updatePlatformWebView(webView, context: context)
+        }
+    #endif
+
+    private static func dismantlePlatformWebView(_ uiView: WKWebView, coordinator: Coordinator) {
+        uiView.stopLoading()
+        uiView.configuration.userContentController.removeAllUserScripts()
+        uiView.configuration.userContentController.removeScriptMessageHandler(forName: "kiririn")
+        uiView.uiDelegate = nil
+        uiView.navigationDelegate = nil
+
+        if let parent = coordinator.parent,
+            parent.displayArea == .overlay,
+            let playerID = parent.playerID
+        {
+            let pluginID = parent.pluginDefinition.id.uuidString
+            PluginOverlaySnapshotRegistry.shared.unregister(
+                uiView, playerID: playerID, pluginID: pluginID)
+        }
+
+        coordinator.tearDown()
+    }
+
+    #if os(macOS)
+        static func dismantleNSView(_ uiView: WKWebView, coordinator: Coordinator) {
+            dismantlePlatformWebView(uiView, coordinator: coordinator)
+        }
+    #else
+        static func dismantleUIView(_ uiView: WKWebView, coordinator: Coordinator) {
+            dismantlePlatformWebView(uiView, coordinator: coordinator)
+        }
+    #endif
+
+    private func makeRuntimeInfoContext() -> [String: Any] {
+        let bundle = Bundle.main
+        let appVersion =
+            bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        let buildVersion =
+            (bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String) ?? "1"
+        let runtimePlayerID: Any = {
+            if displayArea == .overlay {
+                return playerID ?? NSNull()
+            }
+            return NSNull()
+        }()
+
+        return [
+            "platform": {
+                #if os(macOS)
+                    "macOS"
+                #else
+                    "iOS"
+                #endif
+            }(),
+            "osVersion": ProcessInfo.processInfo.operatingSystemVersionString,
+            "appVersion": appVersion ?? NSNull(),
+            "buildVersion": buildVersion,
+            "bundleIdentifier": bundle.bundleIdentifier ?? NSNull(),
+            "bridgeVersion": 3,
+            "displayAreaType": displayArea.rawValue,
+            "playerID": runtimePlayerID,
+        ]
+    }
+
+    private func makeApplicationNameForUserAgent() -> String {
+        let appVersion =
+            (Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String)
+            ?? "1"
+        return "kiririn/\(appVersion)"
+    }
+
+    private func injectPlayables(
+        into webView: WKWebView, coordinator: Coordinator, force: Bool = false
+    ) {
+        let currentIDs = Set(appModel.activePlayerStates.map { $0.id })
+        if let lastIDs = coordinator.lastInjectedPlayerIDs {
+            let removedIDs = lastIDs.subtracting(currentIDs)
+            for removedID in removedIDs {
+                let js =
+                    "if(window.kiririn && window.kiririn._onPlayerClosed) window.kiririn._onPlayerClosed(\"\(removedID)\");"
+                webView.evaluateJavaScript(js)
+            }
+        }
+        coordinator.lastInjectedPlayerIDs = currentIDs
+
+        let playables = appModel.activePlayerStates.compactMap { state -> [String: Any]? in
+            guard var schema = state.currentPlayable?.toPluginSchema() else { return nil }
+            schema["playerID"] = state.id
+            return schema
+        }
+        guard
+            let data = try? JSONSerialization.data(
+                withJSONObject: playables, options: [.sortedKeys]),
+            let json = String(data: data, encoding: .utf8)
+        else { return }
+
+        if !force, let last = coordinator.lastInjectedPlayablesJson, last == json {
+            return
+        }
+        coordinator.lastInjectedPlayablesJson = json
+
+        let js =
+            "if(window.kiririn && window.kiririn._onPlayablesChange) window.kiririn._onPlayablesChange(\(json));"
+        webView.evaluateJavaScript(js)
+    }
+
+    private func loadPluginPage(into webView: WKWebView) {
+        if let extensionPageURL = extensionRuntime.pageURL(for: displayArea) {
+            webView.load(URLRequest(url: extensionPageURL))
+        }
+    }
+
+    private func currentPageURLString() -> String? {
+        extensionRuntime.pageURL(for: displayArea)?.absoluteString
+    }
+
+    private func injectStatuses(
+        into webView: WKWebView, coordinator: Coordinator, force: Bool = false
+    ) {
+        let statuses = appModel.activePlayerStates.compactMap { state -> [String: Any]? in
+            guard let s = state.playbackStatus as PlayerPlaybackStatus?,
+                state.currentPlayable != nil
+            else { return nil }
+            return [
+                "playerID": state.id,
+                "playableID": s.playableID ?? "",
+                "isPlaying": s.isPlaying,
+                "time": s.time,
+                "position": s.position,
+                "rate": s.rate,
+            ]
+        }
+        guard
+            let data = try? JSONSerialization.data(
+                withJSONObject: statuses, options: [.sortedKeys]),
+            let json = String(data: data, encoding: .utf8)
+        else { return }
+
+        if !force, let last = coordinator.lastInjectedStatusesJson, last == json {
+            return
+        }
+        coordinator.lastInjectedStatusesJson = json
+
+        let js =
+            "if(window.kiririn && window.kiririn._onPlayerStatusesChange) window.kiririn._onPlayerStatusesChange(\(json));"
+        webView.evaluateJavaScript(js)
+    }
+
+    private func injectFocus(into webView: WKWebView, coordinator: Coordinator, force: Bool = false)
+    {
+        let activeIDs = Set(appModel.activePlayerStates.map(\.id))
+        let normalizedFocusedID = appModel.focusedPlayerID.flatMap {
+            activeIDs.contains($0) ? $0 : nil
+        }
+        let focusedID = normalizedFocusedID ?? ""
+
+        if !force, let last = coordinator.lastInjectedFocusedPlayerID, last == focusedID {
+            return
+        }
+        coordinator.lastInjectedFocusedPlayerID = focusedID
+
+        let js =
+            "if(window.kiririn && window.kiririn._onFocusedPlayerIDChange) window.kiririn._onFocusedPlayerIDChange(\(focusedID.isEmpty ? "null" : "\"\(focusedID)\""));"
+        webView.evaluateJavaScript(js)
+    }
+
+    private func makeBridgeJS() -> String {
+        let playables = appModel.activePlayerStates.compactMap { state -> [String: Any]? in
+            guard var schema = state.currentPlayable?.toPluginSchema() else { return nil }
+            schema["playerID"] = state.id
+            return schema
+        }
+        let statuses = appModel.activePlayerStates.compactMap { state -> [String: Any]? in
+            guard let s = state.playbackStatus as PlayerPlaybackStatus?,
+                state.currentPlayable != nil
+            else { return nil }
+            return [
+                "playerID": state.id,
+                "playableID": s.playableID ?? "",
+                "isPlaying": s.isPlaying,
+                "time": s.time,
+                "position": s.position,
+                "rate": s.rate,
+            ]
+        }
+        let activeIDs = Set(appModel.activePlayerStates.map(\.id))
+        let focusedID = appModel.focusedPlayerID.flatMap { activeIDs.contains($0) ? $0 : nil } ?? ""
+
+        let playablesJson =
+            (try? JSONSerialization.data(withJSONObject: playables, options: [.sortedKeys])).flatMap
+        { String(data: $0, encoding: .utf8) } ?? "[]"
+        let statusJson =
+            (try? JSONSerialization.data(withJSONObject: statuses, options: [.sortedKeys])).flatMap
+        { String(data: $0, encoding: .utf8) } ?? "[]"
+
+        guard
+            let runtimeInfoData = try? JSONSerialization.data(
+                withJSONObject: makeRuntimeInfoContext(), options: [.sortedKeys]),
+            let runtimeInfoString = String(data: runtimeInfoData, encoding: .utf8)
+        else {
+            return "window.kiririn = {};"
+        }
+
+        let safeAreaInsetsString =
+            (try? JSONSerialization.data(
+                withJSONObject: safeAreaInsets.asDictionary,
+                options: [.sortedKeys]
+            )).flatMap { String(data: $0, encoding: .utf8) }
+            ?? #"{"bottom":0,"left":0,"right":0,"top":0}"#
+
+        return """
+            window.kiririn = {
+                _playables: \(playablesJson),
+                _playablesListeners: [],
+                _statuses: \(statusJson),
+                _statusesListeners: [],
+                _focusedPlayerID: \(focusedID.isEmpty ? "null" : "\"\(focusedID)\""),
+                _focusedPlayerIDListeners: [],
+                _playerClosedListeners: [],
+                _runtimeInfo: \(runtimeInfoString),
+                _safeAreaInsets: \(safeAreaInsetsString),
+                _deeplinkOpenedListeners: [],
+                _captureTakenListeners: [],
+                _captureBlobResolvers: Object.create(null),
+                _captureEventsSubscribed: false,
+
+                getPlayables: function() { return this._playables; },
+                onPlayablesChange: function(callback) { this._playablesListeners.push(callback); },
+                _onPlayablesChange: function(playables) {
+                    this._playables = playables;
+                    this._playablesListeners.forEach(function(cb) { try { cb(playables); } catch(e) {} });
+                },
+
+                getPlayerStatuses: function() { return this._statuses; },
+                onPlayerStatusesChange: function(callback) { this._statusesListeners.push(callback); },
+                _onPlayerStatusesChange: function(statuses) {
+                    this._statuses = statuses;
+                    this._statusesListeners.forEach(function(cb) { try { cb(statuses); } catch(e) {} });
+                },
+
+                getFocusedPlayerID: function() { return this._focusedPlayerID; },
+                onFocusedPlayerIDChange: function(callback) { this._focusedPlayerIDListeners.push(callback); },
+                _onFocusedPlayerIDChange: function(id) {
+                    this._focusedPlayerID = id;
+                    this._focusedPlayerIDListeners.forEach(function(cb) { try { cb(id); } catch(e) {} });
+                },
+
+                onPlayerClosed: function(callback) { this._playerClosedListeners.push(callback); },
+                _onPlayerClosed: function(playerID) {
+                    if (this._focusedPlayerID === playerID) {
+                        this._focusedPlayerID = null;
+                        this._focusedPlayerIDListeners.forEach(function(cb) { try { cb(null); } catch(e) {} });
+                    }
+                    this._playerClosedListeners.forEach(function(cb) { try { cb(playerID); } catch(e) {} });
+                },
+
+                getPlayable: function(playerID) {
+                    return this.getPlayables().find(p => p.playerID === playerID) || null;
+                },
+
+                getPlayerStatus: function(playerID) {
+                    return this.getPlayerStatuses().find(s => s.playerID === playerID) || null;
+                },
+
+                getRuntimeInfo: function() { return this._runtimeInfo; },
+
+                _applySafeAreaInsetsToCSS: function() {
+                    if (!this._safeAreaInsets) { return; }
+                    const insets = this._safeAreaInsets;
+                    const root = document.documentElement;
+                    if (!root || !root.style) { return; }
+                    root.style.setProperty('--kiririn-safe-area-inset-top', String(insets.top) + 'px');
+                    root.style.setProperty('--kiririn-safe-area-inset-right', String(insets.right) + 'px');
+                    root.style.setProperty('--kiririn-safe-area-inset-bottom', String(insets.bottom) + 'px');
+                    root.style.setProperty('--kiririn-safe-area-inset-left', String(insets.left) + 'px');
+                },
+
+                onDeeplinkOpened: function(callback) { this._deeplinkOpenedListeners.push(callback); },
+                _emitDeeplinkOpened: function(payload) {
+                    this._deeplinkOpenedListeners.forEach(function(cb) { try { cb(payload); } catch(e) {} });
+                },
+
+                onCaptureTaken: function(callback) {
+                    this._captureTakenListeners.push(callback);
+                    if (!this._captureEventsSubscribed && window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.kiririn) {
+                        this._captureEventsSubscribed = true;
+                        window.webkit.messageHandlers.kiririn.postMessage({type: '_captureTakenSubscribe'});
+                    }
+                },
+                _emitCaptureTaken: function(payload) {
+                    const normalizedPayload = payload ? Object.assign({}, payload, {
+                        capturedAt: new Date(payload.capturedAt * 1000),
+                        variants: Array.isArray(payload.variants) ? payload.variants : []
+                    }) : payload;
+                    this._captureTakenListeners.forEach(function(cb) { try { cb(normalizedPayload); } catch(e) {} });
+                },
+
+                sendMessage: function(type, data) {
+                    window.webkit.messageHandlers.kiririn.postMessage({type: type, data: data});
+                },
+
+                play: function(playerID) {
+                    window.webkit.messageHandlers.kiririn.postMessage({type: 'player:play', data: {playerID: playerID || null}});
+                },
+
+                pause: function(playerID) {
+                    window.webkit.messageHandlers.kiririn.postMessage({type: 'player:pause', data: {playerID: playerID || null}});
+                },
+
+                togglePlayPause: function(playerID) {
+                    window.webkit.messageHandlers.kiririn.postMessage({type: 'player:togglePlayPause', data: {playerID: playerID || null}});
+                },
+
+                seek: function(position, playerID) {
+                    window.webkit.messageHandlers.kiririn.postMessage({type: 'player:seek', data: {position: position, playerID: playerID || null}});
+                },
+
+                seekToTime: function(time, playerID) {
+                    window.webkit.messageHandlers.kiririn.postMessage({type: 'player:seekToTime', data: {time: time, playerID: playerID || null}});
+                },
+
+                getCaptureBlob: function(captureID, variant) {
+                    return this._performCaptureBlobRequest(captureID, variant);
+                },
+
+                _resolveCaptureBlob: function(requestID, payload) {
+                    const pending = this._captureBlobResolvers[requestID];
+                    if (!pending) { return; }
+                    delete this._captureBlobResolvers[requestID];
+
+                    if (!payload || typeof payload.bodyBase64 !== 'string') {
+                        pending.resolve(null);
+                        return;
+                    }
+
+                    try {
+                        const binary = atob(payload.bodyBase64);
+                        const buffer = new Uint8Array(binary.length);
+                        for (let index = 0; index < binary.length; index += 1) {
+                            buffer[index] = binary.charCodeAt(index);
+                        }
+                        pending.resolve(new Blob([buffer], {
+                            type: payload.mimeType || 'application/octet-stream'
+                        }));
+                    } catch (error) {
+                        pending.reject(error);
+                    }
+                },
+
+                _rejectCaptureBlob: function(requestID, message) {
+                    const pending = this._captureBlobResolvers[requestID];
+                    if (!pending) { return; }
+                    delete this._captureBlobResolvers[requestID];
+                    pending.reject(new TypeError(message || 'Capture blob request failed'));
+                }
+            };
+
+            (function() {
+                let nextCaptureBlobRequestID = 0;
+                window.kiririn._performCaptureBlobRequest = function(captureID, variant) {
+                    if (typeof captureID !== 'string' || captureID.length === 0 || (variant !== 'original' && variant !== 'composite')) {
+                        return Promise.reject(new TypeError('Invalid capture request'));
+                    }
+
+                    if (!window.webkit || !window.webkit.messageHandlers || !window.webkit.messageHandlers.kiririn) {
+                        return Promise.reject(new TypeError('Kiririn bridge is unavailable'));
+                    }
+
+                    return new Promise(function(resolve, reject) {
+                        const requestID = 'capture-blob-' + (++nextCaptureBlobRequestID);
+                        window.kiririn._captureBlobResolvers[requestID] = {
+                            resolve: resolve,
+                            reject: reject
+                        };
+                        window.webkit.messageHandlers.kiririn.postMessage({
+                            type: '_captureBlobRequest',
+                            data: {
+                                requestID: requestID,
+                                captureID: captureID,
+                                variant: variant
+                            }
+                        });
+                    });
+                };
+            })();
+
+            window.kiririn._applySafeAreaInsetsToCSS();
+
+            // Logging interception
+            (function() {
+                function presentUnhandledPluginError(message) {
+                    window.alert(message);
+                }
+
+                window.onerror = function(message) {
+                    presentUnhandledPluginError(String(message));
+                };
+
+                window.onunhandledrejection = function(event) {
+                    presentUnhandledPluginError(String(event.reason));
+                };
+            })();
+            """
+    }
+
+    class Coordinator: NSObject, WKScriptMessageHandler, WKUIDelegate, WKNavigationDelegate {
+        var parent: PluginWebView?
+        weak var webView: WKWebView?
+        var lastLoadedPageURL: String?
+        var lastReloadKey: PluginReloadKey?
+        var lastInjectedPlayablesJson: String?
+        var lastInjectedStatusesJson: String?
+        var lastInjectedFocusedPlayerID: String?
+        var lastInjectedPlayerIDs: Set<String>?
+        var lastInjectedDeeplinkToken: Int = 0
+        var isPageReady = false
+        var wantsCaptureEvents = false
+        var pendingDeeplinkEvents: [URL] = []
+        var announcedCaptureEvents: [String: PluginCaptureEvent] = [:]
+        var captureEventCancellable: AnyCancellable?
+        var onCrash: (@MainActor () -> Void)?
+        private let logger = Logger(label: "PluginBridge")
+
+        init(parent: PluginWebView, onCrash: @escaping @MainActor () -> Void) {
+            self.parent = parent
+            self.onCrash = onCrash
+        }
+
+        func prepareForPageLoad(pageURL: String?, reloadKey: PluginReloadKey) {
+            lastLoadedPageURL = pageURL
+            lastReloadKey = reloadKey
+            lastInjectedPlayablesJson = nil
+            lastInjectedStatusesJson = nil
+            lastInjectedFocusedPlayerID = nil
+            lastInjectedPlayerIDs = nil
+            wantsCaptureEvents = false
+            isPageReady = false
+        }
+
+        func tearDown() {
+            captureEventCancellable?.cancel()
+            captureEventCancellable = nil
+            parent = nil
+            onCrash = nil
+            pendingDeeplinkEvents.removeAll()
+            announcedCaptureEvents.removeAll()
+            lastInjectedPlayablesJson = nil
+            lastInjectedStatusesJson = nil
+            lastInjectedFocusedPlayerID = nil
+            lastInjectedPlayerIDs = nil
+            wantsCaptureEvents = false
+            isPageReady = false
+            webView = nil
+        }
+
+        nonisolated func userContentController(
+            _ userContentController: WKUserContentController,
+            didReceive message: WKScriptMessage
+        ) {
+            Task { @MainActor in
+                guard let body = message.body as? [String: Any],
+                    let type = body["type"] as? String
+                else { return }
+
+                if type == "_captureTakenSubscribe" {
+                    wantsCaptureEvents = true
+                    subscribeToCaptureEventsIfNeeded()
+                } else if type == "_captureBlobRequest" {
+                    guard let data = body["data"] as? [String: Any] else { return }
+                    await handleCaptureBlobRequest(data)
+                } else if type == "player:play" || type == "player:pause"
+                    || type == "player:togglePlayPause" || type == "player:seek"
+                    || type == "player:seekToTime"
+                {
+                    let data = body["data"] as? [String: Any]
+                    let requestedPlayerID = data?["playerID"] as? String
+                    let propPlayerID = self.parent?.playerID
+                    let focusedPlayerID = self.parent?.appModel.focusedPlayerID
+                    let firstPlayerID = self.parent?.appModel.activePlayerStates.first?.id
+                    let resolvedID =
+                        requestedPlayerID ?? propPlayerID ?? focusedPlayerID ?? firstPlayerID
+                    guard let resolvedID,
+                        let target = self.parent?.appModel.activePlayerStates.first(where: {
+                            $0.id == resolvedID
+                        })
+                    else { return }
+                    switch type {
+                    case "player:play":
+                        if !target.isPlaying { target.togglePlayPause() }
+                    case "player:pause":
+                        if target.isPlaying { target.togglePlayPause() }
+                    case "player:togglePlayPause":
+                        target.togglePlayPause()
+                    case "player:seek":
+                        if let rawPosition = data?["position"] as? Double {
+                            target.seek(to: Float(max(0.0, min(1.0, rawPosition))))
+                        }
+                    case "player:seekToTime":
+                        if let time = data?["time"] as? Double {
+                            target.seek(toTime: time)
+                        }
+                    default:
+                        break
+                    }
+                }
+            }
+        }
+
+        @MainActor
+        private func subscribeToCaptureEventsIfNeeded() {
+            guard captureEventCancellable == nil else { return }
+
+            captureEventCancellable = CaptureService.shared.didCaptureForPlugin.sink {
+                [weak self] event in
+                guard let self else { return }
+                guard self.wantsCaptureEvents,
+                    self.isPageReady,
+                    self.canReceiveCaptureEvent(for: event.playerID)
+                else {
+                    return
+                }
+
+                self.dispatchPluginCaptureEvent(event)
+            }
+        }
+
+        @MainActor
+        private func canReceiveCaptureEvent(for playerID: String) -> Bool {
+            guard let contextPlayerID = parent?.playerID else {
+                // Standalone plugin screens do not carry a bound playerID.
+                // Treat them as global capture observers once they opt in.
+                return true
+            }
+            return contextPlayerID == playerID
+        }
+
+        @MainActor
+        private func dispatchPluginCaptureEvent(_ event: PluginCaptureEvent) {
+            announcedCaptureEvents[event.captureID] = event
+            let payload: [String: Any] = [
+                "playerID": event.playerID,
+                "captureID": event.captureID,
+                "capturedAt": event.capturedAt.timeIntervalSince1970,
+                "variants": event.variants.map { Self.captureVariantObject(from: $0) },
+            ]
+
+            guard let payloadLiteral = Self.javaScriptObjectLiteral(payload) else { return }
+            evaluateJavaScript(
+                "if (window.kiririn && window.kiririn._emitCaptureTaken) { window.kiririn._emitCaptureTaken(\(payloadLiteral)); }"
+            )
+        }
+
+        @MainActor
+        private func handleCaptureBlobRequest(_ data: [String: Any]) async {
+            guard let requestID = data["requestID"] as? String else { return }
+            guard let captureID = data["captureID"] as? String,
+                let variantRawValue = data["variant"] as? String,
+                let variant = PluginCaptureVariant(rawValue: variantRawValue)
+            else {
+                rejectCaptureBlob(requestID: requestID, message: "キャプチャ要求が不正です")
+                return
+            }
+
+            guard let announcedEvent = announcedCaptureEvents[captureID] else {
+                rejectCaptureBlob(requestID: requestID, message: "このコンテキストでは対象のキャプチャを取得できません")
+                return
+            }
+
+            guard canReceiveCaptureEvent(for: announcedEvent.playerID) else {
+                rejectCaptureBlob(requestID: requestID, message: "このコンテキストでは対象のキャプチャを取得できません")
+                return
+            }
+
+            guard announcedEvent.variants.contains(where: { $0.type == variant }) else {
+                rejectCaptureBlob(requestID: requestID, message: "このコンテキストでは対象のキャプチャを取得できません")
+                return
+            }
+
+            guard
+                let blob = await CaptureService.shared.captureBlob(
+                    captureID: captureID,
+                    variant: variant
+                )
+            else {
+                resolveCaptureBlob(requestID: requestID, payload: nil)
+                return
+            }
+
+            resolveCaptureBlob(
+                requestID: requestID,
+                payload: [
+                    "bodyBase64": blob.data.base64EncodedString(),
+                    "mimeType": blob.mimeType,
+                ]
+            )
+        }
+
+        func queueDeeplinkEvent(_ url: URL) {
+            pendingDeeplinkEvents.append(url)
+            flushDeeplinkEventsIfPossible()
+        }
+
+        private func flushDeeplinkEventsIfPossible() {
+            guard isPageReady else { return }
+            while !pendingDeeplinkEvents.isEmpty {
+                let url = pendingDeeplinkEvents.removeFirst()
+                guard let payloadLiteral = Self.javaScriptObjectLiteral(["url": url.absoluteString])
+                else { continue }
+                evaluateJavaScript(
+                    "if (window.kiririn && window.kiririn._emitDeeplinkOpened) { window.kiririn._emitDeeplinkOpened(\(payloadLiteral)); }"
+                )
+            }
+        }
+
+        private func resolveCaptureBlob(requestID: String, payload: [String: Any]?) {
+            guard let requestIDLiteral = Self.javaScriptStringLiteral(requestID) else { return }
+            let payloadLiteral = payload.flatMap(Self.javaScriptObjectLiteral) ?? "null"
+
+            evaluateJavaScript(
+                "if (window.kiririn && window.kiririn._resolveCaptureBlob) { window.kiririn._resolveCaptureBlob(\(requestIDLiteral), \(payloadLiteral)); }"
+            )
+        }
+
+        private func rejectCaptureBlob(requestID: String, message: String) {
+            guard let requestIDLiteral = Self.javaScriptStringLiteral(requestID),
+                let messageLiteral = Self.javaScriptStringLiteral(message)
+            else { return }
+
+            evaluateJavaScript(
+                "if (window.kiririn && window.kiririn._rejectCaptureBlob) { window.kiririn._rejectCaptureBlob(\(requestIDLiteral), \(messageLiteral)); }"
+            )
+        }
+
+        private func evaluateJavaScript(_ script: String) {
+            let webView = self.webView
+            Task { @MainActor in
+                try? await webView?.evaluateJavaScript(script)
+            }
+        }
+
+        nonisolated private static func javaScriptStringLiteral(_ value: String) -> String? {
+            guard let data = try? JSONSerialization.data(withJSONObject: [value], options: []),
+                let json = String(data: data, encoding: .utf8)
+            else {
+                return nil
+            }
+
+            return String(json.dropFirst().dropLast())
+        }
+
+        nonisolated private static func javaScriptObjectLiteral(_ value: [String: Any]) -> String? {
+            guard JSONSerialization.isValidJSONObject(value),
+                let data = try? JSONSerialization.data(
+                    withJSONObject: value, options: [.sortedKeys]),
+                let json = String(data: data, encoding: .utf8)
+            else {
+                return nil
+            }
+
+            return json
+        }
+
+        nonisolated private static func captureVariantObject(
+            from variant: PluginCaptureVariantMetadata
+        ) -> [String: Any] {
+            [
+                "type": variant.type.rawValue,
+                "overlayPluginManifestIDs": variant.overlayPluginManifestIDs,
+            ]
+        }
+
+        // MARK: - WKNavigationDelegate
+
+        func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+            Task { @MainActor in
+                onCrash?()
+            }
+        }
+
+        // MARK: - WKUIDelegate
+
+        @MainActor
+        func webView(
+            _ webView: WKWebView, runJavaScriptAlertPanelWithMessage message: String,
+            initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping () -> Void
+        ) {
+            #if os(macOS)
+                let alert = NSAlert()
+                alert.messageText = message
+                alert.addButton(withTitle: "OK")
+                if let window = webView.window ?? NSApp.mainWindow {
+                    alert.beginSheetModal(for: window) { _ in completionHandler() }
+                } else {
+                    _ = alert.runModal()
+                    completionHandler()
+                }
+            #else
+                let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+                alert.addAction(
+                    UIAlertAction(title: "OK", style: .default) { _ in completionHandler() })
+                findParentViewController(of: webView)?.present(alert, animated: true)
+            #endif
+        }
+
+        @MainActor
+        func webView(
+            _ webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String,
+            initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping (Bool) -> Void
+        ) {
+            #if os(macOS)
+                let alert = NSAlert()
+                alert.messageText = message
+                alert.addButton(withTitle: "OK")
+                alert.addButton(withTitle: "キャンセル")
+                if let window = webView.window ?? NSApp.mainWindow {
+                    alert.beginSheetModal(for: window) { response in
+                        completionHandler(response == .alertFirstButtonReturn)
+                    }
+                } else {
+                    completionHandler(alert.runModal() == .alertFirstButtonReturn)
+                }
+            #else
+                let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+                alert.addAction(
+                    UIAlertAction(title: "キャンセル", style: .cancel) { _ in completionHandler(false) })
+                alert.addAction(
+                    UIAlertAction(title: "OK", style: .default) { _ in completionHandler(true) })
+                findParentViewController(of: webView)?.present(alert, animated: true)
+            #endif
+        }
+
+        @MainActor
+        func webView(
+            _ webView: WKWebView, runJavaScriptTextInputPanelWithPrompt prompt: String,
+            defaultText: String?, initiatedByFrame frame: WKFrameInfo,
+            completionHandler: @escaping (String?) -> Void
+        ) {
+            #if os(macOS)
+                let alert = NSAlert()
+                alert.messageText = prompt
+                let input = NSTextField(string: defaultText ?? "")
+                input.frame = NSRect(x: 0, y: 0, width: 280, height: 24)
+                alert.accessoryView = input
+                alert.addButton(withTitle: "OK")
+                alert.addButton(withTitle: "キャンセル")
+                if let window = webView.window ?? NSApp.mainWindow {
+                    alert.beginSheetModal(for: window) { response in
+                        completionHandler(
+                            response == .alertFirstButtonReturn ? input.stringValue : nil)
+                    }
+                } else {
+                    let response = alert.runModal()
+                    completionHandler(response == .alertFirstButtonReturn ? input.stringValue : nil)
+                }
+            #else
+                let alert = UIAlertController(title: nil, message: prompt, preferredStyle: .alert)
+                alert.addTextField { textField in
+                    textField.text = defaultText
+                }
+                alert.addAction(
+                    UIAlertAction(title: "キャンセル", style: .cancel) { _ in completionHandler(nil) })
+                alert.addAction(
+                    UIAlertAction(title: "OK", style: .default) { _ in
+                        completionHandler(alert.textFields?.first?.text)
+                    })
+                findParentViewController(of: webView)?.present(alert, animated: true)
+            #endif
+        }
+
+        #if !os(macOS)
+            private func findParentViewController(of view: UIView) -> UIViewController? {
+                var parentResponder: UIResponder? = view
+                while parentResponder != nil {
+                    parentResponder = parentResponder?.next
+                    if let viewController = parentResponder as? UIViewController {
+                        return viewController
+                    }
+                }
+                return nil
+            }
+        #endif
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            isPageReady = true
+            flushDeeplinkEventsIfPossible()
+            // キャッシュをリセットした直後の reload 完了後に、改めて全状態を注入する
+            parent?.injectAllStates(into: webView, coordinator: self, force: true)
+        }
+    }
+}
+
+private class LeakAversionScriptMessageHandler: NSObject, WKScriptMessageHandler {
+    weak var handler: WKScriptMessageHandler?
+
+    init(handler: WKScriptMessageHandler) {
+        self.handler = handler
+    }
+
+    func userContentController(
+        _ userContentController: WKUserContentController, didReceive message: WKScriptMessage
+    ) {
+        handler?.userContentController(userContentController, didReceive: message)
+    }
+}

--- a/kiririn/Features/Plugin/PluginWebsiteDataStore.swift
+++ b/kiririn/Features/Plugin/PluginWebsiteDataStore.swift
@@ -1,0 +1,98 @@
+import WebKit
+
+@MainActor
+enum PluginWebsiteDataStore {
+    private static let extensionDataTypes = WKWebExtensionController.allExtensionDataTypes
+    private static let websiteDataTypes = WKWebsiteDataStore.allWebsiteDataTypes()
+
+    static func unregisterServiceWorkers(for plugin: PluginDefinition) async {
+        guard let host = try? ExtensionPluginContextConfiguration.websiteDataHost(for: plugin.id)
+        else { return }
+        let swTypes: Set<String> = [WKWebsiteDataTypeServiceWorkerRegistrations]
+        let dataStore = WKWebsiteDataStore.default()
+        let records = await matchingRecords(forHost: host, dataStore: dataStore)
+        guard !records.isEmpty else { return }
+        await withCheckedContinuation { continuation in
+            dataStore.removeData(ofTypes: swTypes, for: records) {
+                continuation.resume(returning: ())
+            }
+        }
+    }
+
+    @MainActor
+    static func removeAllData(for plugin: PluginDefinition, store: PluginStore) async throws
+        -> Bool
+    {
+        let removedWebsiteData = try await removeWebsiteData(for: plugin)
+
+        do {
+            let runtime = try await ExtensionPluginRuntimeRegistry.shared.acquireRuntime(
+                for: plugin,
+                store: store
+            )
+            defer {
+                ExtensionPluginRuntimeRegistry.shared.releaseRuntime(runtime)
+            }
+            let removedExtensionData = await removeExtensionData(for: runtime)
+            return removedExtensionData || removedWebsiteData
+        } catch {
+            if removedWebsiteData {
+                return true
+            }
+            throw error
+        }
+    }
+
+    private static func removeExtensionData(for runtime: ExtensionPluginRuntime) async -> Bool {
+        guard
+            let record = await runtime.controller.dataRecord(
+                ofTypes: extensionDataTypes,
+                for: runtime.context
+            )
+        else {
+            return false
+        }
+
+        let removableTypes = record.containedDataTypes.intersection(extensionDataTypes)
+        guard !removableTypes.isEmpty else { return false }
+
+        await runtime.controller.removeData(ofTypes: removableTypes, from: [record])
+        return true
+    }
+
+    private static func removeWebsiteData(for plugin: PluginDefinition) async throws -> Bool {
+        let host = try ExtensionPluginContextConfiguration.websiteDataHost(for: plugin.id)
+        return await removeWebsiteData(forHost: host)
+    }
+
+    private static func removeWebsiteData(forHost host: String) async -> Bool {
+        let dataStore = WKWebsiteDataStore.default()
+        let records = await matchingRecords(forHost: host, dataStore: dataStore)
+        guard !records.isEmpty else { return false }
+
+        await withCheckedContinuation { continuation in
+            dataStore.removeData(ofTypes: websiteDataTypes, for: records) {
+                continuation.resume(returning: ())
+            }
+        }
+
+        return true
+    }
+
+    private static func matchingRecords(forHost host: String, dataStore: WKWebsiteDataStore) async
+        -> [WKWebsiteDataRecord]
+    {
+        let normalizedHost = host.lowercased()
+
+        return await withCheckedContinuation { continuation in
+            dataStore.fetchDataRecords(ofTypes: websiteDataTypes) { records in
+                continuation.resume(
+                    returning: records.filter {
+                        let displayName = $0.displayName.lowercased()
+                        return displayName == normalizedHost
+                            || displayName.hasSuffix(".\(normalizedHost)")
+                    })
+            }
+        }
+    }
+}

--- a/kiririn/Features/Plugin/macOS/PluginWindowView.swift
+++ b/kiririn/Features/Plugin/macOS/PluginWindowView.swift
@@ -1,23 +1,27 @@
+import AppKit
 import KppxKit
 import SwiftUI
 
 struct PluginWindowView_macOS: View {
-    let pluginID: UUID
     @Environment(AppModel.self) private var appModel
+    let pluginID: UUID
+    @State private var isAlwaysOnTop = false
+    @State private var windowReference = WindowReference_macOS()
 
     private var plugin: PluginDefinition? {
         appModel.pluginStore.plugins.first { $0.id == pluginID }
     }
 
-    @State private var isAlwaysOnTop = false
-    @State private var window: NSWindow?
+    private var window: NSWindow? {
+        windowReference.window
+    }
 
     var body: some View {
         Group {
             if let plugin {
                 ZStack {
                     WindowConfigurator_macOS { nsWindow in
-                        self.window = nsWindow
+                        windowReference.window = nsWindow
                         nsWindow.level = isAlwaysOnTop ? .floating : .normal
                     }
                     .frame(width: 0, height: 0)
@@ -45,6 +49,9 @@ struct PluginWindowView_macOS: View {
                             Text("最前面に固定")
                         }
                     }
+                }
+                .onDisappear {
+                    windowReference.window = nil
                 }
             } else {
                 ContentUnavailableView(

--- a/kiririn/Shared/UI/macOS/WindowReference.swift
+++ b/kiririn/Shared/UI/macOS/WindowReference.swift
@@ -1,0 +1,6 @@
+import AppKit
+
+@MainActor
+final class WindowReference_macOS {
+    weak var window: NSWindow?
+}


### PR DESCRIPTION
Fixes #48 

This pull request introduces a new architecture for managing extension plugins, focusing on runtime management, context configuration, and website data handling. It also refactors parts of the player window handling and improves memory management for plugin overlay snapshots. The most important changes are as follows:

---

**Extension Plugin Architecture**

* Added `ExtensionPluginRuntime`, a class that encapsulates the lifecycle and context of a WebExtension-based plugin, including permission handling and invalidation.
* Introduced `ExtensionPluginRuntimeRegistry`, a singleton responsible for loading, reference counting, and releasing plugin runtimes, ensuring only one instance per plugin is active and handling concurrent load requests.
* Added `ExtensionPluginContextConfiguration`, which centralizes the logic for configuring a `WKWebExtensionContext` for plugins, including stable identity, base URL, and permissions.
* Implemented `PluginWebsiteDataStore`, providing async methods to remove service workers and all website data associated with a plugin, supporting proper cleanup and privacy.

**Plugin Overlay and Snapshot Improvements**

* Refactored `PluginOverlaySnapshotRegistry` to use weak references for web views and a structured key, preventing memory leaks and stale references in plugin overlay snapshots. [[1]](diffhunk://#diff-bc1a99079af6ccaab3fcf7693be3b71bd1d3d06063e48a8542ba7af24f3552c2L8-R32) [[2]](diffhunk://#diff-bc1a99079af6ccaab3fcf7693be3b71bd1d3d06063e48a8542ba7af24f3552c2L26-R44) [[3]](diffhunk://#diff-bc1a99079af6ccaab3fcf7693be3b71bd1d3d06063e48a8542ba7af24f3552c2L114-L117)

**Player Window Handling Refactor**

* Replaced direct `NSWindow` references in player overlay views with a new `WindowReference_macOS` wrapper, improving window reference management and reducing potential retain cycles. [[1]](diffhunk://#diff-c3106c6f27a8e022739bd8b9a5c9a209bf13a8f0d8c57362f5fc45945aa7a383L15-R15) [[2]](diffhunk://#diff-c3106c6f27a8e022739bd8b9a5c9a209bf13a8f0d8c57362f5fc45945aa7a383R44-R47) [[3]](diffhunk://#diff-c3106c6f27a8e022739bd8b9a5c9a209bf13a8f0d8c57362f5fc45945aa7a383L1210-R1214) [[4]](diffhunk://#diff-7efeb1cfb1011676599ae0ed669df3e15697501d8de6b7623d6edd4105aea9b7L16-R16) [[5]](diffhunk://#diff-7efeb1cfb1011676599ae0ed669df3e15697501d8de6b7623d6edd4105aea9b7L29-R29) [[6]](diffhunk://#diff-7efeb1cfb1011676599ae0ed669df3e15697501d8de6b7623d6edd4105aea9b7R127-R140)
* Registered the new `WindowReference.swift` file in the Xcode project for macOS shared UI.

**Other**

* Added `PluginReloadKey` struct for tracking plugin reloads via external or manual triggers.

## Summary by Sourcery

拡張機能プラグインの管理と Web ビュー描画を再構成し、WebExtension ランタイムを共有・正しく解放できるようにするとともに、プラグインオーバーレイのスナップショット処理とクラッシュ／リロード時の動作を改善し、macOS のウィンドウ参照をモダナイズしてメモリリークを防止します。

New Features:
- 参照カウントと共有ランタイムの再利用に対応した、WebExtension ベースのプラグイン管理用 `ExtensionPluginRuntime` とレジストリを導入。
- プラグインの Web コンテンツ描画と、プラットフォーム間のスクリプトブリッジをカプセル化する `PluginWebView` コンポーネントを追加。

Bug Fixes:
- 弱い Web ビュー参照と構造化されたスナップショットキーを用いることで、プラグインオーバーレイのスナップショットにおけるメモリリークを防止。
- 直接 `NSWindow` の状態を保持するのをやめて、弱参照の `WindowReference` ラッパーに置き換えることで、macOS のプレーヤーおよびプラグインウィンドウ処理での retain cycle を削減。
- 外部からのリロードやクラッシュ復旧時に、プラグインランタイムと Web ビューが適切に解放・再ロードされるように保証。

Enhancements:
- `PluginWebsiteDataStore` に拡張機能とウェブサイトデータの削除処理を集約し、プラグインのウェブサイトデータのクリーンアップを改善。
- 外部リロードと手動リロードのトリガーを区別する `PluginReloadKey` によって、プラグインのリロード動作を洗練。
- ベース URL、アイデンティティ、権限の処理を簡素化するために、拡張機能プラグインのコンテキスト設定を独立したモジュールに分離。
- 明示的な teardown、状態インジェクションの調整、クラッシュ処理によって、プラグインの Web ビューライフサイクル管理を効率化。

Build:
- 新しいプラグインランタイム、Web ビュー、ウェブサイトデータストア、リロードキー、macOS ウィンドウ参照のファイルを Xcode プロジェクトに登録。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restructure extension plugin management and web view rendering to share and correctly release WebExtension runtimes, improve plugin overlay snapshot handling and crash/reload behavior, and modernize macOS window references to avoid memory leaks.

New Features:
- Introduce a dedicated ExtensionPluginRuntime and registry for managing WebExtension-based plugins with reference counting and shared runtime reuse.
- Add PluginWebView component to encapsulate plugin web content rendering and bridge scripting across platforms.

Bug Fixes:
- Prevent memory leaks in plugin overlay snapshots by using weak web view references and structured snapshot keys.
- Reduce retain cycles in macOS player and plugin window handling by replacing direct NSWindow state with a weak WindowReference wrapper.
- Ensure plugin runtimes and web views are properly released and reloaded on external reloads and crash recovery.

Enhancements:
- Improve plugin website data cleanup by centralizing extension and website data removal in PluginWebsiteDataStore.
- Refine plugin reload behavior with a PluginReloadKey that distinguishes external and manual reload triggers.
- Separate extension plugin context configuration into its own module to simplify base URL, identity, and permission handling.
- Streamline plugin web view lifecycle management with explicit teardown, state injection coordination, and crash handling.

Build:
- Register new plugin runtime, web view, website data store, reload key, and macOS window reference files in the Xcode project.

</details>