### PR TITLE
fix: データ放送モジュールの再取得でキャッシュを迂回

### DIFF
--- a/kiririn/Features/Player/DataBroadcast/DataBroadcastSession.swift
+++ b/kiririn/Features/Player/DataBroadcast/DataBroadcastSession.swift
@@ -519,7 +519,8 @@ final class DataBroadcastSession {
             from: endpoint.moduleVersionURL(
                 componentTag: request.componentTag, downloadId: request.downloadId,
                 moduleId: request.moduleId, version: request.version),
-            headers: headers)
+            headers: headers,
+            bypassCache: true)
         guard
             let manifest = try? JSONDecoder().decode(
                 MahironModuleManifest.self, from: manifestData)
@@ -576,10 +577,17 @@ final class DataBroadcastSession {
         }
     }
 
-    private nonisolated static func fetchData(from url: URL, headers: [String: String]) async throws
-        -> Data
-    {
-        var urlRequest = URLRequest(url: url)
+    private nonisolated static func fetchData(
+        from url: URL,
+        headers: [String: String],
+        bypassCache: Bool = false
+    ) async throws -> Data {
+        var urlRequest = URLRequest(
+            url: url,
+            cachePolicy: bypassCache ? .reloadIgnoringLocalCacheData : .useProtocolCachePolicy)
+        if bypassCache {
+            urlRequest.setValue("no-cache", forHTTPHeaderField: "Cache-Control")
+        }
         for (field, value) in headers {
             urlRequest.setValue(value, forHTTPHeaderField: field)
         }

--- a/kiririn/Features/Player/DataBroadcast/DataBroadcastSession.swift
+++ b/kiririn/Features/Player/DataBroadcast/DataBroadcastSession.swift
@@ -515,12 +515,11 @@ final class DataBroadcastSession {
     /// bytes are content-addressed and safely cacheable by URLSession.
     private func fetchModuleFiles(_ request: FetchRequest) async throws -> [BMLModuleFile] {
         let headers = endpoint.headers
-        let manifestData = try await Self.fetchData(
+        let manifestData = try await Self.fetchDataBypassingCache(
             from: endpoint.moduleVersionURL(
                 componentTag: request.componentTag, downloadId: request.downloadId,
                 moduleId: request.moduleId, version: request.version),
-            headers: headers,
-            bypassCache: true)
+            headers: headers)
         guard
             let manifest = try? JSONDecoder().decode(
                 MahironModuleManifest.self, from: manifestData)
@@ -577,20 +576,28 @@ final class DataBroadcastSession {
         }
     }
 
-    private nonisolated static func fetchData(
-        from url: URL,
-        headers: [String: String],
-        bypassCache: Bool = false
-    ) async throws -> Data {
-        var urlRequest = URLRequest(
-            url: url,
-            cachePolicy: bypassCache ? .reloadIgnoringLocalCacheData : .useProtocolCachePolicy)
-        if bypassCache {
-            urlRequest.setValue("no-cache", forHTTPHeaderField: "Cache-Control")
-        }
+    private nonisolated static func fetchData(from url: URL, headers: [String: String]) async throws
+        -> Data
+    {
+        var urlRequest = URLRequest(url: url)
         for (field, value) in headers {
             urlRequest.setValue(value, forHTTPHeaderField: field)
         }
+        return try await fetchData(for: urlRequest)
+    }
+
+    private nonisolated static func fetchDataBypassingCache(
+        from url: URL, headers: [String: String]
+    ) async throws -> Data {
+        var urlRequest = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData)
+        for (field, value) in headers {
+            urlRequest.setValue(value, forHTTPHeaderField: field)
+        }
+        urlRequest.setValue("no-cache", forHTTPHeaderField: "Cache-Control")
+        return try await fetchData(for: urlRequest)
+    }
+
+    private nonisolated static func fetchData(for urlRequest: URLRequest) async throws -> Data {
         let (data, response) = try await URLSession.shared.data(for: urlRequest)
         guard let http = response as? HTTPURLResponse else {
             throw ModuleFetchFailure.transient("invalid response")


### PR DESCRIPTION
## 概要

データ放送モジュールのマニフェスト取得でHTTP 425が返った後、再ポーリング時にキャッシュ済みの応答を参照し続ける可能性がありました。

## 変更内容

- モジュールマニフェストの取得時だけ`reloadIgnoringLocalCacheData`を指定
- `Cache-Control: no-cache`を付与し、中間キャッシュにも再検証を要求
- 完成後のモジュールリソースについては従来どおり通常のキャッシュ方針を維持

## 検証

- [x] Xcode MCP経由でmacOSビルド成功
- [x] Xcode Issue Navigatorで警告なし
- [ ] iOSビルド（開いているXcodeタブがmacOS実行先で、Xcode MCPから実行先を変更できないため未実施）

## Summary by Sourcery

エラー応答後、データブロードキャストモジュールのマニフェスト再取得時に、ローカルおよび中間キャッシュをバイパスするようにします。

バグ修正:
- HTTPエラー後にデータブロードキャストモジュールのマニフェストを再ポーリングする際、古いキャッシュ応答が再利用されないようにします。

機能拡張:
- より精密なキャッシュ制御をサポートするため、汎用データ取得ヘルパーにオプションのキャッシュバイパスフラグを追加します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure data broadcast module manifest re-fetch bypasses local and intermediate caches after error responses.

Bug Fixes:
- Prevent reuse of stale cached responses when re-polling the data broadcast module manifest after HTTP errors.

Enhancements:
- Add an optional cache-bypass flag to the generic data fetching helper to support more precise cache control.

</details>