### PR TITLE
fix: ApkSignatureVerifierKitをアプリと同じTeam IDで署名する

### DIFF
--- a/kiririn.xcodeproj/project.pbxproj
+++ b/kiririn.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		CEA761572FDC65F200C55CC4 /* ApkSignatureVerifierKit in Frameworks */ = {isa = PBXBuildFile; productRef = CEA761562FDC65F200C55CC4 /* ApkSignatureVerifierKit */; };
 		CEA761592FDC66F500C55CC4 /* ApkSignatureVerifierKit in Frameworks */ = {isa = PBXBuildFile; productRef = CEA761582FDC66F500C55CC4 /* ApkSignatureVerifierKit */; };
 		CEA7615E2FDC6B1C00C55CC4 /* ARIBStandardKit in Frameworks */ = {isa = PBXBuildFile; productRef = CEA7615D2FDC6B1C00C55CC4 /* ARIBStandardKit */; };
+		CEA761602FDD000000C55CC4 /* ApkSignatureVerifierKit in Embed Frameworks */ = {isa = PBXBuildFile; productRef = CEA761562FDC65F200C55CC4 /* ApkSignatureVerifierKit */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,6 +48,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				CEA761602FDD000000C55CC4 /* ApkSignatureVerifierKit in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## 概要

macOSで起動時に`ApkSignatureVerifierKit.framework`とアプリのTeam IDが一致せず、dyldエラーになる問題を修正します。

## 変更内容

- `ApkSignatureVerifierKit`をEmbed Frameworksへ追加
- コピー時にアプリと同じ署名を適用

## 確認

- macOS向けDebugビルド成功
- フレームワークがアプリ内へ埋め込まれることを確認
- アプリとフレームワークのTeam IDが一致することを確認

## Summary by Sourcery

Build:
- macOSアプリターゲットに `ApkSignatureVerifierKit.framework` を埋め込むようにXcodeプロジェクト設定を更新し、コード署名のためにアプリのTeam IDを適用しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update Xcode project settings to embed ApkSignatureVerifierKit.framework in the macOS app target and apply the app’s Team ID for code signing.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- macOSアプリターゲットに `ApkSignatureVerifierKit.framework` を埋め込むようにXcodeプロジェクト設定を更新し、コード署名のためにアプリのTeam IDを適用しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update Xcode project settings to embed ApkSignatureVerifierKit.framework in the macOS app target and apply the app’s Team ID for code signing.

</details>

</details>