### PR TITLE
feat: Cookie認証を使用できるように

### DIFF
--- a/kiririn/Features/Server/ServerEditView.swift
+++ b/kiririn/Features/Server/ServerEditView.swift
@@ -445,6 +445,7 @@ private enum ServerAuthMethod: String, CaseIterable, Identifiable {
     case none
     case basic
     case bearer
+    case cookie
 
     var id: String { rawValue }
 
@@ -453,6 +454,7 @@ private enum ServerAuthMethod: String, CaseIterable, Identifiable {
         case .none: return "なし"
         case .basic: return "Basic"
         case .bearer: return "Bearer"
+        case .cookie: return "Cookie"
         }
     }
 }
@@ -463,6 +465,7 @@ private struct ServerAuthEditor: View {
     @State private var username: String = ""
     @State private var password: String = ""
     @State private var token: String = ""
+    @State private var cookie: String = ""
 
     var body: some View {
         Section("認証") {
@@ -491,6 +494,13 @@ private struct ServerAuthEditor: View {
                     .textContentType(.password)
                     .onChange(of: token) { _, _ in updateAuth() }
             }
+
+            if method == .cookie {
+                TextField("Cookie", text: $cookie)
+                    .autocorrectionDisabled()
+                    .kiririnPlainTextInputModifiers()
+                    .onChange(of: cookie) { _, _ in updateAuth() }
+            }
         }
         .onAppear {
             switch auth {
@@ -501,6 +511,9 @@ private struct ServerAuthEditor: View {
             case .bearer(let token):
                 method = .bearer
                 self.token = token
+            case .cookie(let cookie):
+                method = .cookie
+                self.cookie = cookie
             default:
                 method = .none
             }
@@ -522,6 +535,12 @@ private struct ServerAuthEditor: View {
                 auth = .none
             } else {
                 auth = .bearer(token: token)
+            }
+        case .cookie:
+            if cookie.isEmpty {
+                auth = .none
+            } else {
+                auth = .cookie(cookie: cookie)
             }
         }
     }

--- a/kiririn/Shared/Infrastructure/APIClient.swift
+++ b/kiririn/Shared/Infrastructure/APIClient.swift
@@ -28,6 +28,10 @@ nonisolated final class APIClient: Sendable {
             if !token.isEmpty {
                 headers["Authorization"] = "Bearer \(token)"
             }
+        case .cookie(let cookie):
+            if !cookie.isEmpty {
+                headers["Cookie"] = cookie
+            }
         case .none, .oauth2:
             break
         }

--- a/kiririn/Shared/Models/ServerConfiguration.swift
+++ b/kiririn/Shared/Models/ServerConfiguration.swift
@@ -53,6 +53,7 @@ nonisolated enum ServerAuth: Codable, Equatable, Sendable {
     case none
     case basic(username: String, password: String)
     case bearer(token: String)
+    case cookie(cookie: String)
     case oauth2(accessToken: String?, refreshToken: String?, expiryDate: Date?)
 }
 

--- a/kiririnTests/APIClientDiagnosticsTests.swift
+++ b/kiririnTests/APIClientDiagnosticsTests.swift
@@ -9,6 +9,19 @@ struct APIClientDiagnosticsTests {
         let programs: [String]
     }
 
+    @Test func cookieAuthAddsCookieHeader() {
+        let configuration = ServerConfiguration(
+            name: "Main",
+            type: .mirakurun,
+            baseURL: "https://example.com",
+            auth: .cookie(cookie: "session=abc123")
+        )
+
+        let client = APIClient(configuration: configuration)
+
+        #expect(client.defaultHeaders["Cookie"] == "session=abc123")
+    }
+
     @Test func decodingDiagnosticReportsJSONErrorIndexAndControlCharacterSnippet() throws {
         let data =
             Data(#"{"programs":["正常"#.utf8)


### PR DESCRIPTION
Fixes #50

## Summary by Sourcery

Cookie ベースのサーバー認証をサポートし、API リクエストに正しく伝播されるようにしました。

新機能:
- Cookie ベースの認証方法でサーバーを設定できるようにしました。
- 設定された Cookie を、API リクエスト用のデフォルト HTTP ヘッダーに含めるようにしました。

テスト:
- Cookie ベース認証によって `Cookie` ヘッダーが設定されることを検証する診断テストを追加しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for cookie-based server authentication and ensure it is correctly propagated to API requests.

New Features:
- Allow configuring servers with a cookie-based authentication method.
- Include the configured cookie in the default HTTP headers for API requests.

Tests:
- Add a diagnostic test verifying that cookie-based authentication sets the Cookie header.

</details>