### PR TITLE
feat: DeepLinkからプラグインをインストールできるようにする

### DIFF
--- a/kiririn/AppShell/AppModel.swift
+++ b/kiririn/AppShell/AppModel.swift
@@ -286,6 +286,11 @@ final class AppModel {
     }
 
     private func handlePluginDeepLink(components: URLComponents) {
+        if PluginInstallDeepLink.isInstallRequest(components) {
+            handlePluginInstallDeepLink(components: components)
+            return
+        }
+
         let pathComponents = components.path.split(separator: "/").map(String.init)
         guard let manifestID = pathComponents.first, !manifestID.isEmpty else {
             logger.warning("deep link plugins rejected: missing manifest id")
@@ -314,6 +319,31 @@ final class AppModel {
             ]
         )
         logger.info("deep link plugin callback queued: manifestID=\(manifestID)")
+    }
+
+    private func handlePluginInstallDeepLink(components: URLComponents) {
+        guard let request = PluginInstallDeepLink(components: components) else {
+            logger.warning("deep link plugin install rejected: invalid parameters")
+            pendingPluginInstallErrorMessage =
+                "プラグインの追加URLにupdateManifestUrlまたはmanifestIDが正しく設定されていません"
+            return
+        }
+
+        Task {
+            do {
+                let preview = try await pluginStore.previewPlugin(
+                    fromUpdateManifestURL: request.updateManifestURL,
+                    manifestID: request.manifestID
+                )
+                pendingPluginInstallPreviews.append(preview)
+                logger.info("deep link plugin install resolved: manifestID=\(request.manifestID)")
+            } catch {
+                logger.warning(
+                    "deep link plugin install failed: manifestID=\(request.manifestID), error=\(error.localizedDescription)"
+                )
+                pendingPluginInstallErrorMessage = error.localizedDescription
+            }
+        }
     }
 
     private func parseMediaURL(from components: URLComponents) -> URL? {

--- a/kiririn/AppShell/AppModel.swift
+++ b/kiririn/AppShell/AppModel.swift
@@ -329,7 +329,7 @@ final class AppModel {
             return
         }
 
-        Task {
+        Task { @MainActor in
             do {
                 let preview = try await pluginStore.previewPlugin(
                     fromUpdateManifestURL: request.updateManifestURL,

--- a/kiririn/Features/Plugin/PluginInstallDeepLink.swift
+++ b/kiririn/Features/Plugin/PluginInstallDeepLink.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+struct PluginInstallDeepLink: Equatable {
+    static let updateManifestURLQueryName = "updateManifestUrl"
+
+    let updateManifestURL: URL
+    let manifestID: String
+
+    static func isInstallRequest(_ components: URLComponents) -> Bool {
+        components.queryItems?.contains(where: {
+            $0.name == updateManifestURLQueryName
+        }) == true
+    }
+
+    init?(components: URLComponents) {
+        let queryItems = components.queryItems ?? []
+        guard
+            let rawUpdateManifestURL = queryItems.first(where: {
+                $0.name == Self.updateManifestURLQueryName
+            })?.value,
+            let updateManifestURL = URL(string: rawUpdateManifestURL),
+            let scheme = updateManifestURL.scheme?.lowercased(),
+            ["http", "https"].contains(scheme),
+            let manifestID = queryItems.first(where: { $0.name == "manifestID" })?.value?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+            !manifestID.isEmpty
+        else {
+            return nil
+        }
+
+        self.updateManifestURL = updateManifestURL
+        self.manifestID = manifestID
+    }
+}

--- a/kiririn/Features/Plugin/PluginInstallDeepLink.swift
+++ b/kiririn/Features/Plugin/PluginInstallDeepLink.swift
@@ -17,7 +17,7 @@ struct PluginInstallDeepLink: Equatable {
         guard
             let rawUpdateManifestURL = queryItems.first(where: {
                 $0.name == Self.updateManifestURLQueryName
-            })?.value,
+            })?.value?.trimmingCharacters(in: .whitespacesAndNewlines),
             let updateManifestURL = URL(string: rawUpdateManifestURL),
             let scheme = updateManifestURL.scheme?.lowercased(),
             ["http", "https"].contains(scheme),

--- a/kiririn/Features/Plugin/PluginStore.swift
+++ b/kiririn/Features/Plugin/PluginStore.swift
@@ -1037,6 +1037,53 @@ class PluginStore {
             manifestID: previous.manifestID,
             currentVersion: previous.manifestVersion
         )
+        let preview = try await previewPlugin(
+            fromUpdateManifestEntry: entry,
+            manifestID: previous.manifestID
+        )
+        guard preview.packageAuthentication.isSigned else {
+            throw PluginManifestValidationError(messages: [
+                "アップデートで取得したパッケージに署名がありません"
+            ])
+        }
+        guard
+            matchingSignerKeyHashes(
+                lhs: previous.packageAuthentication.signerKeyHashes,
+                rhs: preview.packageAuthentication.signerKeyHashes
+            )
+        else {
+            throw PluginManifestValidationError(messages: [
+                "アップデートで取得したパッケージの署名鍵が既存パッケージと一致しません"
+            ])
+        }
+
+        try updateResolver.validateUpdateVersion(
+            currentVersion: previous.manifestVersion,
+            candidateVersion: preview.manifest.version
+        )
+
+        return preview
+    }
+
+    func previewPlugin(fromUpdateManifestURL url: URL, manifestID: String) async throws
+        -> PluginInstallPreview
+    {
+        guard let scheme = url.scheme?.lowercased(), ["http", "https"].contains(scheme) else {
+            throw PluginManifestValidationError(messages: ["URLはhttp(s)である必要があります"])
+        }
+
+        let entry = try await updateResolver.resolveUpdateEntry(
+            fromUpdateManifestURL: url,
+            manifestID: manifestID,
+            currentVersion: nil
+        )
+        return try await previewPlugin(fromUpdateManifestEntry: entry, manifestID: manifestID)
+    }
+
+    private func previewPlugin(
+        fromUpdateManifestEntry entry: GeckoUpdateManifestEntry,
+        manifestID: String
+    ) async throws -> PluginInstallPreview {
         guard let packageURL = URL(string: entry.updateLink) else {
             throw PluginManifestValidationError(messages: [
                 "アップデートのダウンロードURLが有効ではありません"
@@ -1070,34 +1117,14 @@ class PluginStore {
             entryVersion: entry.version,
             packageVersion: preview.manifest.version
         )
-        guard preview.packageAuthentication.isSigned else {
-            throw PluginManifestValidationError(messages: [
-                "アップデートで取得したパッケージに署名がありません"
-            ])
-        }
-        guard
-            matchingSignerKeyHashes(
-                lhs: previous.packageAuthentication.signerKeyHashes,
-                rhs: preview.packageAuthentication.signerKeyHashes
-            )
-        else {
-            throw PluginManifestValidationError(messages: [
-                "アップデートで取得したパッケージの署名鍵が既存パッケージと一致しません"
-            ])
-        }
         guard case .package = preview.payload else {
             throw PluginManifestValidationError(messages: ["プラグインパッケージの読み込みに失敗しました"])
         }
-        guard preview.manifest.manifestID == previous.manifestID else {
+        guard preview.manifest.manifestID == manifestID else {
             throw PluginManifestValidationError(messages: [
-                "プラグインIDが一致しません。別のプラグインパッケージのため更新を中止しました"
+                "プラグインIDが一致しません。別のプラグインパッケージのため処理を中止しました"
             ])
         }
-
-        try updateResolver.validateUpdateVersion(
-            currentVersion: previous.manifestVersion,
-            candidateVersion: preview.manifest.version
-        )
 
         return preview
     }

--- a/kiririnTests/PluginInstallDeepLinkTests.swift
+++ b/kiririnTests/PluginInstallDeepLinkTests.swift
@@ -35,6 +35,20 @@ struct PluginInstallDeepLinkTests {
         #expect(PluginInstallDeepLink(components: components) == nil)
     }
 
+    @Test func trimsUpdateManifestURL() throws {
+        let url = try #require(
+            URL(
+                string:
+                    "kiririn://plugins/?updateManifestUrl=%20https://example.com/update.json%20&manifestID=com.example.plugin"
+            ))
+        let components = try #require(
+            URLComponents(url: url, resolvingAgainstBaseURL: false)
+        )
+        let request = try #require(PluginInstallDeepLink(components: components))
+
+        #expect(request.updateManifestURL.absoluteString == "https://example.com/update.json")
+    }
+
     @Test func rejectsNonHTTPUpdateManifestURL() throws {
         let url = try #require(
             URL(

--- a/kiririnTests/PluginInstallDeepLinkTests.swift
+++ b/kiririnTests/PluginInstallDeepLinkTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+
+@testable import kiririn
+
+struct PluginInstallDeepLinkTests {
+    @Test func parsesUpdateManifestInstallRequest() throws {
+        let url = try #require(
+            URL(
+                string:
+                    "kiririn://plugins/?updateManifestUrl=https://cdn.jsdelivr.net/gh/ci7lus/kiririn-plugins@main/update.json&manifestID=io.github.ci7lus.kiririn-plugins.nicojk"
+            ))
+        let components = try #require(
+            URLComponents(url: url, resolvingAgainstBaseURL: false)
+        )
+        let request = try #require(PluginInstallDeepLink(components: components))
+
+        #expect(
+            request.updateManifestURL.absoluteString
+                == "https://cdn.jsdelivr.net/gh/ci7lus/kiririn-plugins@main/update.json"
+        )
+        #expect(request.manifestID == "io.github.ci7lus.kiririn-plugins.nicojk")
+    }
+
+    @Test func rejectsMissingManifestID() throws {
+        let url = try #require(
+            URL(
+                string:
+                    "kiririn://plugins/?updateManifestUrl=https://example.com/update.json"
+            ))
+        let components = try #require(
+            URLComponents(url: url, resolvingAgainstBaseURL: false)
+        )
+
+        #expect(PluginInstallDeepLink(components: components) == nil)
+    }
+
+    @Test func rejectsNonHTTPUpdateManifestURL() throws {
+        let url = try #require(
+            URL(
+                string:
+                    "kiririn://plugins/?updateManifestUrl=file:///tmp/update.json&manifestID=com.example.plugin"
+            ))
+        let components = try #require(
+            URLComponents(url: url, resolvingAgainstBaseURL: false)
+        )
+
+        #expect(PluginInstallDeepLink(components: components) == nil)
+    }
+}


