### PR TITLE
chore: データ放送表示中のプラグイン合成領域を変更など

### DIFF
--- a/Plugin/KiririnPluginBridge.d.ts
+++ b/Plugin/KiririnPluginBridge.d.ts
@@ -49,6 +49,17 @@ export interface Service {
     channel?: Channel;
 }
 
+export interface PlayerDisplayRect {
+    /** プレイヤー表示領域の幅を1とした左端座標。 */
+    x: number;
+    /** プレイヤー表示領域の高さを1とした上端座標。 */
+    y: number;
+    /** プレイヤー表示領域の幅を1とした表示幅。 */
+    width: number;
+    /** プレイヤー表示領域の高さを1とした表示高さ。 */
+    height: number;
+}
+
 export interface PlayerPlaybackState {
     playerID: string;
     playableID: string;
@@ -56,6 +67,16 @@ export interface PlayerPlaybackState {
     time: number;
     position: number;
     rate: number;
+    /**
+     * プレイヤー領域内でテレビ画面として使われる描画領域の正規化座標です。
+     * データ放送表示中はデータ放送コンテンツの描画領域、それ以外は全面を示します。
+     */
+    televisionDisplayRect: PlayerDisplayRect;
+    /**
+     * プレイヤー領域内で映像が実際に表示されている領域の正規化座標です。
+     * データ放送に映像プレーンがない場合を含め、映像が全面表示されるときは全面を示します。
+     */
+    videoDisplayRect: PlayerDisplayRect;
 }
 
 export interface Playable {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kiririn
 
-kiririn は macOS/iOS 上で日本のデジタル放送を視聴する体験を研究する目的で配布される研究資料です。<br>
+kiririn は macOS/iOS 上において、デジタル放送の視聴を行うプログラムの実装を研究する目的で頒布される研究資料です。<br>
 本アプリに CAS 処理は含まれていないため、暗号化された放送データを視聴することはできません。<br>
 放送視聴機能を利用するには利用者自身が管理する [Chinachu/Mirakurun](https://github.com/Chinachu/Mirakurun) または [l3tnun/EPGStation](https://github.com/l3tnun/EPGStation) が必要です。
 

--- a/kiririn/Features/Capture/CaptureService.swift
+++ b/kiririn/Features/Capture/CaptureService.swift
@@ -150,29 +150,11 @@ final class CaptureService: ObservableObject {
         var effectiveOverlayPluginManifestIDs: [String] = []
         var compositeURLForCopy: URL?
 
-        // 合成順: プラグイン → データ放送（表示順に合わせる）
-        // 両方有効な場合は、プラグイン合成結果に対してデータ放送を合成する
+        // 合成順: データ放送 → プラグイン（表示順に合わせる）
         var currentBasePath = savedPath
         var hasComposite = false
 
-        // 1. プラグイン合成
-        if shouldCompositePluginOverlay, let overlay = overlayImage,
-            let compositePath = try? await saveCompositedCapturePath(
-                savedPath: currentBasePath,
-                overlayImage: overlay,
-                programName: programName,
-                serviceName: serviceName,
-                caption: caption,
-                broadcastTime: broadcastTime,
-                overlayPluginManifestIDs: overlayPluginManifestIDs
-            )
-        {
-            currentBasePath = compositePath
-            effectiveOverlayPluginManifestIDs = overlayPluginManifestIDs
-            hasComposite = true
-        }
-
-        // 2. データ放送合成（プラグイン合成結果に対して合成）
+        // 1. データ放送合成
         if let dataBroadcastOverlay = dataBroadcastOverlayImage,
             let dataBroadcastLayout = dataBroadcastLayout,
             let dataBroadcastPath = try? await saveCompositedCapturePath(
@@ -187,6 +169,23 @@ final class CaptureService: ObservableObject {
             )
         {
             currentBasePath = dataBroadcastPath
+            hasComposite = true
+        }
+
+        // 2. プラグイン合成（データ放送を含む画面全体に対して合成）
+        if shouldCompositePluginOverlay, let overlay = overlayImage,
+            let compositePath = try? await saveCompositedCapturePath(
+                savedPath: currentBasePath,
+                overlayImage: overlay,
+                programName: programName,
+                serviceName: serviceName,
+                caption: caption,
+                broadcastTime: broadcastTime,
+                overlayPluginManifestIDs: overlayPluginManifestIDs
+            )
+        {
+            currentBasePath = compositePath
+            effectiveOverlayPluginManifestIDs = overlayPluginManifestIDs
             hasComposite = true
         }
 

--- a/kiririn/Features/Player/DataBroadcast/DataBroadcastSession.swift
+++ b/kiririn/Features/Player/DataBroadcast/DataBroadcastSession.swift
@@ -9,8 +9,26 @@ import WebKit
 #endif
 
 struct DataBroadcastCaptureLayout {
+    let sourceFrame: CGRect
     let canvasSize: CGSize
     let videoFrame: CGRect
+
+    init?(sourceFrame: CGRect, videoFrame: CGRect, outputHeight: CGFloat) {
+        guard sourceFrame.width > 0, sourceFrame.height > 0,
+            videoFrame.width > 0, videoFrame.height > 0,
+            outputHeight > 0
+        else { return nil }
+
+        let scale = outputHeight / sourceFrame.height
+        self.sourceFrame = sourceFrame
+        self.canvasSize = CGSize(width: sourceFrame.width * scale, height: outputHeight)
+        self.videoFrame = CGRect(
+            x: (videoFrame.minX - sourceFrame.minX) * scale,
+            y: (videoFrame.minY - sourceFrame.minY) * scale,
+            width: videoFrame.width * scale,
+            height: videoFrame.height * scale
+        )
+    }
 }
 
 struct DataBroadcastCaptureSnapshot {
@@ -52,6 +70,7 @@ final class DataBroadcastSession {
     }
 
     private(set) var status: Status = .idle
+    private(set) var stageRect: CGRect?
     private(set) var videoRect: CGRect?
     private(set) var isInvisible = false
     /// 実機の「データ取得中...」に相当。コンテンツが待っているモジュール取得が
@@ -69,20 +88,11 @@ final class DataBroadcastSession {
     let webView: WKWebView
 
     func captureLayout(outputHeight: CGFloat) -> DataBroadcastCaptureLayout? {
-        let sourceSize = webView.bounds.size
-        guard sourceSize.width > 0, sourceSize.height > 0, outputHeight > 0,
-            let videoRect, videoRect.width > 0, videoRect.height > 0
-        else { return nil }
-
-        let scale = outputHeight / sourceSize.height
+        guard let stageRect, let videoRect else { return nil }
         return DataBroadcastCaptureLayout(
-            canvasSize: CGSize(width: sourceSize.width * scale, height: outputHeight),
-            videoFrame: CGRect(
-                x: videoRect.minX * scale,
-                y: videoRect.minY * scale,
-                width: videoRect.width * scale,
-                height: videoRect.height * scale
-            )
+            sourceFrame: stageRect,
+            videoFrame: videoRect,
+            outputHeight: outputHeight
         )
     }
 
@@ -90,7 +100,9 @@ final class DataBroadcastSession {
         -> DataBroadcastCaptureSnapshot?
     {
         await withCheckedContinuation { continuation in
-            webView.takeSnapshot(with: nil) { image, _ in
+            let configuration = WKSnapshotConfiguration()
+            configuration.rect = layout.sourceFrame
+            webView.takeSnapshot(with: configuration) { image, _ in
                 #if os(macOS)
                     let cgImage = image?.cgImage(forProposedRect: nil, context: nil, hints: nil)
                 #else
@@ -579,18 +591,32 @@ final class DataBroadcastSession {
                 "BML setMainAudioStream: componentId=\(request.componentId) channelId=\(String(describing: request.channelId)) pid=\(String(describing: request.pid)) index=\(String(describing: request.audioIndex))"
             )
             audioStreamHandler(request)
-        case "videoRect":
-            if let x = body["x"] as? Double, let y = body["y"] as? Double,
-                let width = body["width"] as? Double, let height = body["height"] as? Double
+        case "layoutRects":
+            if let stageX = body["stageX"] as? Double,
+                let stageY = body["stageY"] as? Double,
+                let stageWidth = body["stageWidth"] as? Double,
+                let stageHeight = body["stageHeight"] as? Double,
+                let videoX = body["videoX"] as? Double,
+                let videoY = body["videoY"] as? Double,
+                let videoWidth = body["videoWidth"] as? Double,
+                let videoHeight = body["videoHeight"] as? Double
             {
-                // Zero size = the active document has no video object; show
-                // the video full-bleed rather than keeping a stale rect.
-                if width > 0, height > 0 {
-                    videoRect = CGRect(x: x, y: y, width: width, height: height)
-                    logger.info("BML videoRect: \(x),\(y) \(width)x\(height)")
+                if stageWidth > 0, stageHeight > 0 {
+                    stageRect = CGRect(
+                        x: stageX, y: stageY, width: stageWidth, height: stageHeight)
+                } else {
+                    stageRect = nil
+                }
+                // Zero video size means the active document has no video object.
+                if videoWidth > 0, videoHeight > 0 {
+                    videoRect = CGRect(
+                        x: videoX, y: videoY, width: videoWidth, height: videoHeight)
+                    logger.info(
+                        "BML layoutRects: stage=\(stageX),\(stageY) \(stageWidth)x\(stageHeight) video=\(videoX),\(videoY) \(videoWidth)x\(videoHeight)"
+                    )
                 } else {
                     videoRect = nil
-                    logger.info("BML videoRect cleared")
+                    logger.info("BML videoRect cleared by layoutRects")
                 }
             }
         case "invisible":
@@ -721,6 +747,7 @@ final class DataBroadcastSession {
             webView.backgroundColor = .clear
             webView.scrollView.backgroundColor = .clear
             webView.scrollView.isScrollEnabled = false
+            webView.scrollView.contentInsetAdjustmentBehavior = .never
         #endif
         return webView
     }

--- a/kiririn/Features/Player/DataBroadcast/DataBroadcastSession.swift
+++ b/kiririn/Features/Player/DataBroadcast/DataBroadcastSession.swift
@@ -51,6 +51,11 @@ struct DataBroadcastCaptureSnapshot {
 @MainActor
 @Observable
 final class DataBroadcastSession {
+    private struct LayoutRects {
+        let stage: CGRect?
+        let video: CGRect?
+    }
+
     struct InputRequest: Identifiable, Equatable {
         let id: Int
         let characterType: String
@@ -592,32 +597,16 @@ final class DataBroadcastSession {
             )
             audioStreamHandler(request)
         case "layoutRects":
-            if let stageX = body["stageX"] as? Double,
-                let stageY = body["stageY"] as? Double,
-                let stageWidth = body["stageWidth"] as? Double,
-                let stageHeight = body["stageHeight"] as? Double,
-                let videoX = body["videoX"] as? Double,
-                let videoY = body["videoY"] as? Double,
-                let videoWidth = body["videoWidth"] as? Double,
-                let videoHeight = body["videoHeight"] as? Double
-            {
-                if stageWidth > 0, stageHeight > 0 {
-                    stageRect = CGRect(
-                        x: stageX, y: stageY, width: stageWidth, height: stageHeight)
-                } else {
-                    stageRect = nil
-                }
-                // Zero video size means the active document has no video object.
-                if videoWidth > 0, videoHeight > 0 {
-                    videoRect = CGRect(
-                        x: videoX, y: videoY, width: videoWidth, height: videoHeight)
-                    logger.info(
-                        "BML layoutRects: stage=\(stageX),\(stageY) \(stageWidth)x\(stageHeight) video=\(videoX),\(videoY) \(videoWidth)x\(videoHeight)"
-                    )
-                } else {
-                    videoRect = nil
-                    logger.info("BML videoRect cleared by layoutRects")
-                }
+            guard let layoutRects = Self.parseLayoutRects(from: body) else {
+                logger.warning("invalid BML layoutRects message")
+                return
+            }
+            stageRect = layoutRects.stage
+            videoRect = layoutRects.video
+            if let stageRect, let videoRect {
+                logger.info("BML layoutRects: stage=\(stageRect) video=\(videoRect)")
+            } else {
+                logger.info("BML layout rect cleared by layoutRects")
             }
         case "invisible":
             let nextValue = (body["value"] as? Bool) ?? false
@@ -703,6 +692,34 @@ final class DataBroadcastSession {
         default:
             break
         }
+    }
+
+    private static func parseLayoutRects(from body: [String: Any]) -> LayoutRects? {
+        guard let stageX = body["stageX"] as? Double,
+            let stageY = body["stageY"] as? Double,
+            let stageWidth = body["stageWidth"] as? Double,
+            let stageHeight = body["stageHeight"] as? Double,
+            let videoX = body["videoX"] as? Double,
+            let videoY = body["videoY"] as? Double,
+            let videoWidth = body["videoWidth"] as? Double,
+            let videoHeight = body["videoHeight"] as? Double,
+            [
+                stageX, stageY, stageWidth, stageHeight,
+                videoX, videoY, videoWidth, videoHeight,
+            ].allSatisfy(\.isFinite)
+        else { return nil }
+
+        return LayoutRects(
+            stage: layoutRect(
+                x: stageX, y: stageY, width: stageWidth, height: stageHeight),
+            video: layoutRect(
+                x: videoX, y: videoY, width: videoWidth, height: videoHeight)
+        )
+    }
+
+    private static func layoutRect(x: Double, y: Double, width: Double, height: Double) -> CGRect? {
+        guard width > 0, height > 0 else { return nil }
+        return CGRect(x: x, y: y, width: width, height: height)
     }
 
     // MARK: - WebView construction

--- a/kiririn/Features/Player/PlayerOverlayView.swift
+++ b/kiririn/Features/Player/PlayerOverlayView.swift
@@ -311,21 +311,6 @@ struct PlayerOverlayView_iOS: View {
                         }
                     }
                 )
-
-                ForEach(playerState.availableOverlayPlugins) { plugin in
-                    PluginOverlayView(
-                        pluginDefinition: plugin,
-                        appModel: appModel,
-                        reloadToken: playerState.pluginReloadToken
-                            + playerState.perPluginReloadTokens[
-                                plugin.id.uuidString, default: 0],
-                        displayArea: .overlay,
-                        playerID: playerState.id
-                    )
-                    .id(plugin.id)
-                    .opacity(playerState.showingPluginOverlay ? 1 : 0)
-                    .allowsHitTesting(false)
-                }
             }
             .frame(width: frame.width, height: frame.height)
             .clipShape(.rect(cornerRadius: playerState.mode == .mini ? 14 : 0))
@@ -341,6 +326,29 @@ struct PlayerOverlayView_iOS: View {
                 .position(x: frame.midX, y: frame.midY)
                 .opacity(playerState.bmlContentVisible ? 1 : 0)
                 .allowsHitTesting(false)
+                .ignoresSafeArea(edges: verticalSizeClass == .compact ? .bottom : [])
+        }
+
+        if playerState.player != nil {
+            let frame = playerSurfaceFrame(in: geo)
+            ForEach(playerState.availableOverlayPlugins) { plugin in
+                PluginOverlayView(
+                    pluginDefinition: plugin,
+                    appModel: appModel,
+                    reloadToken: playerState.pluginReloadToken
+                        + playerState.perPluginReloadTokens[
+                            plugin.id.uuidString, default: 0],
+                    displayArea: .overlay,
+                    playerID: playerState.id
+                )
+                .id(plugin.id)
+                .frame(width: frame.width, height: frame.height)
+                .clipShape(.rect(cornerRadius: playerState.mode == .mini ? 14 : 0))
+                .position(x: frame.midX, y: frame.midY)
+                .opacity(playerState.showingPluginOverlay ? 1 : 0)
+                .allowsHitTesting(false)
+                .ignoresSafeArea(edges: verticalSizeClass == .compact ? .bottom : [])
+            }
         }
     }
 

--- a/kiririn/Features/Player/PlayerState.swift
+++ b/kiririn/Features/Player/PlayerState.swift
@@ -1576,13 +1576,17 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
         if CaptureService.shared.shouldCompositePluginOverlay && !visibleOverlayPlugins.isEmpty {
             let playerID = self.id
             pendingOverlayManifestIDs = visibleOverlayPlugins.map(\.manifestID)
-            let snapshotSize = CGSize(
-                width: CGFloat(snapshotWidth), height: CGFloat(snapshotHeight))
+            let compositedDataBroadcastLayout =
+                CaptureService.shared.shouldCompositeDataBroadcast ? dataBroadcastLayout : nil
+            let snapshotSize =
+                compositedDataBroadcastLayout?.canvasSize
+                ?? CGSize(width: CGFloat(snapshotWidth), height: CGFloat(snapshotHeight))
+            let snapshotAspectRatio = Double(snapshotSize.width / snapshotSize.height)
             pendingPluginOverlayTask = Task { @MainActor in
                 await PluginOverlaySnapshotRegistry.shared.takeCompositeSnapshot(
                     for: playerID,
                     targetSize: snapshotSize,
-                    targetAspectRatio: displayAspectRatio,
+                    targetAspectRatio: snapshotAspectRatio,
                     targetFrame: nil
                 )
             }

--- a/kiririn/Features/Player/macOS/DetachedPlayerOverlayView.swift
+++ b/kiririn/Features/Player/macOS/DetachedPlayerOverlayView.swift
@@ -86,25 +86,6 @@
                                 Color.black
                             }
 
-                            if !playerState.availableOverlayPlugins.isEmpty {
-                                ForEach(playerState.availableOverlayPlugins) { plugin in
-                                    PluginOverlayView(
-                                        pluginDefinition: plugin,
-                                        appModel: appModel,
-                                        reloadToken: playerState.pluginReloadToken
-                                            + playerState.perPluginReloadTokens[
-                                                plugin.id.uuidString, default: 0],
-                                        displayArea: .overlay,
-                                        playerID: playerState.id
-                                    )
-                                    .id(plugin.id)
-                                    .frame(width: videoFrame.width, height: videoFrame.height)
-                                    .position(x: videoFrame.midX, y: videoFrame.midY)
-                                    .opacity(playerState.showingPluginOverlay ? 1 : 0)
-                                    .allowsHitTesting(false)
-                                }
-                            }
-
                             if let session = playerState.dataBroadcastSession {
                                 // Visibility is content-driven (ARIB invisible state):
                                 // the content shows itself on DataButton. Mouse input
@@ -114,6 +95,23 @@
                                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                                     .opacity(playerState.bmlContentVisible ? 1 : 0)
                                     .allowsHitTesting(false)
+                            }
+
+                            ForEach(playerState.availableOverlayPlugins) { plugin in
+                                PluginOverlayView(
+                                    pluginDefinition: plugin,
+                                    appModel: appModel,
+                                    reloadToken: playerState.pluginReloadToken
+                                        + playerState.perPluginReloadTokens[
+                                            plugin.id.uuidString, default: 0],
+                                    displayArea: .overlay,
+                                    playerID: playerState.id
+                                )
+                                .id(plugin.id)
+                                .frame(width: videoGeo.size.width, height: videoGeo.size.height)
+                                .position(x: videoGeo.size.width / 2, y: videoGeo.size.height / 2)
+                                .opacity(playerState.showingPluginOverlay ? 1 : 0)
+                                .allowsHitTesting(false)
                             }
                         }
                         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/kiririn/Features/Plugin/PluginOverlayView.swift
+++ b/kiririn/Features/Plugin/PluginOverlayView.swift
@@ -88,10 +88,20 @@ struct PluginOverlayView: View {
 
     var body: some View {
         // アクティブな全プレイヤーの状態を追跡するハッシュを生成し、これを元に再描画と同期をトリガーさせる。
-        // 再生位置(time)は頻繁すぎるため除外するが、番組変更や再生/停止、シーク可否の変化は網羅する。
+        // 再生位置(time)は頻繁すぎるため除外するが、番組変更や再生/停止、シーク可否、映像表示領域の変化は網羅する。
         let stateHash =
             appModel.activePlayerStates.map {
-                "\($0.id):\($0.currentPlayable?.id ?? "none"):\($0.playbackStatus.isPlaying):\($0.currentPlayable?.isSeekable ?? false)"
+                let stageRect = $0.dataBroadcastSession?.stageRect
+                let videoRect = $0.dataBroadcastSession?.videoRect
+                return [
+                    $0.id,
+                    $0.currentPlayable?.id ?? "none",
+                    String($0.playbackStatus.isPlaying),
+                    String($0.currentPlayable?.isSeekable ?? false),
+                    String($0.bmlContentVisible),
+                    String(describing: stageRect),
+                    String(describing: videoRect),
+                ].joined(separator: ":")
             }.joined(separator: "|") + (appModel.focusedPlayerID ?? "")
         ZStack {
             if let loadedRuntime {

--- a/kiririn/Features/Plugin/PluginWebView.swift
+++ b/kiririn/Features/Plugin/PluginWebView.swift
@@ -188,7 +188,7 @@ struct PluginWebView: PluginWebViewRepresentable {
             "appVersion": appVersion ?? NSNull(),
             "buildVersion": buildVersion,
             "bundleIdentifier": bundle.bundleIdentifier ?? NSNull(),
-            "bridgeVersion": 3,
+            "bridgeVersion": 4,
             "displayAreaType": displayArea.rawValue,
             "playerID": runtimePlayerID,
         ]
@@ -258,7 +258,7 @@ struct PluginWebView: PluginWebViewRepresentable {
                 "playableID": s.playableID ?? "",
                 "isPlaying": s.isPlaying,
                 "time": s.time,
-                "position": s.position,
+                "position": s.bytePosition > 0 ? s.bytePosition : s.position,
                 "rate": s.rate,
             ]
         }
@@ -311,7 +311,7 @@ struct PluginWebView: PluginWebViewRepresentable {
                 "playableID": s.playableID ?? "",
                 "isPlaying": s.isPlaying,
                 "time": s.time,
-                "position": s.position,
+                "position": s.bytePosition > 0 ? s.bytePosition : s.position,
                 "rate": s.rate,
             ]
         }

--- a/kiririn/Features/Plugin/PluginWebView.swift
+++ b/kiririn/Features/Plugin/PluginWebView.swift
@@ -188,7 +188,7 @@ struct PluginWebView: PluginWebViewRepresentable {
             "appVersion": appVersion ?? NSNull(),
             "buildVersion": buildVersion,
             "bundleIdentifier": bundle.bundleIdentifier ?? NSNull(),
-            "bridgeVersion": 4,
+            "bridgeVersion": 5,
             "displayAreaType": displayArea.rawValue,
             "playerID": runtimePlayerID,
         ]
@@ -249,19 +249,7 @@ struct PluginWebView: PluginWebViewRepresentable {
     private func injectStatuses(
         into webView: WKWebView, coordinator: Coordinator, force: Bool = false
     ) {
-        let statuses = appModel.activePlayerStates.compactMap { state -> [String: Any]? in
-            guard let s = state.playbackStatus as PlayerPlaybackStatus?,
-                state.currentPlayable != nil
-            else { return nil }
-            return [
-                "playerID": state.id,
-                "playableID": s.playableID ?? "",
-                "isPlaying": s.isPlaying,
-                "time": s.time,
-                "position": s.bytePosition > 0 ? s.bytePosition : s.position,
-                "rate": s.rate,
-            ]
-        }
+        let statuses = appModel.activePlayerStates.compactMap(makePlayerStatusSchema)
         guard
             let data = try? JSONSerialization.data(
                 withJSONObject: statuses, options: [.sortedKeys]),
@@ -296,25 +284,59 @@ struct PluginWebView: PluginWebViewRepresentable {
         webView.evaluateJavaScript(js)
     }
 
+    private func makePlayerStatusSchema(_ state: PlayerState) -> [String: Any]? {
+        guard let status = state.playbackStatus as PlayerPlaybackStatus?,
+            state.currentPlayable != nil
+        else { return nil }
+
+        let displayRects = normalizedDisplayRects(for: state)
+        return [
+            "playerID": state.id,
+            "playableID": status.playableID ?? "",
+            "isPlaying": status.isPlaying,
+            "time": status.time,
+            "position": status.bytePosition > 0 ? status.bytePosition : status.position,
+            "rate": status.rate,
+            "televisionDisplayRect": displayRects.television,
+            "videoDisplayRect": displayRects.video,
+        ]
+    }
+
+    private func normalizedDisplayRects(for state: PlayerState) -> (
+        television: [String: Double], video: [String: Double]
+    ) {
+        let fullRect = ["x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0]
+        guard state.bmlContentVisible,
+            let session = state.dataBroadcastSession
+        else { return (fullRect, fullRect) }
+
+        let bounds = session.webView.bounds
+        return (
+            normalizedDisplayRect(session.stageRect, in: bounds) ?? fullRect,
+            normalizedDisplayRect(session.videoRect, in: bounds) ?? fullRect
+        )
+    }
+
+    private func normalizedDisplayRect(_ rect: CGRect?, in bounds: CGRect) -> [String: Double]? {
+        guard let rect, bounds.width > 0, bounds.height > 0 else { return nil }
+        let visibleRect = rect.intersection(bounds)
+        guard !visibleRect.isNull, visibleRect.width > 0, visibleRect.height > 0 else { return nil }
+
+        return [
+            "x": Double((visibleRect.minX - bounds.minX) / bounds.width),
+            "y": Double((visibleRect.minY - bounds.minY) / bounds.height),
+            "width": Double(visibleRect.width / bounds.width),
+            "height": Double(visibleRect.height / bounds.height),
+        ]
+    }
+
     private func makeBridgeJS() -> String {
         let playables = appModel.activePlayerStates.compactMap { state -> [String: Any]? in
             guard var schema = state.currentPlayable?.toPluginSchema() else { return nil }
             schema["playerID"] = state.id
             return schema
         }
-        let statuses = appModel.activePlayerStates.compactMap { state -> [String: Any]? in
-            guard let s = state.playbackStatus as PlayerPlaybackStatus?,
-                state.currentPlayable != nil
-            else { return nil }
-            return [
-                "playerID": state.id,
-                "playableID": s.playableID ?? "",
-                "isPlaying": s.isPlaying,
-                "time": s.time,
-                "position": s.bytePosition > 0 ? s.bytePosition : s.position,
-                "rate": s.rate,
-            ]
-        }
+        let statuses = appModel.activePlayerStates.compactMap(makePlayerStatusSchema)
         let activeIDs = Set(appModel.activePlayerStates.map(\.id))
         let focusedID = appModel.focusedPlayerID.flatMap { activeIDs.contains($0) ? $0 : nil } ?? ""
 

--- a/kiririn/Features/Settings/SettingsView.swift
+++ b/kiririn/Features/Settings/SettingsView.swift
@@ -33,16 +33,17 @@ private struct CacheRecoverySectionContent: View {
                     .font(.headline)
                     .foregroundStyle(.yellow)
 
-                Text("キャッシュの破損を検知しました")
+                Text("一部キャッシュの読み込みに失敗しています")
                     .font(.headline)
             }
 
             Text(
-                "キャッシュの一部データの読み込みに失敗しています。キャッシュを削除しますか？\n削除すると、再生位置履歴・キャプチャ履歴（元ファイル除く）などが削除されます。"
+                "読み込みの失敗は、アプリの二重起動でも起こることがあります。その場合は閉じて開き直すことで解消します。\n繰り返し読み込みに失敗する場合は、キャッシュの削除を行ってください。\n削除すると、再生位置履歴・キャプチャ履歴（元ファイル除く）などが削除されます。"
             )
             .font(.callout)
             .foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)
+            .lineSpacing(4)
 
             Button(role: .destructive, action: onDelete) {
                 Label(

--- a/kiririnTests/DataBroadcastCaptureLayoutTests.swift
+++ b/kiririnTests/DataBroadcastCaptureLayoutTests.swift
@@ -1,0 +1,38 @@
+import CoreGraphics
+import Testing
+
+@testable import kiririn
+
+struct DataBroadcastCaptureLayoutTests {
+    @Test func cropsLandscapeCaptureToStageBounds() throws {
+        let layout = try #require(
+            DataBroadcastCaptureLayout(
+                sourceFrame: CGRect(x: 48.5, y: 0, width: 1920, height: 1080),
+                videoFrame: CGRect(x: 640, y: 60, width: 1200, height: 675),
+                outputHeight: 1080
+            )
+        )
+
+        #expect(layout.canvasSize == CGSize(width: 1920, height: 1080))
+        #expect(layout.videoFrame == CGRect(x: 591.5, y: 60, width: 1200, height: 675))
+    }
+
+    @Test func cropsPortraitCaptureToLandscapeStageBounds() throws {
+        let stageHeight = 559 * 9.0 / 16.0
+        let stageFrame = CGRect(x: 0, y: (1080 - stageHeight) / 2, width: 559, height: stageHeight)
+        let layout = try #require(
+            DataBroadcastCaptureLayout(
+                sourceFrame: stageFrame,
+                videoFrame: stageFrame,
+                outputHeight: 1080
+            )
+        )
+
+        #expect(abs(layout.canvasSize.width - 1920) < 0.001)
+        #expect(layout.canvasSize.height == 1080)
+        #expect(layout.videoFrame.minX == 0)
+        #expect(layout.videoFrame.minY == 0)
+        #expect(abs(layout.videoFrame.width - 1920) < 0.001)
+        #expect(layout.videoFrame.height == 1080)
+    }
+}

--- a/web/bml/src/index.ts
+++ b/web/bml/src/index.ts
@@ -231,28 +231,35 @@ function reapplyStageScale(): void {
     if (lastResolution != null) {
         applyStageScale(lastResolution.width, lastResolution.height);
     }
-    postVideoRect();
+    postLayoutRects();
 }
 window.addEventListener("resize", reapplyStageScale);
 // The WKWebView may still be zero-sized (or resize without a window resize
 // event) around document load; ResizeObserver catches every geometry change.
 new ResizeObserver(reapplyStageScale).observe(document.documentElement);
 
-// Always measure the video plane fresh instead of trusting videochanged's
+// Always measure the stage and video plane fresh instead of trusting videochanged's
 // payload: web-bml fires videochanged during document load, BEFORE the stage
 // transform for the new document is applied (the load event comes after),
 // and it doesn't re-fire when only the transform changes. Re-measuring here
 // (and re-posting on load/resize) keeps the native rect in real WKWebView
 // points. A document without a video object clears the rect (native side
 // then shows the video full-bleed).
-function postVideoRect(): void {
+function postLayoutRects(): void {
+    const stageRect = stage.getBoundingClientRect();
     const videoElement = bmlBrowser.getVideoElement();
-    if (videoElement == null) {
-        postToNative({ type: "videoRect", x: 0, y: 0, width: 0, height: 0 });
-        return;
-    }
-    const rect = videoElement.getBoundingClientRect();
-    postToNative({ type: "videoRect", x: rect.x, y: rect.y, width: rect.width, height: rect.height });
+    const videoRect = videoElement?.getBoundingClientRect();
+    postToNative({
+        type: "layoutRects",
+        stageX: stageRect.x,
+        stageY: stageRect.y,
+        stageWidth: stageRect.width,
+        stageHeight: stageRect.height,
+        videoX: videoRect?.x ?? 0,
+        videoY: videoRect?.y ?? 0,
+        videoWidth: videoRect?.width ?? 0,
+        videoHeight: videoRect?.height ?? 0,
+    });
 }
 
 bmlBrowser.addEventListener("load", (evt) => {
@@ -266,7 +273,7 @@ bmlBrowser.addEventListener("load", (evt) => {
     // The transform for this document was just (re)applied; re-measure the
     // video plane so any videochanged fired mid-load (pre-transform) is
     // corrected, and documents without a video object clear the stale rect.
-    postVideoRect();
+    postLayoutRects();
     postToNative({
         type: "loaded",
         width: evt.detail.resolution.width,
@@ -280,7 +287,7 @@ bmlBrowser.addEventListener("videochanged", (evt) => {
     console.info(
         `[kiririn-bml] videochanged: ${rect.x},${rect.y} ${rect.width}x${rect.height}`,
     );
-    postVideoRect();
+    postLayoutRects();
 });
 
 bmlBrowser.addEventListener("invisible", (evt) => {

--- a/web/bml/src/types.ts
+++ b/web/bml/src/types.ts
@@ -39,7 +39,17 @@ export type WebToNativeMessage =
           audioIndex: number | null;
       }
     | { type: "loaded"; width: number; height: number; profile: string }
-    | { type: "videoRect"; x: number; y: number; width: number; height: number }
+    | {
+          type: "layoutRects";
+          stageX: number;
+          stageY: number;
+          stageWidth: number;
+          stageHeight: number;
+          videoX: number;
+          videoY: number;
+          videoWidth: number;
+          videoHeight: number;
+      }
     | { type: "invisible"; value: boolean }
     | { type: "receiving"; value: boolean }
     | { type: "networking"; value: boolean }

--- a/web/bml/static/bml.html
+++ b/web/bml/static/bml.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover" />
 <title>kiririn BML</title>
 <style>
   html, body {


### PR DESCRIPTION
Fixes #47 

This pull request contains several improvements to how overlay plugins and data broadcast overlays are composited and managed in the player, as well as enhancements to plugin-webview communication and UI refinements for overlay display. The most significant changes include reordering the overlay compositing process, improving the calculation and propagation of video and stage rectangles, and providing more detailed status information to plugins. Additionally, there are UI improvements for overlay rendering and clearer messaging for cache errors.

**Overlay compositing and rendering improvements:**
- Changed the overlay compositing order so that the data broadcast overlay is composited before plugin overlays, ensuring the correct visual stacking and more accurate screenshots. (`CaptureService.swift`)
- Improved how video and stage rectangles are calculated and propagated in `DataBroadcastSession`, including using both stage and video rectangles and passing them to overlays and snapshots for accurate positioning and scaling. (`DataBroadcastSession.swift`) [[1]](diffhunk://#diff-c663500d1807c38aa9c78fffdaf5856560eac5ffae4432eb8c820826ea7f3241R12-R31) [[2]](diffhunk://#diff-c663500d1807c38aa9c78fffdaf5856560eac5ffae4432eb8c820826ea7f3241R73) [[3]](diffhunk://#diff-c663500d1807c38aa9c78fffdaf5856560eac5ffae4432eb8c820826ea7f3241L72-R105) [[4]](diffhunk://#diff-c663500d1807c38aa9c78fffdaf5856560eac5ffae4432eb8c820826ea7f3241L582-R619)
- Updated overlay view rendering logic on both iOS and macOS to ensure overlays are clipped, positioned, and layered correctly, and to prevent hit testing interference. (`PlayerOverlayView.swift`, `DetachedPlayerOverlayView.swift`) [[1]](diffhunk://#diff-ad8c864ccf18b9088c902f974431188959e183848a0e00f0f796cd652ab200cfR314-R333) [[2]](diffhunk://#diff-ad8c864ccf18b9088c902f974431188959e183848a0e00f0f796cd652ab200cfL326-L343) [[3]](diffhunk://#diff-c3106c6f27a8e022739bd8b9a5c9a209bf13a8f0d8c57362f5fc45945aa7a383L89-R99) [[4]](diffhunk://#diff-c3106c6f27a8e022739bd8b9a5c9a209bf13a8f0d8c57362f5fc45945aa7a383L101-L118)

**Plugin-webview communication and status schema:**
- Enhanced the plugin bridge version and status schema sent to plugins, including normalized display rectangles and additional playback state details, so plugins can better align overlays with the video. (`PluginWebView.swift`) [[1]](diffhunk://#diff-85f06eabbfbd1f65c291cd9610eaadb03fd4acaa9731232b8241445574755a79L191-R191) [[2]](diffhunk://#diff-85f06eabbfbd1f65c291cd9610eaadb03fd4acaa9731232b8241445574755a79L252-R252) [[3]](diffhunk://#diff-85f06eabbfbd1f65c291cd9610eaadb03fd4acaa9731232b8241445574755a79L299-R330)
- Updated the state hash in `PluginOverlayView` to include video rectangle and BML visibility, ensuring overlays update when these properties change. (`PluginOverlayView.swift`)

**UI and UX improvements:**
- Improved the cache error message in the settings view to provide clearer guidance and more user-friendly language. (`SettingsView.swift`)

**Other technical improvements:**
- Adjusted plugin overlay snapshot sizing and aspect ratio calculations to match the composited data broadcast layout when present, ensuring correct overlay alignment in screenshots. (`PlayerState.swift`)
- Set `contentInsetAdjustmentBehavior` to `.never` for the webview scroll view to prevent unwanted content insets. (`DataBroadcastSession.swift`)

## Summary by Sourcery

実際のステージ上の動画領域に合わせて、データ放送レイアウト、プラグインオーバーレイ、およびキャプチャコンポジションを整合させるとともに、各プレイヤーの正規化された表示領域を公開するようプラグインブリッジを拡張します。

New Features:
- bridgeVersion 5 と再生ステータススキーマの更新を通じて、プラグインに対しプレイヤーの正規化された表示矩形を公開します。

Bug Fixes:
- データ放送キャプチャがステージ境界に対してクロップされるよう修正し、プラグインオーバーレイのコンポジション順序を画面上のレイヤー構成と整合させます。
- iOS および macOS において、セーフエリアの扱いやキャプチャ時のアスペクト比を含め、プラグインオーバーレイとデータ放送が実際のプレイヤー表面と整合するようにします。
- Web BML からネイティブへステージ矩形と動画矩形の両方を送信し、ステージ領域のみをスナップショットすることで、データ放送レイアウトメッセージングを修正します。

Enhancements:
- 復旧手順をよりわかりやすく説明するため、設定画面におけるキャッシュ破損警告の文言とタイポグラフィを改善します。
- データ放送をフルブリードかつセーフエリア対応でレンダリングするため、BML WKWebView のビューポートおよびスクロールインセットの処理を調整します。

Tests:
- 異なるステージおよび動画のアスペクト比に対するスケーリングとクロッピング動作を検証するため、`DataBroadcastCaptureLayout` のユニットテストを追加します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align data broadcast layouts, plugin overlays, and capture composition with the actual staged video area while extending the plugin bridge to expose normalized display regions for each player.

New Features:
- Expose normalized player display rectangles to plugins via bridgeVersion 5 and playback status schema updates.

Bug Fixes:
- Correct data broadcast capture to crop against the stage bounds and align plugin overlay composition order with on-screen layering.
- Ensure plugin overlays and data broadcasts align with the actual player surface on iOS and macOS, including safe area handling and aspect ratio during capture.
- Fix data broadcast layout messaging by posting both stage and video rects from web BML to native and snapshotting only the stage region.

Enhancements:
- Refine cache corruption warning copy and typography in settings to better explain recovery steps.
- Adjust BML WKWebView viewport and scroll inset handling for full-bleed, safe-area-aware rendering of data broadcasts.

Tests:
- Add unit tests for DataBroadcastCaptureLayout to validate scaling and cropping behavior for different stage and video aspect ratios.

</details>