### PR TITLE
fix: ウィンドウタイトルに番組名が反映されるように

### DIFF
--- a/kiririn/Features/Player/macOS/PlayerWindowView.swift
+++ b/kiririn/Features/Player/macOS/PlayerWindowView.swift
@@ -41,6 +41,7 @@
             .background(Color.clear)
             .frame(minWidth: 640, minHeight: 360)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .navigationTitle(windowTitle)
             .toolbar(removing: .title)
             .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
             .overlay {
@@ -135,6 +136,16 @@
             playerWindowReference.window
         }
 
+        private var windowTitle: String {
+            let title =
+                playerState.currentPlayable?.title.trimmingCharacters(in: .whitespacesAndNewlines)
+                .replacingARIBEnclosedGlyphsForDisplay()
+            guard let title, !title.isEmpty else {
+                return Self.defaultWindowTitle
+            }
+            return title
+        }
+
         private func configureWindow(_ window: NSWindow) {
             if playerWindow !== window {
                 playerWindowReference.window = window
@@ -159,14 +170,7 @@
 
         private func applyWindowTitle(window: NSWindow?) {
             guard let window else { return }
-            let currentTitle =
-                playerState.currentPlayable?.title.trimmingCharacters(in: .whitespacesAndNewlines)
-                .replacingARIBEnclosedGlyphsForDisplay()
-            if let currentTitle, !currentTitle.isEmpty {
-                setWindowTitle(currentTitle, window: window)
-            } else {
-                setWindowTitle(Self.defaultWindowTitle, window: window)
-            }
+            setWindowTitle(windowTitle, window: window)
         }
 
         private func applyWindowLevel(window: NSWindow?, isAlwaysOnTop: Bool) {

--- a/kiririn/Features/ProgramGuide/ProgramGuideView.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideView.swift
@@ -517,7 +517,11 @@ struct ProgramGuideView: View {
         }
 
         if now >= timelineStart && now < timelineEnd {
-            let targetY = max(0, sectionHeaderHeight + yOffset(for: now) - viewportHeight * 0.2)
+            let requestedY =
+                sectionHeaderHeight + yOffset(for: now) - viewportHeight * 0.2
+            let maximumY = max(
+                0, sectionHeaderHeight + timelineHeight - viewportHeight)
+            let targetY = min(max(0, requestedY), maximumY)
             if animated {
                 withAnimation { updateScrollPosition(toY: targetY) }
             } else {


### PR DESCRIPTION
Fixes #52

## Summary by Sourcery

プレイヤーウィンドウを更新し、現在の番組タイトルを反映するとともに、タイムライン終端付近での番組ガイドの自動スクロール動作を調整しました。

New Features:
- macOS において、再生可能な現在の番組タイトルをウィンドウのナビゲーションタイトルとして表示します。

Bug Fixes:
- 目標スクロール位置を制限することで、番組ガイドの自動スクロールが表示中のタイムライン範囲を行き過ぎてしまうのを防ぎます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the player window to reflect the current program title and refine the program guide auto-scroll behavior near the end of the timeline.

New Features:
- Display the current playable program title as the window navigation title on macOS.

Bug Fixes:
- Prevent program guide auto-scroll from overshooting past the visible timeline by clamping the target scroll position.

</details>