### PR DESCRIPTION
Fixes #54

## Summary by Sourcery

ディープリンクからのインストールパラメータを解析し、アップデートマニフェストから対象プラグインのプレビューを行い、その結果やエラーをアプリモデル上に表示することで、プラグインのインストールをサポートします。

New Features:
- アップデートマニフェストの URL とマニフェスト ID を指定するディープリンク経由でプラグインをインストールできるようにします。

Enhancements:
- プラグインプレビューのロジックをリファクタリングし、アップデートマニフェスト URL からのプレビューに対応するとともに、より厳格なマニフェスト ID チェックを含む共通バリデーションを再利用するようにします。

Tests:
- プラグインインストール用ディープリンクのパラメータ解析およびバリデーションの挙動を検証する単体テストを追加し、パラメータ不足や無効なパラメータに対するエラーケースもカバーします。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for installing plugins from deep links by parsing install parameters, previewing the target plugin from its update manifest, and surfacing the result or errors in the app model.

New Features:
- Allow plugins to be installed via deep links that specify an update manifest URL and manifest ID.

Enhancements:
- Refactor plugin preview logic to support previewing from an update manifest URL and to reuse common validation, including stricter manifest ID checks.

Tests:
- Add unit tests to validate parsing and validation behavior of plugin install deep links, including error cases for missing or invalid parameters.

</details>