### PR TITLE
feat: リモコン機能を追加

### DIFF
--- a/kiririn.xcodeproj/project.pbxproj
+++ b/kiririn.xcodeproj/project.pbxproj
@@ -65,7 +65,9 @@
 		CE4442832FB8887D0092C2BF /* Exceptions for "kiririn" folder in "kiririn" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				Config.xcconfig,
 				Info.plist,
+				LocalSettings.xcconfig,
 			);
 			platformFiltersByRelativePath = {
 				AppShell/macOS/CaptionWindowView.swift = (macos, );
@@ -264,7 +266,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1600;
-				LastUpgradeCheck = 2630;
+				LastUpgradeCheck = 2660;
 				TargetAttributes = {
 					105FC5792E9EAD3100EA8BCF = {
 						CreatedOnToolsVersion = 16.0;

--- a/kiririn.xcodeproj/project.pbxproj
+++ b/kiririn.xcodeproj/project.pbxproj
@@ -557,7 +557,7 @@
 				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_INCOMING_NETWORK_CONNECTIONS = NO;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
@@ -579,7 +579,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
 				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 ci7lus";
-				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "ローカルネットワーク上のサーバーと通信します。";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "ローカルネットワーク上のサーバーとの通信と、リモコンに使用します。";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -633,7 +633,7 @@
 				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_INCOMING_NETWORK_CONNECTIONS = NO;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
@@ -655,7 +655,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
 				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 ci7lus";
-				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "ローカルネットワーク上のサーバーと通信します。";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "ローカルネットワーク上のサーバーとの通信と、リモコンに使用します。";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/kiririn/AppShell/AppModel.swift
+++ b/kiririn/AppShell/AppModel.swift
@@ -27,6 +27,7 @@ final class AppModel {
     let manager: ServerManager
     let playerState: PlayerState
     let pluginStore: PluginStore
+    let remoteControlService: RemoteControlService
     private(set) var cacheStore: CacheStore?
 
     var activePlayerStates: [PlayerState] = []
@@ -75,12 +76,14 @@ final class AppModel {
         activePlayerStates = [playerState]
         focusedPlayerID = playerState.id
         pluginStore = PluginStore()
+        remoteControlService = RemoteControlService()
         pluginStore.onLocalFolderManifestChanged = { [weak self] pluginID in
             guard let self else { return }
             self.syncPluginsToPlayer()
             self.reloadPluginInAllPlayerStates(id: pluginID.uuidString)
         }
         playerState.plugins = pluginStore.plugins
+        remoteControlService.configure(appModel: self)
     }
 
     func setupIfNeeded() {

--- a/kiririn/AppShell/ContentView.swift
+++ b/kiririn/AppShell/ContentView.swift
@@ -143,6 +143,7 @@ struct ContentView: View {
             .task {
                 appModel.setupIfNeeded()
                 appModel.syncPluginsToPlayer()
+                appModel.remoteControlService.restoreReceiverIfEnabled()
             }
             .onChange(of: pluginStore.plugins) { _, _ in
                 appModel.syncPluginsToPlayer()

--- a/kiririn/Features/Player/DataBroadcast/ARIBRemoteKey.swift
+++ b/kiririn/Features/Player/DataBroadcast/ARIBRemoteKey.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+nonisolated enum BMLKeyGroup: String, Codable, Hashable, Sendable {
+    case basic
+    case numericTuning = "numeric-tuning"
+    case dataButton = "data-button"
+}
+
+nonisolated enum ARIBRemoteKey: Int, Codable, Hashable, Sendable {
+    case up = 1
+    case down = 2
+    case left = 3
+    case right = 4
+    case digit0 = 5
+    case digit1 = 6
+    case digit2 = 7
+    case digit3 = 8
+    case digit4 = 9
+    case digit5 = 10
+    case digit6 = 11
+    case digit7 = 12
+    case digit8 = 13
+    case digit9 = 14
+    case digit10 = 15
+    case digit11 = 16
+    case digit12 = 17
+    case enter = 18
+    case back = 19
+    case data = 20
+    case blue = 21
+    case red = 22
+    case green = 23
+    case yellow = 24
+    case reserved25 = 25
+    case reserved26 = 26
+    case special = 100
+
+    var requiredGroup: BMLKeyGroup? {
+        switch self {
+        case .up, .down, .left, .right, .enter, .back:
+            .basic
+        case .digit0, .digit1, .digit2, .digit3, .digit4, .digit5, .digit6,
+            .digit7, .digit8, .digit9, .digit10, .digit11, .digit12:
+            .numericTuning
+        case .data:
+            nil
+        case .blue, .red, .green, .yellow, .reserved25, .reserved26, .special:
+            .dataButton
+        }
+    }
+
+    static func digit(_ number: Int) -> ARIBRemoteKey? {
+        guard (0...12).contains(number) else { return nil }
+        return ARIBRemoteKey(rawValue: number + 5)
+    }
+}

--- a/kiririn/Features/Player/DataBroadcast/BMLKeyMonitor.swift
+++ b/kiririn/Features/Player/DataBroadcast/BMLKeyMonitor.swift
@@ -58,7 +58,7 @@ final class BMLKeyMonitor {
         guard let key = Self.aribKey(for: event) else {
             return event
         }
-        let contentVisible = session.status == .active && !session.isInvisible
+        let contentVisible = session.status == .active && session.isContentVisible
 
         guard event.type == .keyDown else {
             // keyUp is always delivered for mapped keys: web-bml holds

--- a/kiririn/Features/Player/DataBroadcast/BMLKeyMonitor.swift
+++ b/kiririn/Features/Player/DataBroadcast/BMLKeyMonitor.swift
@@ -55,7 +55,7 @@ final class BMLKeyMonitor {
         guard event.modifierFlags.intersection([.command, .control]).isEmpty else {
             return event
         }
-        guard let code = Self.aribKeyCode(for: event) else {
+        guard let key = Self.aribKey(for: event) else {
             return event
         }
         let contentVisible = session.status == .active && !session.isInvisible
@@ -66,7 +66,7 @@ final class BMLKeyMonitor {
             // the declared groups / visibility may have changed in between
             // (e.g. the press itself navigated or closed the content) -
             // dropping the up would wedge all subsequent key handling.
-            session.sendKey(down: false, aribKeyCode: code)
+            session.sendKey(down: false, aribKeyCode: key.rawValue)
             return contentVisible ? nil : event
         }
 
@@ -78,45 +78,34 @@ final class BMLKeyMonitor {
         // behavior), but the swallow is unconditional: usedKeyList
         // arrives async from JS and is briefly empty/stale across page
         // transitions.
-        if session.usedKeyGroups.contains(Self.keyGroup(for: code)) {
+        if let requiredGroup = key.requiredGroup,
+            session.usedKeyGroups.contains(requiredGroup.rawValue)
+        {
             if event.isARepeat {
                 // web-bml ignores further keyDowns until the previous
                 // press completes with a keyUp (keyProcessStatus), so
                 // expand OS key repeats into full up->down cycles to get
                 // hold-to-repeat navigation.
-                session.sendKey(down: false, aribKeyCode: code)
+                session.sendKey(down: false, aribKeyCode: key.rawValue)
             }
-            session.sendKey(down: true, aribKeyCode: code)
+            session.sendKey(down: true, aribKeyCode: key.rawValue)
         }
         return nil
     }
 
     // MARK: - AribKeyCode mapping (see web-bml/client/content.ts's AribKeyCode)
 
-    private static func keyGroup(for aribKeyCode: Int) -> String {
-        switch aribKeyCode {
-        case 1, 2, 3, 4, 18, 19:
-            return "basic"
-        case 5...17:
-            return "numeric-tuning"
-        case 20...26, 100:
-            return "data-button"
-        default:
-            return ""
-        }
-    }
-
-    private static func aribKeyCode(for event: NSEvent) -> Int? {
+    private static func aribKey(for event: NSEvent) -> ARIBRemoteKey? {
         // Plain arrows are the player's volume/seek keys, so BML
         // navigation requires ⌥ - see the type-level comment.
         let hasOption = event.modifierFlags.contains(.option)
         switch event.keyCode {
-        case 126: return hasOption ? 1 : nil  // ⌥Up
-        case 125: return hasOption ? 2 : nil  // ⌥Down
-        case 123: return hasOption ? 3 : nil  // ⌥Left
-        case 124: return hasOption ? 4 : nil  // ⌥Right
-        case 36: return 18  // Return -> Enter
-        case 51, 53: return 19  // Delete/Escape -> Back
+        case 126: return hasOption ? .up : nil
+        case 125: return hasOption ? .down : nil
+        case 123: return hasOption ? .left : nil
+        case 124: return hasOption ? .right : nil
+        case 36: return .enter
+        case 51, 53: return .back
         default: break
         }
         guard let scalar = event.charactersIgnoringModifiers?.unicodeScalars.first,
@@ -125,23 +114,23 @@ final class BMLKeyMonitor {
             return nil
         }
         switch Character(scalar).lowercased() {
-        case "0": return 5
-        case "1": return 6
-        case "2": return 7
-        case "3": return 8
-        case "4": return 9
-        case "5": return 10
-        case "6": return 11
-        case "7": return 12
-        case "8": return 13
-        case "9": return 14
+        case "0": return .digit0
+        case "1": return .digit1
+        case "2": return .digit2
+        case "3": return .digit3
+        case "4": return .digit4
+        case "5": return .digit5
+        case "6": return .digit6
+        case "7": return .digit7
+        case "8": return .digit8
+        case "9": return .digit9
         // "d" is intentionally not mapped to AribKeyCode.DataButton (20) -
         // it's reserved for the native overlay toggle (see
         // DetachedPlayerOverlayView_macOS's d-button/shortcut).
-        case "b": return 21  // BlueButton
-        case "r": return 22  // RedButton
-        case "g": return 23  // GreenButton
-        case "y": return 24  // YellowButton
+        case "b": return .blue
+        case "r": return .red
+        case "g": return .green
+        case "y": return .yellow
         default: return nil
         }
     }

--- a/kiririn/Features/Player/DataBroadcast/BMLRemoteControlAvailability.swift
+++ b/kiririn/Features/Player/DataBroadcast/BMLRemoteControlAvailability.swift
@@ -1,0 +1,14 @@
+nonisolated struct BMLRemoteControlAvailability: Equatable, Sendable {
+    let isDataButtonEnabled: Bool
+    let enabledGroups: Set<BMLKeyGroup>
+
+    func isEnabled(_ key: ARIBRemoteKey) -> Bool {
+        guard isDataButtonEnabled else {
+            return false
+        }
+        guard let requiredGroup = key.requiredGroup else {
+            return true
+        }
+        return enabledGroups.contains(requiredGroup)
+    }
+}

--- a/kiririn/Features/Player/DataBroadcast/BMLRemoteControlPad.swift
+++ b/kiririn/Features/Player/DataBroadcast/BMLRemoteControlPad.swift
@@ -1,0 +1,200 @@
+import SwiftUI
+
+/// プレイヤー内と遠隔操作画面で共用するデータ放送リモコン。
+/// キー送信先は呼び出し側が注入し、このViewは配置と有効状態だけを扱う。
+struct BMLRemoteControlPad: View {
+    enum Layout {
+        case panel
+        case touch
+    }
+
+    let layout: Layout
+    let availability: BMLRemoteControlAvailability
+    var showsDataButton = true
+    let onPress: (ARIBRemoteKey) -> Void
+
+    private var buttonHeight: CGFloat {
+        switch layout {
+        case .panel:
+            26
+        case .touch:
+            44
+        }
+    }
+
+    private var buttonFontSize: CGFloat {
+        switch layout {
+        case .panel:
+            12
+        case .touch:
+            16
+        }
+    }
+
+    private var directionalButtonWidth: CGFloat? {
+        switch layout {
+        case .panel:
+            52
+        case .touch:
+            nil
+        }
+    }
+
+    private var cornerRadius: CGFloat {
+        layout == .touch ? 10 : 6
+    }
+
+    var body: some View {
+        VStack(spacing: 10) {
+            dataButtonRow
+            arrowPad
+            colorButtonRow
+            digitGrid
+        }
+        .padding(layout == .touch ? 0 : 12)
+        .frame(
+            minWidth: layout == .panel ? 196 : nil,
+            maxWidth: layout == .panel ? 196 : .infinity
+        )
+    }
+
+    private var dataButtonRow: some View {
+        HStack(spacing: 8) {
+            if showsDataButton {
+                remoteKey(.data, help: "d") {
+                    HStack(spacing: 4) {
+                        Text("d").italic().bold()
+                        Text("ボタン")
+                    }
+                }
+                .accessibilityLabel("dボタン")
+            }
+
+            remoteKey(.back, help: "Delete / Esc") {
+                Text("戻る")
+            }
+            .accessibilityLabel("戻る")
+        }
+    }
+
+    private var arrowPad: some View {
+        VStack(spacing: 6) {
+            arrowKey("chevron.up", label: "上", key: .up, help: "⌥↑")
+            HStack(spacing: 6) {
+                arrowKey("chevron.left", label: "左", key: .left, help: "⌥←")
+                remoteKey(.enter, help: "Return") {
+                    Text("決定")
+                }
+                .frame(width: directionalButtonWidth)
+                .accessibilityLabel("決定")
+                arrowKey("chevron.right", label: "右", key: .right, help: "⌥→")
+            }
+            arrowKey("chevron.down", label: "下", key: .down, help: "⌥↓")
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func arrowKey(
+        _ systemImage: String,
+        label: String,
+        key: ARIBRemoteKey,
+        help: String
+    ) -> some View {
+        remoteKey(key, help: help) {
+            Image(systemName: systemImage)
+        }
+        .frame(width: directionalButtonWidth)
+        .buttonRepeatBehavior(.enabled)
+        .accessibilityLabel(label)
+    }
+
+    private var colorButtonRow: some View {
+        HStack(spacing: 6) {
+            colorKey("青", color: .blue, key: .blue, help: "b")
+            colorKey("赤", color: .red, key: .red, help: "r")
+            colorKey("緑", color: .green, key: .green, help: "g")
+            colorKey("黄", color: .yellow, key: .yellow, help: "y")
+        }
+    }
+
+    private func colorKey(
+        _ label: String,
+        color: Color,
+        key: ARIBRemoteKey,
+        help: String
+    ) -> some View {
+        Button {
+            onPress(key)
+        } label: {
+            Text(label)
+                .font(.system(size: buttonFontSize, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity)
+                .frame(height: buttonHeight)
+                .background(color.opacity(0.75), in: RoundedRectangle(cornerRadius: cornerRadius))
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!availability.isEnabled(key))
+        .opacity(availability.isEnabled(key) ? 1 : 0.35)
+        .help(help)
+        .accessibilityLabel(label)
+    }
+
+    private var digitGrid: some View {
+        Grid(horizontalSpacing: 6, verticalSpacing: 6) {
+            ForEach(0..<4) { row in
+                GridRow {
+                    ForEach(1..<4) { column in
+                        digitKey(row * 3 + column)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func digitKey(_ number: Int) -> some View {
+        if let key = ARIBRemoteKey.digit(number) {
+            remoteKey(
+                key,
+                help: number <= 9 ? "\(number)" : nil
+            ) {
+                Text("\(number)")
+            }
+            .frame(maxWidth: .infinity)
+            .accessibilityLabel("\(number)")
+        }
+    }
+
+    private func remoteKey(
+        _ key: ARIBRemoteKey,
+        help: String? = nil,
+        @ViewBuilder label: () -> some View
+    ) -> some View {
+        let isEnabled = availability.isEnabled(key)
+        return Button {
+            onPress(key)
+        } label: {
+            label()
+                .font(.system(size: buttonFontSize, weight: .semibold))
+                .frame(maxWidth: .infinity)
+                .frame(height: buttonHeight)
+                .background(
+                    Color.primary.opacity(layout == .touch ? 0.08 : 0.1),
+                    in: RoundedRectangle(cornerRadius: cornerRadius)
+                )
+                .overlay {
+                    if layout == .touch {
+                        RoundedRectangle(cornerRadius: cornerRadius)
+                            .stroke(Color.secondary.opacity(0.3))
+                    }
+                }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!isEnabled)
+        .opacity(isEnabled ? 1 : 0.35)
+        .help(help.map { "キー: \($0)" } ?? "")
+    }
+}

--- a/kiririn/Features/Player/DataBroadcast/BMLRemoteControlView.swift
+++ b/kiririn/Features/Player/DataBroadcast/BMLRemoteControlView.swift
@@ -1,175 +1,32 @@
 import SwiftUI
 
 /// データ放送用のオンスクリーンリモコン(BMLRemotePanelControllerの
-/// フローティングパネルに載る)。キーボードを介さずにARIBキーをBML
-/// コンテンツへ直接送るため、プレイヤー側ショートカットと競合しない。
-/// 各キーはコンテンツがusedKeyListで宣言したグループに応じて有効化される
-/// (dボタンのみ常時有効 - コンテンツはinvisible状態から起動されるため)。
+/// フローティングパネルに載る)。共有のキー配置をPlayerStateへ接続する。
 struct BMLRemoteControlView: View {
-    enum Layout {
-        case panel
-        case tab
-    }
+    typealias Layout = BMLRemoteControlPad.Layout
 
     let playerState: PlayerState
     var layout: Layout = .panel
     var showsDataButton = true
 
-    private let spacing: CGFloat = 10
-    private var buttonHeight: CGFloat { layout == .tab ? 38 : 26 }
-    private var buttonFontSize: CGFloat { layout == .tab ? 16 : 12 }
-    private var directionalButtonWidth: CGFloat { layout == .tab ? 72 : 52 }
-
-    private var session: DataBroadcastSession? { playerState.dataBroadcastSession }
-    private var usedKeyGroups: Set<String> { session?.usedKeyGroups ?? [] }
-    private var basicEnabled: Bool {
-        playerState.bmlContentVisible && usedKeyGroups.contains("basic")
-    }
-    private var colorEnabled: Bool {
-        playerState.bmlContentVisible && usedKeyGroups.contains("data-button")
-    }
-    private var digitEnabled: Bool {
-        playerState.bmlContentVisible && usedKeyGroups.contains("numeric-tuning")
-    }
-
     var body: some View {
-        VStack(spacing: spacing) {
-            dataButtonRow
-            arrowPad
-            colorButtonRow
-            digitGrid
+        BMLRemoteControlPad(
+            layout: layout,
+            availability: BMLRemoteControlAvailability(
+                isDataButtonEnabled: playerState.bmlAvailable,
+                enabledGroups: playerState.bmlContentVisible ? usedKeyGroups : []
+            ),
+            showsDataButton: showsDataButton
+        ) { key in
+            _ = playerState.pressBMLKey(key)
         }
-        .padding(12)
-        .frame(
-            minWidth: layout == .panel ? 196 : nil,
-            maxWidth: layout == .tab ? .infinity : 196
+    }
+
+    private var usedKeyGroups: Set<BMLKeyGroup> {
+        Set(
+            playerState.dataBroadcastSession?.usedKeyGroups.compactMap(
+                BMLKeyGroup.init(rawValue:)
+            ) ?? []
         )
-    }
-
-    private var dataButtonRow: some View {
-        HStack(spacing: 8) {
-            if showsDataButton {
-                remoteKey(enabled: playerState.bmlAvailable, help: "d") {
-                    playerState.pressBMLDataButton()
-                } label: {
-                    HStack(spacing: 4) {
-                        Text("d").italic().bold()
-                        Text("データ")
-                    }
-                }
-            }
-            remoteKey(enabled: basicEnabled, help: "Delete / Esc") {
-                press(19)  // Back
-            } label: {
-                Text("戻る")
-            }
-        }
-    }
-
-    private var arrowPad: some View {
-        VStack(spacing: 6) {
-            arrowKey("chevron.up", code: 1, help: "⌥↑")
-            HStack(spacing: 6) {
-                arrowKey("chevron.left", code: 3, help: "⌥←")
-                remoteKey(enabled: basicEnabled, help: "Return") {
-                    press(18)  // Enter
-                } label: {
-                    Text("決定")
-                }
-                .frame(width: directionalButtonWidth)
-                arrowKey("chevron.right", code: 4, help: "⌥→")
-            }
-            arrowKey("chevron.down", code: 2, help: "⌥↓")
-        }
-        .frame(maxWidth: layout == .tab ? 360 : nil)
-        .frame(maxWidth: .infinity)
-    }
-
-    private func arrowKey(_ systemImage: String, code: Int, help: String) -> some View {
-        remoteKey(enabled: basicEnabled, help: help) {
-            press(code)
-        } label: {
-            Image(systemName: systemImage)
-        }
-        .frame(width: directionalButtonWidth)
-        .buttonRepeatBehavior(.enabled)
-    }
-
-    private var colorButtonRow: some View {
-        HStack(spacing: 6) {
-            colorKey("青", color: .blue, code: 21, help: "b")
-            colorKey("赤", color: .red, code: 22, help: "r")
-            colorKey("緑", color: .green, code: 23, help: "g")
-            colorKey("黄", color: .yellow, code: 24, help: "y")
-        }
-    }
-
-    private func colorKey(_ label: String, color: Color, code: Int, help: String) -> some View {
-        Button {
-            press(code)
-        } label: {
-            Text(label)
-                .font(.system(size: buttonFontSize, weight: .bold))
-                .foregroundStyle(.white)
-                .frame(maxWidth: .infinity)
-                .frame(height: buttonHeight)
-                .background(color.opacity(0.75), in: RoundedRectangle(cornerRadius: 6))
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .disabled(!colorEnabled)
-        .opacity(colorEnabled ? 1 : 0.35)
-        .help(help)
-    }
-
-    private var digitGrid: some View {
-        Grid(horizontalSpacing: 6, verticalSpacing: 6) {
-            ForEach(0..<4) { row in
-                GridRow {
-                    ForEach(1..<4) { column in
-                        digitKey(row * 3 + column)
-                    }
-                }
-            }
-        }
-    }
-
-    private func digitKey(_ number: Int) -> some View {
-        // AribKeyCode: Digit0=5...Digit9=14, Digit10=15, Digit11=16, Digit12=17
-        remoteKey(
-            enabled: digitEnabled,
-            help: number <= 9 ? "\(number)" : nil
-        ) {
-            press(number <= 9 ? 5 + number : 15 + (number - 10))
-        } label: {
-            Text("\(number)")
-        }
-        .frame(maxWidth: .infinity)
-    }
-
-    private func remoteKey(
-        enabled: Bool,
-        help: String? = nil,
-        action: @escaping () -> Void,
-        @ViewBuilder label: () -> some View
-    ) -> some View {
-        Button(action: action) {
-            label()
-                .font(.system(size: buttonFontSize, weight: .semibold))
-                .frame(maxWidth: .infinity)
-                .frame(height: buttonHeight)
-                .background(Color.primary.opacity(0.1), in: RoundedRectangle(cornerRadius: 6))
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .disabled(!enabled)
-        .opacity(enabled ? 1 : 0.35)
-        .help(help.map { "キー: \($0)" } ?? "")
-    }
-
-    private func press(_ aribKeyCode: Int) {
-        guard let session else { return }
-        session.sendKey(down: true, aribKeyCode: aribKeyCode)
-        session.sendKey(down: false, aribKeyCode: aribKeyCode)
     }
 }

--- a/kiririn/Features/Player/DataBroadcast/DataBroadcastSession.swift
+++ b/kiririn/Features/Player/DataBroadcast/DataBroadcastSession.swift
@@ -79,6 +79,8 @@ final class DataBroadcastSession {
     private(set) var stageRect: CGRect?
     private(set) var videoRect: CGRect?
     private(set) var isInvisible = false
+    private var isPresentationSuppressed = true
+    private var requestedPresentationVisible: Bool?
     /// 実機の「データ取得中...」に相当。コンテンツが待っているモジュール取得が
     /// 保留中のあいだtrue (web-bmlのIndicator.setReceivingStatus由来)。
     private(set) var isReceiving = false
@@ -100,6 +102,20 @@ final class DataBroadcastSession {
             videoFrame: videoRect,
             outputHeight: outputHeight
         )
+    }
+
+    var isContentVisible: Bool {
+        !isInvisible && !isPresentationSuppressed
+    }
+
+    func pressDataButton() {
+        let shouldShow = !isContentVisible
+        requestedPresentationVisible = shouldShow
+        if !shouldShow {
+            isPresentationSuppressed = true
+        }
+        logger.info("BML presentation requested: visible=\(shouldShow)")
+        post(#"{"type":"setPresentationVisible","visible":\#(shouldShow)}"#)
     }
 
     func takeCaptureSnapshot(layout: DataBroadcastCaptureLayout) async
@@ -234,6 +250,12 @@ final class DataBroadcastSession {
         isNetworking = false
         invisibleUpdateTask?.cancel()
         invisibleUpdateTask = nil
+        stageRect = nil
+        videoRect = nil
+        isInvisible = false
+        isPresentationSuppressed = true
+        requestedPresentationVisible = nil
+        usedKeyGroups.removeAll()
         inputRequest = nil
         consecutiveFailures = 0
         sseClient.cancelAll()
@@ -792,6 +814,10 @@ final class DataBroadcastSession {
                 if self.isInvisible != nextValue {
                     self.isInvisible = nextValue
                     self.logger.info("BML invisible: \(nextValue)")
+                }
+                if self.requestedPresentationVisible == !nextValue {
+                    self.isPresentationSuppressed = nextValue
+                    self.requestedPresentationVisible = nil
                 }
             }
         case "receiving":

--- a/kiririn/Features/Player/PlayerOverlayView.swift
+++ b/kiririn/Features/Player/PlayerOverlayView.swift
@@ -1126,13 +1126,16 @@ struct PlayerOverlayView_iOS: View {
             if isDataBroadcastEnabled {
                 NavigationStack {
                     if playerState.dataBroadcastSession != nil {
-                        BMLRemoteControlView(
-                            playerState: playerState,
-                            layout: .tab
-                        )
-                        .padding(.top, 24)
-                        .padding(.bottom, collapsedBarReservedBottomHeight)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                        ScrollView {
+                            BMLRemoteControlView(
+                                playerState: playerState,
+                                layout: .touch
+                            )
+                            .padding(.horizontal)
+                            .padding(.top, 24)
+                            .padding(.bottom, collapsedBarReservedBottomHeight / 2)
+                        }
+                        .scrollIndicators(.hidden)
                         .navigationBarTitleDisplayMode(.inline)
                     } else {
                         unavailableLowerContextView(
@@ -2597,8 +2600,8 @@ struct PlayerOverlayView_iOS: View {
     }
 
     private func jump(seconds: Double) {
-        guard isSeekActionAvailable, let player = playerState.player else { return }
-        player.jump(withOffset: Int32(seconds) * 1000)
+        guard isSeekActionAvailable else { return }
+        playerState.skip(by: seconds)
         showSeekFeedback(for: seconds)
     }
 

--- a/kiririn/Features/Player/PlayerOverlayView.swift
+++ b/kiririn/Features/Player/PlayerOverlayView.swift
@@ -321,6 +321,7 @@ struct PlayerOverlayView_iOS: View {
         if let session = playerState.dataBroadcastSession {
             let frame = playerSurfaceFrame(in: geo)
             BMLOverlayView_iOS(session: session)
+                .id(ObjectIdentifier(session.webView))
                 .frame(width: frame.width, height: frame.height)
                 .clipShape(.rect(cornerRadius: playerState.mode == .mini ? 14 : 0))
                 .position(x: frame.midX, y: frame.midY)

--- a/kiririn/Features/Player/PlayerState.swift
+++ b/kiririn/Features/Player/PlayerState.swift
@@ -258,14 +258,12 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
             return true
         }
     }
-    /// Whether the BML content is currently presenting itself. Visibility is
-    /// content-driven (ARIB receivers auto-start data broadcasting in an
-    /// invisible state; the content shows itself upon receiving the
-    /// DataButton key), so this mirrors web-bml's `invisible` state rather
-    /// than any native toggle.
+    /// Whether the BML content is currently presenting itself. A newly
+    /// created session stays closed until the next DataButton press, then
+    /// follows web-bml's `invisible` state.
     var bmlContentVisible: Bool {
         guard let session = dataBroadcastSession else { return false }
-        return session.status == .active && !session.isInvisible
+        return session.status == .active && session.isContentVisible
     }
     var isRecording = false
     var caption: String = ""
@@ -1435,10 +1433,19 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
 
     @discardableResult
     func pressBMLKey(_ key: ARIBRemoteKey) -> Bool {
-        guard let session = dataBroadcastSession, session.status == .active else {
-            return false
+        guard let session = dataBroadcastSession else { return false }
+        if key == .data {
+            switch session.status {
+            case .unsupported, .failed:
+                return false
+            default:
+                break
+            }
+            session.pressDataButton()
+            return true
         }
 
+        guard session.status == .active else { return false }
         if let requiredGroup = key.requiredGroup {
             guard bmlContentVisible,
                 session.usedKeyGroups.contains(requiredGroup.rawValue)

--- a/kiririn/Features/Player/PlayerState.swift
+++ b/kiririn/Features/Player/PlayerState.swift
@@ -244,6 +244,8 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
     var selectedVideoTrack: PlayerVideoTrack?
     var selectedAudioStereoMode: PlayerAudioStereoMode = .unset
     var selectedAudioMixMode: PlayerAudioMixMode = .unset
+    private var requestedPlayingState: Bool?
+    private var playbackTransitionID: UUID?
     var showingPluginOverlay = true
     var plugins: [PluginDefinition] = []
     var dataBroadcastSession: DataBroadcastSession?
@@ -488,32 +490,57 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
     }
 
     func togglePlayPause() {
-        guard let player = player else { return }
-        if isPlaying {
+        setPlaying(!(requestedPlayingState ?? isPlaying))
+    }
+
+    func setPlaying(_ enabled: Bool) {
+        guard let player else { return }
+        requestedPlayingState = enabled
+        playbackTransitionID = nil
+
+        if !enabled {
             player.pause()
             isPlaying = false
             playbackStatus.isPlaying = false
-        } else {
-            Task {
-                await refreshCurrentPlayableHeaders()
-                if let media = player.media, let headers = currentPlayable?.headers {
-                    media.removeAllHTTPHeaders()
-                    for (key, value) in headers {
-                        media.addHTTPHeader(withName: key, value: value)
-                    }
-                }
+            requestedPlayingState = nil
+            return
+        }
 
-                player.rate = playbackRate
-                if player.isSeekable {
-                    player.play()
-                } else {
-                    player.stop()
-                    player.play()
-                }
-                isPlaying = true
-                playbackStatus.isPlaying = true
-                playbackStatus.rate = playbackRate
+        guard !isPlaying else {
+            requestedPlayingState = nil
+            return
+        }
+
+        let transitionID = UUID()
+        playbackTransitionID = transitionID
+        Task { @MainActor [weak self, weak player] in
+            guard let self, let player else { return }
+            await refreshCurrentPlayableHeaders()
+            guard playbackTransitionID == transitionID,
+                requestedPlayingState == true,
+                self.player === player
+            else {
+                return
             }
+            if let media = player.media, let headers = currentPlayable?.headers {
+                media.removeAllHTTPHeaders()
+                for (key, value) in headers {
+                    media.addHTTPHeader(withName: key, value: value)
+                }
+            }
+
+            player.rate = playbackRate
+            if player.isSeekable {
+                player.play()
+            } else {
+                player.stop()
+                player.play()
+            }
+            isPlaying = true
+            playbackStatus.isPlaying = true
+            playbackStatus.rate = playbackRate
+            requestedPlayingState = nil
+            playbackTransitionID = nil
         }
     }
 
@@ -633,6 +660,11 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
         applyAudioOutput()
     }
 
+    func setMuted(_ enabled: Bool) {
+        guard enabled != isMuted else { return }
+        toggleMute()
+    }
+
     func toggleMute() {
         isMuted.toggle()
         applyAudioOutput()
@@ -692,6 +724,23 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
     func togglePip() {
         guard isPipAvailable else { return }
         isPipEnabled.toggle()
+    }
+
+    func setPipEnabled(_ enabled: Bool) {
+        guard enabled != isPipEnabled else { return }
+        togglePip()
+    }
+
+    func skip(by seconds: Double) {
+        let milliseconds = seconds * 1_000
+        guard seconds.isFinite,
+            milliseconds >= Double(Int32.min),
+            milliseconds <= Double(Int32.max),
+            let player
+        else {
+            return
+        }
+        player.jump(withOffset: Int32(milliseconds.rounded()))
     }
 
     private func loadAudioTracks() {
@@ -1381,9 +1430,26 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
     /// press. The content itself toggles between invisible/visible in
     /// response (DataButtonPressed event), exactly like a hardware receiver.
     func pressBMLDataButton() {
-        guard let session = dataBroadcastSession, session.status == .active else { return }
-        session.sendKey(down: true, aribKeyCode: 20)  // AribKeyCode.DataButton
-        session.sendKey(down: false, aribKeyCode: 20)
+        _ = pressBMLKey(.data)
+    }
+
+    @discardableResult
+    func pressBMLKey(_ key: ARIBRemoteKey) -> Bool {
+        guard let session = dataBroadcastSession, session.status == .active else {
+            return false
+        }
+
+        if let requiredGroup = key.requiredGroup {
+            guard bmlContentVisible,
+                session.usedKeyGroups.contains(requiredGroup.rawValue)
+            else {
+                return false
+            }
+        }
+
+        session.sendKey(down: true, aribKeyCode: key.rawValue)
+        session.sendKey(down: false, aribKeyCode: key.rawValue)
+        return true
     }
 
     private func savePlaybackPositionIfNeeded() {
@@ -1677,6 +1743,11 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
             player.startRecording(atPath: tempDir.path)
             isRecording = true
         }
+    }
+
+    func setRecording(_ enabled: Bool) {
+        guard enabled != isRecording else { return }
+        toggleRecording()
     }
 
     private func makePlayer() -> VLCMediaPlayer {

--- a/kiririn/Features/Player/macOS/DetachedPlayerOverlayView.swift
+++ b/kiririn/Features/Player/macOS/DetachedPlayerOverlayView.swift
@@ -13,6 +13,7 @@
         let pluginStore: PluginStore
         @Binding var isAlwaysOnTop: Bool
         let playerWindowReference: WindowReference_macOS
+        var volumeFeedbackRequestID: UUID? = nil
         let onToggleFullscreen: () -> Void
         let onControlsVisibilityChanged: (Bool) -> Void
 
@@ -222,6 +223,10 @@
                     } else if oldValue {
                         showCaptureFeedback(text: "録画終了", systemImage: "stop.circle.fill")
                     }
+                }
+                .onChange(of: volumeFeedbackRequestID) { _, requestID in
+                    guard requestID != nil else { return }
+                    showVolumeFeedback()
                 }
                 .onChange(of: playerState.playbackErrorMessage) { _, newValue in
                     guard let raw = newValue else { return }
@@ -686,8 +691,7 @@
         }
 
         private func jump(seconds: Double) {
-            guard let player = playerState.player else { return }
-            player.jump(withOffset: Int32(seconds) * 1000)
+            playerState.skip(by: seconds)
             showSeekFeedback(for: seconds)
         }
 

--- a/kiririn/Features/Player/macOS/DetachedPlayerOverlayView.swift
+++ b/kiririn/Features/Player/macOS/DetachedPlayerOverlayView.swift
@@ -93,6 +93,7 @@
                                 // never reaches this layer anyway - WindowDragSurface
                                 // sits above it in the ZStack; BML is keyboard-only.
                                 BMLOverlayView_macOS(session: session)
+                                    .id(ObjectIdentifier(session.webView))
                                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                                     .opacity(playerState.bmlContentVisible ? 1 : 0)
                                     .allowsHitTesting(false)

--- a/kiririn/Features/Player/macOS/PlayerWindowView.swift
+++ b/kiririn/Features/Player/macOS/PlayerWindowView.swift
@@ -16,7 +16,9 @@
         @State private var playerWindowReference = WindowReference_macOS()
         @State private var isAlwaysOnTop = false
         @State private var isOverlayVisible = true
+        @State private var volumeFeedbackRequestID: UUID?
         @State private var restorationWaitTask: Task<Void, Never>?
+        @State private var remoteEndpoint: PlayerWindowRemoteEndpoint_macOS?
 
         var body: some View {
             ZStack {
@@ -27,6 +29,7 @@
                         pluginStore: appModel.pluginStore,
                         isAlwaysOnTop: $isAlwaysOnTop,
                         playerWindowReference: playerWindowReference,
+                        volumeFeedbackRequestID: volumeFeedbackRequestID,
                         onToggleFullscreen: {
                             playerWindow?.toggleFullScreen(nil)
                         },
@@ -75,6 +78,7 @@
                 appModel.focusedPlayerID = playerState.id
                 appModel.setupIfNeeded()
                 appModel.configureDetachedPlayerState(playerState)
+                registerRemoteEndpointIfNeeded()
                 logWindowContext(trigger: "onAppear", playable: initialPlayable)
             }
             .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification))
@@ -119,6 +123,8 @@
                 scheduleRestorationFallbackIfNeeded()
             }
             .onDisappear {
+                appModel.remoteControlService.unregisterWindowEndpoint(playerID: playerState.id)
+                remoteEndpoint = nil
                 appModel.activePlayerStates.removeAll { $0 === playerState }
                 if appModel.focusedPlayerID == playerState.id {
                     appModel.focusedPlayerID = nil
@@ -134,6 +140,22 @@
 
         private var playerWindow: NSWindow? {
             playerWindowReference.window
+        }
+
+        private func registerRemoteEndpointIfNeeded() {
+            guard remoteEndpoint == nil else { return }
+            let endpoint = PlayerWindowRemoteEndpoint_macOS(
+                windowReference: playerWindowReference,
+                isAlwaysOnTop: { isAlwaysOnTop },
+                setAlwaysOnTop: { isAlwaysOnTop = $0 },
+                showVolumeFeedback: { volumeFeedbackRequestID = UUID() },
+                close: { dismiss() }
+            )
+            remoteEndpoint = endpoint
+            appModel.remoteControlService.registerWindowEndpoint(
+                endpoint,
+                playerID: playerState.id
+            )
         }
 
         private var windowTitle: String {

--- a/kiririn/Features/RemoteControl/MultipeerRemoteTransport.swift
+++ b/kiririn/Features/RemoteControl/MultipeerRemoteTransport.swift
@@ -1,0 +1,292 @@
+import Foundation
+@preconcurrency import MultipeerConnectivity
+
+nonisolated enum RemoteTransportEvent: Sendable {
+    case discovered(RemoteDiscoveredPeer)
+    case lost(String)
+    case connecting(String)
+    case connected(String)
+    case disconnected(String)
+    case received(Data, connectionID: String)
+    case failed(String)
+}
+
+@MainActor
+final class MultipeerRemoteTransport: NSObject {
+    static let serviceType = "kiririn-rc"
+    nonisolated private static let maximumMessageSize = 256 * 1024
+
+    var onEvent: ((RemoteTransportEvent) -> Void)?
+
+    private let localPeerID: MCPeerID
+    private let session: MCSession
+    private let advertisedDisplayName: String
+    private let localIdentityID: String
+    private var advertiser: MCNearbyServiceAdvertiser?
+    private var browser: MCNearbyServiceBrowser?
+    private var discoveredPeerIDs: [String: MCPeerID] = [:]
+    private var connectedPeerIDs: [String: MCPeerID] = [:]
+    private var reservedConnectionID: String?
+
+    init(displayName: String, identityID: String) {
+        advertisedDisplayName = displayName
+        localIdentityID = identityID
+        let peerID = MCPeerID(displayName: identityID)
+        localPeerID = peerID
+        session = MCSession(
+            peer: peerID,
+            securityIdentity: nil,
+            encryptionPreference: .required
+        )
+        super.init()
+        session.delegate = self
+    }
+
+    func startAdvertising() {
+        stopAdvertising()
+        let advertiser = MCNearbyServiceAdvertiser(
+            peer: localPeerID,
+            discoveryInfo: [
+                "id": localIdentityID,
+                "name": advertisedDisplayName,
+                "v": String(RemoteControlEnvelope.currentProtocolVersion),
+            ],
+            serviceType: Self.serviceType
+        )
+        advertiser.delegate = self
+        self.advertiser = advertiser
+        advertiser.startAdvertisingPeer()
+    }
+
+    func stopAdvertising() {
+        advertiser?.stopAdvertisingPeer()
+        advertiser?.delegate = nil
+        advertiser = nil
+    }
+
+    func startBrowsing() {
+        stopBrowsing()
+        discoveredPeerIDs.removeAll()
+        let browser = MCNearbyServiceBrowser(
+            peer: localPeerID,
+            serviceType: Self.serviceType
+        )
+        browser.delegate = self
+        self.browser = browser
+        browser.startBrowsingForPeers()
+    }
+
+    func stopBrowsing() {
+        browser?.stopBrowsingForPeers()
+        browser?.delegate = nil
+        browser = nil
+        discoveredPeerIDs.removeAll()
+    }
+
+    func connect(to connectionID: String) {
+        guard let peerID = discoveredPeerIDs[connectionID], let browser else {
+            onEvent?(.failed("接続先が見つかりません"))
+            return
+        }
+        guard reservedConnectionID == nil || reservedConnectionID == connectionID else {
+            onEvent?(.failed("別の接続を処理しています"))
+            return
+        }
+        reservedConnectionID = connectionID
+        onEvent?(.connecting(connectionID))
+        browser.invitePeer(peerID, to: session, withContext: nil, timeout: 15)
+    }
+
+    func send(_ data: Data, to connectionID: String) throws {
+        guard let peerID = connectedPeerIDs[connectionID] else {
+            throw RemoteTransportError.notConnected
+        }
+        try session.send(data, toPeers: [peerID], with: .reliable)
+    }
+
+    func disconnect() {
+        session.disconnect()
+        connectedPeerIDs.removeAll()
+        reservedConnectionID = nil
+    }
+
+    private func handleFoundPeer(
+        _ peerID: MCPeerID,
+        discoveryInfo: [String: String]?
+    ) {
+        let connectionID = peerID.displayName
+        discoveredPeerIDs[connectionID] = peerID
+        let name = discoveryInfo?["name"] ?? peerID.displayName
+        onEvent?(
+            .discovered(
+                RemoteDiscoveredPeer(
+                    id: connectionID,
+                    displayName: name
+                )
+            )
+        )
+    }
+
+    private func handleLostPeer(_ peerID: MCPeerID) {
+        let connectionID = peerID.displayName
+        discoveredPeerIDs.removeValue(forKey: connectionID)
+        onEvent?(.lost(connectionID))
+    }
+
+    private func handleInvitation(
+        from peerID: MCPeerID,
+        invitationHandler: @escaping (Bool, MCSession?) -> Void
+    ) {
+        let connectionID = peerID.displayName
+        guard connectedPeerIDs.isEmpty,
+            reservedConnectionID == nil || reservedConnectionID == connectionID
+        else {
+            invitationHandler(false, nil)
+            return
+        }
+        reservedConnectionID = connectionID
+        invitationHandler(true, session)
+    }
+
+    private func handleState(_ state: MCSessionState, peerID: MCPeerID) {
+        let connectionID = peerID.displayName
+        switch state {
+        case .notConnected:
+            connectedPeerIDs.removeValue(forKey: connectionID)
+            if reservedConnectionID == connectionID {
+                reservedConnectionID = nil
+            }
+            onEvent?(.disconnected(connectionID))
+        case .connecting:
+            guard reservedConnectionID == nil || reservedConnectionID == connectionID else {
+                session.cancelConnectPeer(peerID)
+                return
+            }
+            reservedConnectionID = connectionID
+            onEvent?(.connecting(connectionID))
+        case .connected:
+            guard reservedConnectionID == nil || reservedConnectionID == connectionID else {
+                session.cancelConnectPeer(peerID)
+                return
+            }
+            reservedConnectionID = connectionID
+            connectedPeerIDs[connectionID] = peerID
+            onEvent?(.connected(connectionID))
+        @unknown default:
+            onEvent?(.failed("未対応の接続状態です"))
+        }
+    }
+}
+
+extension MultipeerRemoteTransport: MCNearbyServiceAdvertiserDelegate {
+    nonisolated func advertiser(
+        _ advertiser: MCNearbyServiceAdvertiser,
+        didReceiveInvitationFromPeer peerID: MCPeerID,
+        withContext context: Data?,
+        invitationHandler: @escaping (Bool, MCSession?) -> Void
+    ) {
+        Task { @MainActor [weak self] in
+            self?.handleInvitation(from: peerID, invitationHandler: invitationHandler)
+        }
+    }
+
+    nonisolated func advertiser(
+        _ advertiser: MCNearbyServiceAdvertiser,
+        didNotStartAdvertisingPeer error: any Error
+    ) {
+        let message = error.localizedDescription
+        Task { @MainActor [weak self] in
+            self?.onEvent?(.failed(message))
+        }
+    }
+}
+
+extension MultipeerRemoteTransport: MCNearbyServiceBrowserDelegate {
+    nonisolated func browser(
+        _ browser: MCNearbyServiceBrowser,
+        foundPeer peerID: MCPeerID,
+        withDiscoveryInfo info: [String: String]?
+    ) {
+        Task { @MainActor [weak self] in
+            self?.handleFoundPeer(peerID, discoveryInfo: info)
+        }
+    }
+
+    nonisolated func browser(
+        _ browser: MCNearbyServiceBrowser,
+        lostPeer peerID: MCPeerID
+    ) {
+        Task { @MainActor [weak self] in
+            self?.handleLostPeer(peerID)
+        }
+    }
+
+    nonisolated func browser(
+        _ browser: MCNearbyServiceBrowser,
+        didNotStartBrowsingForPeers error: any Error
+    ) {
+        let message = error.localizedDescription
+        Task { @MainActor [weak self] in
+            self?.onEvent?(.failed(message))
+        }
+    }
+}
+
+extension MultipeerRemoteTransport: MCSessionDelegate {
+    nonisolated func session(
+        _ session: MCSession,
+        peer peerID: MCPeerID,
+        didChange state: MCSessionState
+    ) {
+        Task { @MainActor [weak self] in
+            self?.handleState(state, peerID: peerID)
+        }
+    }
+
+    nonisolated func session(
+        _ session: MCSession,
+        didReceive data: Data,
+        fromPeer peerID: MCPeerID
+    ) {
+        guard data.count <= Self.maximumMessageSize else { return }
+        let connectionID = peerID.displayName
+        Task { @MainActor [weak self] in
+            self?.onEvent?(.received(data, connectionID: connectionID))
+        }
+    }
+
+    nonisolated func session(
+        _ session: MCSession,
+        didReceive stream: InputStream,
+        withName streamName: String,
+        fromPeer peerID: MCPeerID
+    ) {}
+
+    nonisolated func session(
+        _ session: MCSession,
+        didStartReceivingResourceWithName resourceName: String,
+        fromPeer peerID: MCPeerID,
+        with progress: Progress
+    ) {}
+
+    nonisolated func session(
+        _ session: MCSession,
+        didFinishReceivingResourceWithName resourceName: String,
+        fromPeer peerID: MCPeerID,
+        at localURL: URL?,
+        withError error: (any Error)?
+    ) {}
+
+    nonisolated func session(
+        _ session: MCSession,
+        didReceiveCertificate certificate: [Any]?,
+        fromPeer peerID: MCPeerID,
+        certificateHandler: @escaping (Bool) -> Void
+    ) {
+        certificateHandler(true)
+    }
+}
+
+nonisolated enum RemoteTransportError: Error {
+    case notConnected
+}

--- a/kiririn/Features/RemoteControl/RemoteAudioTrackSelection.swift
+++ b/kiririn/Features/RemoteControl/RemoteAudioTrackSelection.swift
@@ -1,0 +1,9 @@
+nonisolated struct RemoteAudioTrackSelection: Codable, Equatable, Hashable, Sendable {
+    enum Role: String, Codable, Equatable, Hashable, Sendable {
+        case main
+        case sub
+    }
+
+    let trackID: String
+    let role: Role?
+}

--- a/kiririn/Features/RemoteControl/RemoteControlAudioTrackOption.swift
+++ b/kiririn/Features/RemoteControl/RemoteControlAudioTrackOption.swift
@@ -1,0 +1,8 @@
+nonisolated struct RemoteControlAudioTrackOption: Codable, Equatable, Identifiable, Sendable {
+    let selection: RemoteAudioTrackSelection
+    let label: String
+
+    var id: RemoteAudioTrackSelection {
+        selection
+    }
+}

--- a/kiririn/Features/RemoteControl/RemoteControlCommand.swift
+++ b/kiririn/Features/RemoteControl/RemoteControlCommand.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+nonisolated enum RemoteControlCommand: Codable, Equatable, Sendable {
+    case setPlaying(Bool)
+    case seekToTime(Double)
+    case skipBy(Double)
+    case setRate(Float)
+    case setVolume(Float)
+    case setMuted(Bool)
+    case selectAudioTrack(RemoteAudioTrackSelection?)
+    case selectVideoTrack(String)
+    case setSubtitleEnabled(Bool)
+    case setPipEnabled(Bool)
+    case takeCapture
+    case setRecording(Bool)
+    case reload
+    case pressBMLKey(ARIBRemoteKey)
+    case setFullscreen(Bool)
+    case setAlwaysOnTop(Bool)
+    case close
+}
+
+nonisolated struct RemotePlayerCommandRequest: Codable, Equatable, Sendable {
+    let playerID: String
+    let command: RemoteControlCommand
+}
+
+nonisolated enum RemoteCommandError: String, Codable, Equatable, Sendable {
+    case playerNotFound
+    case unsupported
+    case invalidValue
+    case unavailable
+    case unauthorized
+}
+
+nonisolated struct RemoteCommandResponse: Codable, Equatable, Sendable {
+    let requestID: UUID
+    let error: RemoteCommandError?
+}

--- a/kiririn/Features/RemoteControl/RemoteControlCryptography.swift
+++ b/kiririn/Features/RemoteControl/RemoteControlCryptography.swift
@@ -1,0 +1,74 @@
+import CryptoKit
+import Foundation
+import Security
+
+nonisolated enum RemoteControlCryptography {
+    private static let authenticationContext = Data("kiririn-remote-auth-v1".utf8)
+    private static let pairingContext = Data("kiririn-remote-pair-v1".utf8)
+
+    static func randomNonce() -> Data {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else {
+            return Data(UUID().uuidString.utf8)
+        }
+        return Data(bytes)
+    }
+
+    static func authenticationData(
+        nonce: Data,
+        receiverID: String,
+        controllerID: String
+    ) -> Data {
+        joined(
+            authenticationContext,
+            nonce,
+            Data(receiverID.utf8),
+            Data(controllerID.utf8)
+        )
+    }
+
+    static func pairingData(
+        nonce: Data,
+        receiverID: String,
+        controllerID: String
+    ) -> Data {
+        joined(
+            pairingContext,
+            nonce,
+            Data(receiverID.utf8),
+            Data(controllerID.utf8)
+        )
+    }
+
+    static func pairingProof(pin: String, data: Data) -> Data {
+        let key = SymmetricKey(data: Data(pin.utf8))
+        return Data(HMAC<SHA256>.authenticationCode(for: data, using: key))
+    }
+
+    static func verifyPairingProof(_ proof: Data, pin: String, data: Data) -> Bool {
+        let key = SymmetricKey(data: Data(pin.utf8))
+        return HMAC<SHA256>.isValidAuthenticationCode(proof, authenticating: data, using: key)
+    }
+
+    static func verify(
+        signature: Data,
+        data: Data,
+        publicKey: Data
+    ) -> Bool {
+        guard let key = try? Curve25519.Signing.PublicKey(rawRepresentation: publicKey) else {
+            return false
+        }
+        return key.isValidSignature(signature, for: data)
+    }
+
+    private static func joined(_ components: Data...) -> Data {
+        var result = Data()
+        for component in components {
+            var length = UInt32(component.count).bigEndian
+            withUnsafeBytes(of: &length) { result.append(contentsOf: $0) }
+            result.append(component)
+        }
+        return result
+    }
+}

--- a/kiririn/Features/RemoteControl/RemoteControlModels.swift
+++ b/kiririn/Features/RemoteControl/RemoteControlModels.swift
@@ -38,6 +38,7 @@ nonisolated struct RemotePlayerSnapshot: Codable, Equatable, Identifiable, Senda
     let isRecording: Bool
     let isSubtitleEnabled: Bool
     let isPipEnabled: Bool
+    let isDataBroadcastVisible: Bool
     let isFullscreen: Bool?
     let isAlwaysOnTop: Bool?
     let capabilities: Set<RemoteControlCapability>

--- a/kiririn/Features/RemoteControl/RemoteControlModels.swift
+++ b/kiririn/Features/RemoteControl/RemoteControlModels.swift
@@ -68,7 +68,7 @@ nonisolated struct RemotePairingRequest: Equatable, Identifiable, Sendable {
 nonisolated enum RemoteConnectionStatus: Equatable, Sendable {
     case idle
     case browsing
-    case connecting(String)
+    case connecting(peerID: String, displayName: String)
     case pairing(String)
     case connected(String)
     case failed(String)

--- a/kiririn/Features/RemoteControl/RemoteControlModels.swift
+++ b/kiririn/Features/RemoteControl/RemoteControlModels.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+nonisolated enum RemoteControlCapability: String, Codable, Hashable, Sendable {
+    case playback
+    case seek
+    case rate
+    case volume
+    case audioTrack
+    case videoTrack
+    case subtitle
+    case pictureInPicture
+    case capture
+    case recording
+    case reload
+    case dataBroadcast
+    case fullscreen
+    case alwaysOnTop
+    case close
+}
+
+nonisolated struct RemoteControlTrack: Codable, Equatable, Identifiable, Sendable {
+    let id: String
+    let name: String
+    let detail: String?
+}
+
+nonisolated struct RemotePlayerSnapshot: Codable, Equatable, Identifiable, Sendable {
+    let id: String
+    let title: String
+    let serviceName: String?
+    let isPlaying: Bool
+    let isSeekable: Bool
+    let time: Double
+    let duration: Double
+    let rate: Float
+    let volume: Float
+    let isMuted: Bool
+    let isRecording: Bool
+    let isSubtitleEnabled: Bool
+    let isPipEnabled: Bool
+    let isFullscreen: Bool?
+    let isAlwaysOnTop: Bool?
+    let capabilities: Set<RemoteControlCapability>
+    let audioTracks: [RemoteControlAudioTrackOption]
+    let selectedAudioTrackSelection: RemoteAudioTrackSelection?
+    let videoTracks: [RemoteControlTrack]
+    let selectedVideoTrackID: String?
+    let bmlKeyGroups: Set<BMLKeyGroup>
+}
+
+nonisolated struct RemoteTrustedPeer: Codable, Equatable, Identifiable, Sendable {
+    let id: String
+    var displayName: String
+    let publicKey: Data
+    let pairedAt: Date
+}
+
+nonisolated struct RemoteDiscoveredPeer: Equatable, Identifiable, Sendable {
+    let id: String
+    let displayName: String
+}
+
+nonisolated struct RemotePairingRequest: Equatable, Identifiable, Sendable {
+    let id: String
+    let displayName: String
+}
+
+nonisolated enum RemoteConnectionStatus: Equatable, Sendable {
+    case idle
+    case browsing
+    case connecting(String)
+    case pairing(String)
+    case connected(String)
+    case failed(String)
+}
+
+nonisolated struct RemoteWindowSnapshot: Equatable, Sendable {
+    let isFullscreen: Bool
+    let isAlwaysOnTop: Bool
+}

--- a/kiririn/Features/RemoteControl/RemoteControlProtocol.swift
+++ b/kiririn/Features/RemoteControl/RemoteControlProtocol.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+nonisolated struct RemotePeerIdentity: Codable, Equatable, Sendable {
+    let id: String
+    let displayName: String
+    let publicKey: Data
+}
+
+nonisolated struct RemoteAuthenticationChallenge: Codable, Equatable, Sendable {
+    let nonce: Data
+    let receiverSignature: Data
+}
+
+nonisolated struct RemoteAuthenticationResponse: Codable, Equatable, Sendable {
+    let signature: Data
+}
+
+nonisolated struct RemotePairingChallenge: Codable, Equatable, Sendable {
+    let receiverIdentity: RemotePeerIdentity
+    let nonce: Data
+}
+
+nonisolated struct RemotePairingResponse: Codable, Equatable, Sendable {
+    let pinProof: Data
+    let signature: Data
+}
+
+nonisolated struct RemotePairingAccepted: Codable, Equatable, Sendable {
+    let receiverIdentity: RemotePeerIdentity
+    let signature: Data
+}
+
+nonisolated enum RemoteControlPayload: Codable, Equatable, Sendable {
+    case hello(RemotePeerIdentity)
+    case pairingRequired(RemotePairingChallenge)
+    case pairingResponse(RemotePairingResponse)
+    case pairingAccepted(RemotePairingAccepted)
+    case authenticationChallenge(RemoteAuthenticationChallenge)
+    case authenticationResponse(RemoteAuthenticationResponse)
+    case authenticationAccepted
+    case authenticationRejected
+    case playerSnapshots([RemotePlayerSnapshot])
+    case command(RemotePlayerCommandRequest)
+    case commandResponse(RemoteCommandResponse)
+}
+
+nonisolated struct RemoteControlEnvelope: Codable, Equatable, Sendable {
+    static let currentProtocolVersion = 2
+
+    let protocolVersion: Int
+    let messageID: UUID
+    let payload: RemoteControlPayload
+
+    init(
+        messageID: UUID = UUID(),
+        payload: RemoteControlPayload
+    ) {
+        protocolVersion = Self.currentProtocolVersion
+        self.messageID = messageID
+        self.payload = payload
+    }
+}

--- a/kiririn/Features/RemoteControl/RemoteControlProtocol.swift
+++ b/kiririn/Features/RemoteControl/RemoteControlProtocol.swift
@@ -45,7 +45,7 @@ nonisolated enum RemoteControlPayload: Codable, Equatable, Sendable {
 }
 
 nonisolated struct RemoteControlEnvelope: Codable, Equatable, Sendable {
-    static let currentProtocolVersion = 2
+    static let currentProtocolVersion = 1
 
     let protocolVersion: Int
     let messageID: UUID

--- a/kiririn/Features/RemoteControl/RemoteControlService.swift
+++ b/kiririn/Features/RemoteControl/RemoteControlService.swift
@@ -147,7 +147,7 @@ final class RemoteControlService {
     func connect(to peer: RemoteDiscoveredPeer) {
         operationMode = .controller
         currentConnectionID = peer.id
-        connectionStatus = .connecting(peer.displayName)
+        connectionStatus = .connecting(peerID: peer.id, displayName: peer.displayName)
         lastErrorMessage = nil
         transport.connect(to: peer.id)
     }
@@ -318,7 +318,7 @@ final class RemoteControlService {
                 discoveredPeers.first(where: { $0.id == connectionID })?.displayName
                 ?? remoteIdentity?.displayName
                 ?? "接続先"
-            connectionStatus = .connecting(name)
+            connectionStatus = .connecting(peerID: connectionID, displayName: name)
         case .connected(let connectionID):
             guard currentConnectionID == nil || currentConnectionID == connectionID else {
                 return

--- a/kiririn/Features/RemoteControl/RemoteControlService.swift
+++ b/kiririn/Features/RemoteControl/RemoteControlService.swift
@@ -1,0 +1,879 @@
+import CryptoKit
+import Foundation
+
+@MainActor
+@Observable
+final class RemoteControlService {
+    private enum OperationMode {
+        case idle
+        case receiver
+        case controller
+    }
+
+    private static let receiverEnabledKey = "kiririn.remote-control.receiver-enabled"
+    private static let maximumMessageSize = 256 * 1024
+    private static let maximumPairingAttempts = 5
+
+    private(set) var discoveredPeers: [RemoteDiscoveredPeer] = []
+    private(set) var trustedPeers: [RemoteTrustedPeer] = []
+    private(set) var remotePlayers: [RemotePlayerSnapshot] = []
+    private(set) var connectionStatus: RemoteConnectionStatus = .idle
+    private(set) var pairingRequest: RemotePairingRequest?
+    private(set) var pairingPIN = ""
+    private(set) var pairingPINExpiresAt = Date()
+    private(set) var isReceiverEnabled: Bool
+    private(set) var lastErrorMessage: String?
+    var selectedPlayerID: String?
+
+    private let defaults: UserDefaults
+    private let trustedPeerStore: RemoteTrustedPeerStore
+    private let dispatcher = RemotePlayerCommandDispatcher()
+    private var identityIsPersistent = true
+    @ObservationIgnored private lazy var identity: RemoteLocalIdentity = {
+        let displayName = Self.localDisplayName()
+        do {
+            return try RemoteIdentityStore().loadOrCreate(displayName: displayName)
+        } catch {
+            identityIsPersistent = false
+            lastErrorMessage = "端末情報をKeychainに保存できませんでした"
+            return RemoteLocalIdentity(
+                id: UUID().uuidString,
+                displayName: displayName,
+                privateKey: .init()
+            )
+        }
+    }()
+    @ObservationIgnored private lazy var transport: MultipeerRemoteTransport = {
+        let transport = MultipeerRemoteTransport(
+            displayName: identity.displayName,
+            identityID: identity.id
+        )
+        transport.onEvent = { [weak self] event in
+            self?.handleTransportEvent(event)
+        }
+        return transport
+    }()
+    private var operationMode: OperationMode = .idle
+    private var hasLoadedTrustedPeers = false
+    private var currentConnectionID: String?
+    private var remoteIdentity: RemotePeerIdentity?
+    private var pairingChallenge: RemotePairingChallenge?
+    private var submittedPIN: String?
+    private var authenticationNonce: Data?
+    private var isAuthenticated = false
+    private var authenticatedConnectionID: String?
+    private var awaitingAuthenticationAcceptanceConnectionID: String?
+    private var pairingFailureCount = 0
+    private var snapshotTask: Task<Void, Never>?
+    private var lastSentSnapshots: [RemotePlayerSnapshot] = []
+    private var processedCommandResponses: [UUID: RemoteCommandResponse] = [:]
+    private var processedCommandOrder: [UUID] = []
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        let trustedPeerStore = RemoteTrustedPeerStore()
+        self.trustedPeerStore = trustedPeerStore
+        isReceiverEnabled = defaults.bool(forKey: Self.receiverEnabledKey)
+
+        rotatePairingPIN()
+    }
+
+    func configure(appModel: AppModel) {
+        dispatcher.configure(appModel: appModel)
+    }
+
+    func restoreReceiverIfEnabled() {
+        guard isReceiverEnabled, operationMode != .receiver else { return }
+        startReceiver()
+    }
+
+    func prepare() {
+        _ = loadTrustedPeersIfNeeded()
+    }
+
+    func setReceiverEnabled(_ enabled: Bool) {
+        guard enabled != isReceiverEnabled else { return }
+        isReceiverEnabled = enabled
+        defaults.set(enabled, forKey: Self.receiverEnabledKey)
+        if enabled {
+            startReceiver()
+        } else {
+            stopReceiver()
+        }
+    }
+
+    func rotatePairingPIN() {
+        pairingPIN = String(format: "%06d", Int.random(in: 0..<1_000_000))
+        pairingPINExpiresAt = Date().addingTimeInterval(5 * 60)
+        pairingFailureCount = 0
+    }
+
+    func startBrowsing() {
+        guard
+            operationMode != .controller
+                || currentConnectionID == nil
+        else {
+            return
+        }
+        _ = identity
+        guard identityIsPersistent else {
+            connectionStatus = .failed("端末情報をKeychainに保存できませんでした")
+            return
+        }
+        guard loadTrustedPeersIfNeeded() else {
+            connectionStatus = .failed("登録済み端末をKeychainから読み込めませんでした")
+            return
+        }
+        operationMode = .controller
+        resetConnectionState()
+        discoveredPeers = []
+        connectionStatus = .browsing
+        transport.stopAdvertising()
+        transport.startBrowsing()
+    }
+
+    func stopBrowsing() {
+        transport.stopBrowsing()
+        if !isAuthenticated {
+            if currentConnectionID != nil {
+                transport.disconnect()
+                resetConnectionState()
+            }
+            operationMode = .idle
+            connectionStatus = .idle
+        }
+    }
+
+    func connect(to peer: RemoteDiscoveredPeer) {
+        operationMode = .controller
+        currentConnectionID = peer.id
+        connectionStatus = .connecting(peer.displayName)
+        lastErrorMessage = nil
+        transport.connect(to: peer.id)
+    }
+
+    func disconnect() {
+        transport.disconnect()
+        resetConnectionState()
+        if operationMode == .controller {
+            connectionStatus = .browsing
+            transport.startBrowsing()
+        } else {
+            connectionStatus = .idle
+        }
+    }
+
+    func submitPairingPIN(_ pin: String) {
+        guard operationMode == .controller,
+            let pairingChallenge,
+            let currentConnectionID
+        else {
+            return
+        }
+        let normalizedPIN = pin.filter(\.isNumber)
+        guard normalizedPIN.count == 6 else {
+            lastErrorMessage = "PINコードは6桁で入力してください"
+            return
+        }
+
+        let data = RemoteControlCryptography.pairingData(
+            nonce: pairingChallenge.nonce,
+            receiverID: pairingChallenge.receiverIdentity.id,
+            controllerID: identity.id
+        )
+        guard let signature = try? identity.signature(for: data) else {
+            lastErrorMessage = "端末認証に失敗しました"
+            return
+        }
+        submittedPIN = normalizedPIN
+        awaitingAuthenticationAcceptanceConnectionID = currentConnectionID
+        connectionStatus = .pairing(pairingChallenge.receiverIdentity.displayName)
+        guard
+            send(
+                RemoteControlEnvelope(
+                    payload: .pairingResponse(
+                        RemotePairingResponse(
+                            pinProof: RemoteControlCryptography.pairingProof(
+                                pin: normalizedPIN,
+                                data: data
+                            ),
+                            signature: signature
+                        )
+                    )
+                ),
+                to: currentConnectionID
+            )
+        else {
+            rejectConnection(message: "ペアリング情報を送信できませんでした")
+            return
+        }
+    }
+
+    func cancelPairing() {
+        pairingRequest = nil
+        submittedPIN = nil
+        disconnect()
+    }
+
+    func forgetTrustedPeer(id: String) {
+        let updatedPeers = trustedPeers.filter { $0.id != id }
+        do {
+            try trustedPeerStore.save(updatedPeers)
+            trustedPeers = updatedPeers
+        } catch {
+            lastErrorMessage = "登録済み端末をKeychainから削除できませんでした"
+            return
+        }
+        if remoteIdentity?.id == id {
+            disconnect()
+        }
+        rotatePairingPIN()
+    }
+
+    func clearError() {
+        lastErrorMessage = nil
+    }
+
+    func sendCommand(
+        _ command: RemoteControlCommand,
+        playerID: String? = nil
+    ) {
+        guard operationMode == .controller,
+            isAuthenticated,
+            let currentConnectionID,
+            let targetPlayerID = playerID ?? selectedPlayerID
+        else {
+            lastErrorMessage = "リモコンが接続されていません"
+            return
+        }
+        send(
+            RemoteControlEnvelope(
+                payload: .command(
+                    RemotePlayerCommandRequest(
+                        playerID: targetPlayerID,
+                        command: command
+                    )
+                )
+            ),
+            to: currentConnectionID
+        )
+    }
+
+    func registerWindowEndpoint(
+        _ endpoint: any RemotePlayerWindowEndpoint,
+        playerID: String
+    ) {
+        dispatcher.register(endpoint, forPlayerID: playerID)
+    }
+
+    func unregisterWindowEndpoint(playerID: String) {
+        dispatcher.unregisterWindowEndpoint(forPlayerID: playerID)
+    }
+
+    private func startReceiver() {
+        guard operationMode != .receiver else { return }
+        _ = identity
+        guard identityIsPersistent else {
+            connectionStatus = .failed("端末情報をKeychainに保存できませんでした")
+            return
+        }
+        guard loadTrustedPeersIfNeeded() else {
+            connectionStatus = .failed("登録済み端末をKeychainから読み込めませんでした")
+            return
+        }
+        operationMode = .receiver
+        resetConnectionState()
+        rotatePairingPIN()
+        transport.stopBrowsing()
+        transport.startAdvertising()
+    }
+
+    private func stopReceiver() {
+        transport.stopAdvertising()
+        transport.disconnect()
+        operationMode = .idle
+        resetConnectionState()
+        connectionStatus = .idle
+    }
+
+    private func handleTransportEvent(_ event: RemoteTransportEvent) {
+        switch event {
+        case .discovered(let peer):
+            if let index = discoveredPeers.firstIndex(where: { $0.id == peer.id }) {
+                discoveredPeers[index] = peer
+            } else {
+                discoveredPeers.append(peer)
+                discoveredPeers.sort {
+                    $0.displayName.localizedCompare($1.displayName) == .orderedAscending
+                }
+            }
+        case .lost(let connectionID):
+            discoveredPeers.removeAll { $0.id == connectionID }
+        case .connecting(let connectionID):
+            guard currentConnectionID == nil || currentConnectionID == connectionID else {
+                return
+            }
+            currentConnectionID = connectionID
+            let name =
+                discoveredPeers.first(where: { $0.id == connectionID })?.displayName
+                ?? remoteIdentity?.displayName
+                ?? "接続先"
+            connectionStatus = .connecting(name)
+        case .connected(let connectionID):
+            guard currentConnectionID == nil || currentConnectionID == connectionID else {
+                return
+            }
+            currentConnectionID = connectionID
+            if operationMode == .controller {
+                transport.stopBrowsing()
+            }
+            send(
+                RemoteControlEnvelope(payload: .hello(identity.peerIdentity)),
+                to: connectionID
+            )
+        case .disconnected(let connectionID):
+            guard currentConnectionID == nil || currentConnectionID == connectionID else {
+                return
+            }
+            resetConnectionState()
+            if operationMode == .controller {
+                connectionStatus = .browsing
+                transport.startBrowsing()
+            } else {
+                connectionStatus = .idle
+            }
+        case .received(let data, let connectionID):
+            guard currentConnectionID == connectionID else { return }
+            handleReceivedData(data, connectionID: connectionID)
+        case .failed(let message):
+            lastErrorMessage = message
+            connectionStatus = .failed(message)
+        }
+    }
+
+    private func handleReceivedData(_ data: Data, connectionID: String) {
+        guard data.count <= Self.maximumMessageSize,
+            let envelope = try? JSONDecoder().decode(RemoteControlEnvelope.self, from: data),
+            envelope.protocolVersion == RemoteControlEnvelope.currentProtocolVersion
+        else {
+            rejectConnection(message: "接続先と互換性がありません")
+            return
+        }
+
+        switch envelope.payload {
+        case .hello(let peerIdentity):
+            remoteIdentity = peerIdentity
+            if operationMode == .receiver {
+                beginReceiverAuthentication(for: peerIdentity, connectionID: connectionID)
+            }
+        case .pairingRequired(let challenge):
+            handlePairingRequired(challenge)
+        case .pairingResponse(let response):
+            handlePairingResponse(response, connectionID: connectionID)
+        case .pairingAccepted(let accepted):
+            handlePairingAccepted(accepted, connectionID: connectionID)
+        case .authenticationChallenge(let challenge):
+            handleAuthenticationChallenge(challenge, connectionID: connectionID)
+        case .authenticationResponse(let response):
+            handleAuthenticationResponse(response, connectionID: connectionID)
+        case .authenticationAccepted:
+            guard operationMode == .controller,
+                awaitingAuthenticationAcceptanceConnectionID == connectionID
+            else {
+                rejectConnection(message: "端末認証の手順が正しくありません")
+                return
+            }
+            authorizeControllerConnection(connectionID: connectionID)
+        case .authenticationRejected:
+            rejectConnection(message: "端末を認証できませんでした")
+        case .playerSnapshots(let snapshots):
+            guard operationMode == .controller,
+                authenticatedConnectionID == connectionID
+            else {
+                return
+            }
+            remotePlayers = snapshots
+            if let selectedPlayerID,
+                snapshots.contains(where: { $0.id == selectedPlayerID })
+            {
+                return
+            }
+            selectedPlayerID = snapshots.first?.id
+        case .command(let request):
+            handleCommand(
+                request,
+                messageID: envelope.messageID,
+                connectionID: connectionID
+            )
+        case .commandResponse(let response):
+            if let error = response.error {
+                lastErrorMessage = commandErrorMessage(error)
+            }
+        }
+    }
+
+    private func beginReceiverAuthentication(
+        for peerIdentity: RemotePeerIdentity,
+        connectionID: String
+    ) {
+        if let trusted = trustedPeer(id: peerIdentity.id),
+            trusted.publicKey == peerIdentity.publicKey
+        {
+            let nonce = RemoteControlCryptography.randomNonce()
+            let data = RemoteControlCryptography.authenticationData(
+                nonce: nonce,
+                receiverID: identity.id,
+                controllerID: peerIdentity.id
+            )
+            guard let signature = try? identity.signature(for: data) else {
+                rejectConnection(message: "端末認証に失敗しました")
+                return
+            }
+            authenticationNonce = nonce
+            send(
+                RemoteControlEnvelope(
+                    payload: .authenticationChallenge(
+                        RemoteAuthenticationChallenge(
+                            nonce: nonce,
+                            receiverSignature: signature
+                        )
+                    )
+                ),
+                to: connectionID
+            )
+            return
+        }
+
+        if Date() >= pairingPINExpiresAt {
+            rotatePairingPIN()
+        }
+        let challenge = RemotePairingChallenge(
+            receiverIdentity: identity.peerIdentity,
+            nonce: RemoteControlCryptography.randomNonce()
+        )
+        pairingChallenge = challenge
+        connectionStatus = .pairing(peerIdentity.displayName)
+        send(
+            RemoteControlEnvelope(payload: .pairingRequired(challenge)),
+            to: connectionID
+        )
+    }
+
+    private func handlePairingRequired(_ challenge: RemotePairingChallenge) {
+        guard operationMode == .controller else { return }
+        if let remoteIdentity,
+            remoteIdentity.id != challenge.receiverIdentity.id
+                || remoteIdentity.publicKey != challenge.receiverIdentity.publicKey
+        {
+            rejectConnection(message: "接続先の端末情報が一致しません")
+            return
+        }
+        remoteIdentity = challenge.receiverIdentity
+        pairingChallenge = challenge
+        pairingRequest = RemotePairingRequest(
+            id: challenge.receiverIdentity.id,
+            displayName: challenge.receiverIdentity.displayName
+        )
+        connectionStatus = .pairing(challenge.receiverIdentity.displayName)
+    }
+
+    private func handlePairingResponse(
+        _ response: RemotePairingResponse,
+        connectionID: String
+    ) {
+        guard operationMode == .receiver,
+            let pairingChallenge,
+            let remoteIdentity
+        else {
+            return
+        }
+
+        let pairingData = RemoteControlCryptography.pairingData(
+            nonce: pairingChallenge.nonce,
+            receiverID: identity.id,
+            controllerID: remoteIdentity.id
+        )
+        let isValid =
+            Date() < pairingPINExpiresAt
+            && RemoteControlCryptography.verifyPairingProof(
+                response.pinProof,
+                pin: pairingPIN,
+                data: pairingData
+            )
+            && RemoteControlCryptography.verify(
+                signature: response.signature,
+                data: pairingData,
+                publicKey: remoteIdentity.publicKey
+            )
+        guard isValid else {
+            pairingFailureCount += 1
+            if pairingFailureCount >= Self.maximumPairingAttempts {
+                rotatePairingPIN()
+            }
+            send(
+                RemoteControlEnvelope(payload: .authenticationRejected),
+                to: connectionID
+            )
+            return
+        }
+
+        guard let receiverSignature = try? identity.signature(for: pairingData) else {
+            rejectConnection(message: "端末認証に失敗しました")
+            return
+        }
+        guard
+            send(
+                RemoteControlEnvelope(
+                    payload: .pairingAccepted(
+                        RemotePairingAccepted(
+                            receiverIdentity: identity.peerIdentity,
+                            signature: receiverSignature
+                        )
+                    )
+                ),
+                to: connectionID
+            )
+        else {
+            return
+        }
+        guard saveTrustedPeer(remoteIdentity) else {
+            rejectConnection(message: "登録済み端末をKeychainに保存できませんでした")
+            return
+        }
+        authorizeReceiverConnection(remoteIdentity, connectionID: connectionID)
+        rotatePairingPIN()
+    }
+
+    private func handlePairingAccepted(
+        _ accepted: RemotePairingAccepted,
+        connectionID: String
+    ) {
+        guard operationMode == .controller,
+            let pairingChallenge,
+            submittedPIN != nil,
+            awaitingAuthenticationAcceptanceConnectionID == connectionID,
+            accepted.receiverIdentity.id == pairingChallenge.receiverIdentity.id,
+            accepted.receiverIdentity.publicKey == pairingChallenge.receiverIdentity.publicKey
+        else {
+            rejectConnection(message: "接続先の端末情報が一致しません")
+            return
+        }
+        let data = RemoteControlCryptography.pairingData(
+            nonce: pairingChallenge.nonce,
+            receiverID: accepted.receiverIdentity.id,
+            controllerID: identity.id
+        )
+        guard
+            RemoteControlCryptography.verify(
+                signature: accepted.signature,
+                data: data,
+                publicKey: accepted.receiverIdentity.publicKey
+            )
+        else {
+            rejectConnection(message: "接続先を認証できませんでした")
+            return
+        }
+
+        guard saveTrustedPeer(accepted.receiverIdentity) else {
+            rejectConnection(message: "登録済み端末をKeychainに保存できませんでした")
+            return
+        }
+        remoteIdentity = accepted.receiverIdentity
+        pairingRequest = nil
+        self.submittedPIN = nil
+        authorizeControllerConnection(connectionID: connectionID)
+    }
+
+    private func handleAuthenticationChallenge(
+        _ challenge: RemoteAuthenticationChallenge,
+        connectionID: String
+    ) {
+        guard operationMode == .controller,
+            let remoteIdentity,
+            let trusted = trustedPeer(id: remoteIdentity.id),
+            trusted.publicKey == remoteIdentity.publicKey
+        else {
+            rejectConnection(message: "接続先は登録済み端末ではありません")
+            return
+        }
+
+        let data = RemoteControlCryptography.authenticationData(
+            nonce: challenge.nonce,
+            receiverID: remoteIdentity.id,
+            controllerID: identity.id
+        )
+        guard
+            RemoteControlCryptography.verify(
+                signature: challenge.receiverSignature,
+                data: data,
+                publicKey: trusted.publicKey
+            ), let responseSignature = try? identity.signature(for: data)
+        else {
+            rejectConnection(message: "接続先を認証できませんでした")
+            return
+        }
+
+        guard
+            send(
+                RemoteControlEnvelope(
+                    payload: .authenticationResponse(
+                        RemoteAuthenticationResponse(signature: responseSignature)
+                    )
+                ),
+                to: connectionID
+            )
+        else {
+            rejectConnection(message: "端末認証情報を送信できませんでした")
+            return
+        }
+        awaitingAuthenticationAcceptanceConnectionID = connectionID
+    }
+
+    private func handleAuthenticationResponse(
+        _ response: RemoteAuthenticationResponse,
+        connectionID: String
+    ) {
+        guard operationMode == .receiver,
+            let remoteIdentity,
+            let nonce = authenticationNonce,
+            let trusted = trustedPeer(id: remoteIdentity.id),
+            trusted.publicKey == remoteIdentity.publicKey
+        else {
+            rejectConnection(message: "端末を認証できませんでした")
+            return
+        }
+
+        let data = RemoteControlCryptography.authenticationData(
+            nonce: nonce,
+            receiverID: identity.id,
+            controllerID: remoteIdentity.id
+        )
+        guard
+            RemoteControlCryptography.verify(
+                signature: response.signature,
+                data: data,
+                publicKey: trusted.publicKey
+            )
+        else {
+            rejectConnection(message: "端末を認証できませんでした")
+            return
+        }
+
+        authenticationNonce = nil
+        guard saveTrustedPeer(remoteIdentity) else {
+            rejectConnection(message: "登録済み端末をKeychainに保存できませんでした")
+            return
+        }
+        guard
+            send(
+                RemoteControlEnvelope(payload: .authenticationAccepted),
+                to: connectionID
+            )
+        else {
+            rejectConnection(message: "端末認証情報を送信できませんでした")
+            return
+        }
+        authorizeReceiverConnection(remoteIdentity, connectionID: connectionID)
+    }
+
+    private func authorizeReceiverConnection(
+        _ peerIdentity: RemotePeerIdentity,
+        connectionID: String
+    ) {
+        isAuthenticated = true
+        authenticatedConnectionID = connectionID
+        connectionStatus = .connected(peerIdentity.displayName)
+        startSnapshotUpdates()
+    }
+
+    private func authorizeControllerConnection(connectionID: String) {
+        isAuthenticated = true
+        authenticatedConnectionID = connectionID
+        awaitingAuthenticationAcceptanceConnectionID = nil
+        transport.stopBrowsing()
+        pairingRequest = nil
+        pairingChallenge = nil
+        let name = remoteIdentity?.displayName ?? "Mac"
+        connectionStatus = .connected(name)
+    }
+
+    private func handleCommand(
+        _ request: RemotePlayerCommandRequest,
+        messageID: UUID,
+        connectionID: String
+    ) {
+        guard operationMode == .receiver,
+            authenticatedConnectionID == connectionID
+        else {
+            let response = RemoteCommandResponse(
+                requestID: messageID,
+                error: .unauthorized
+            )
+            send(
+                RemoteControlEnvelope(payload: .commandResponse(response)),
+                to: connectionID
+            )
+            return
+        }
+
+        if let cached = processedCommandResponses[messageID] {
+            send(
+                RemoteControlEnvelope(payload: .commandResponse(cached)),
+                to: connectionID
+            )
+            return
+        }
+
+        let response = RemoteCommandResponse(
+            requestID: messageID,
+            error: dispatcher.execute(request)
+        )
+        rememberCommandResponse(response, messageID: messageID)
+        send(
+            RemoteControlEnvelope(payload: .commandResponse(response)),
+            to: connectionID
+        )
+        sendSnapshotsIfChanged()
+    }
+
+    private func rememberCommandResponse(
+        _ response: RemoteCommandResponse,
+        messageID: UUID
+    ) {
+        processedCommandResponses[messageID] = response
+        processedCommandOrder.append(messageID)
+        if processedCommandOrder.count > 100 {
+            let removed = processedCommandOrder.removeFirst()
+            processedCommandResponses.removeValue(forKey: removed)
+        }
+    }
+
+    private func startSnapshotUpdates() {
+        snapshotTask?.cancel()
+        sendSnapshotsIfChanged(force: true)
+        snapshotTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(500))
+                guard !Task.isCancelled else { return }
+                self?.sendSnapshotsIfChanged()
+            }
+        }
+    }
+
+    private func sendSnapshotsIfChanged(force: Bool = false) {
+        guard operationMode == .receiver,
+            isAuthenticated,
+            let currentConnectionID
+        else {
+            return
+        }
+        let snapshots = dispatcher.snapshots()
+        guard force || snapshots != lastSentSnapshots else { return }
+        lastSentSnapshots = snapshots
+        send(
+            RemoteControlEnvelope(payload: .playerSnapshots(snapshots)),
+            to: currentConnectionID
+        )
+    }
+
+    @discardableResult
+    private func send(_ envelope: RemoteControlEnvelope, to connectionID: String) -> Bool {
+        do {
+            let data = try JSONEncoder().encode(envelope)
+            guard data.count <= Self.maximumMessageSize else {
+                lastErrorMessage = "リモコン通信のデータが大きすぎます"
+                return false
+            }
+            try transport.send(data, to: connectionID)
+            return true
+        } catch {
+            lastErrorMessage = "リモコン通信の送信に失敗しました"
+            return false
+        }
+    }
+
+    private func saveTrustedPeer(_ peerIdentity: RemotePeerIdentity) -> Bool {
+        let pairedAt = trustedPeer(id: peerIdentity.id)?.pairedAt ?? Date()
+        let peer = RemoteTrustedPeer(
+            id: peerIdentity.id,
+            displayName: peerIdentity.displayName,
+            publicKey: peerIdentity.publicKey,
+            pairedAt: pairedAt
+        )
+        var updatedPeers = trustedPeers.filter { $0.id != peer.id }
+        updatedPeers.append(peer)
+        updatedPeers.sort { $0.pairedAt < $1.pairedAt }
+        do {
+            try trustedPeerStore.save(updatedPeers)
+            trustedPeers = updatedPeers
+            return true
+        } catch {
+            lastErrorMessage = "登録済み端末をKeychainに保存できませんでした"
+            return false
+        }
+    }
+
+    private func trustedPeer(id: String) -> RemoteTrustedPeer? {
+        trustedPeers.first { $0.id == id }
+    }
+
+    private func loadTrustedPeersIfNeeded() -> Bool {
+        guard !hasLoadedTrustedPeers else { return true }
+        do {
+            trustedPeers = try trustedPeerStore.load()
+            hasLoadedTrustedPeers = true
+            return true
+        } catch {
+            lastErrorMessage = "登録済み端末をKeychainから読み込めませんでした"
+            return false
+        }
+    }
+
+    private func rejectConnection(message: String) {
+        lastErrorMessage = message
+        connectionStatus = .failed(message)
+        transport.disconnect()
+        resetConnectionState()
+    }
+
+    private func resetConnectionState() {
+        snapshotTask?.cancel()
+        snapshotTask = nil
+        currentConnectionID = nil
+        remoteIdentity = nil
+        pairingChallenge = nil
+        pairingRequest = nil
+        submittedPIN = nil
+        authenticationNonce = nil
+        isAuthenticated = false
+        authenticatedConnectionID = nil
+        awaitingAuthenticationAcceptanceConnectionID = nil
+        remotePlayers = []
+        selectedPlayerID = nil
+        lastSentSnapshots = []
+        processedCommandResponses.removeAll()
+        processedCommandOrder.removeAll()
+    }
+
+    private func commandErrorMessage(_ error: RemoteCommandError) -> String {
+        switch error {
+        case .playerNotFound:
+            "選択したプレイヤーは終了しています"
+        case .unsupported:
+            "この操作には対応していません"
+        case .invalidValue:
+            "操作内容が正しくありません"
+        case .unavailable:
+            "現在この操作は利用できません"
+        case .unauthorized:
+            "リモコンが認証されていません"
+        }
+    }
+
+    private static func localDisplayName() -> String {
+        let name = ProcessInfo.processInfo.hostName
+            .replacingOccurrences(of: ".local", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? "kiririn" : name
+    }
+}

--- a/kiririn/Features/RemoteControl/RemoteControlSettingsView.swift
+++ b/kiririn/Features/RemoteControl/RemoteControlSettingsView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct RemoteControlSettingsView: View {
+    let service: RemoteControlService
+
+    var body: some View {
+        Group {
+            #if os(macOS)
+                RemoteReceiverSettingsView(service: service)
+            #else
+                RemoteDestinationListView(service: service)
+            #endif
+        }
+        .task {
+            service.prepare()
+        }
+    }
+}

--- a/kiririn/Features/RemoteControl/RemoteIdentityStore.swift
+++ b/kiririn/Features/RemoteControl/RemoteIdentityStore.swift
@@ -1,0 +1,69 @@
+import CryptoKit
+import Foundation
+
+nonisolated struct RemoteLocalIdentity: Sendable {
+    let id: String
+    let displayName: String
+    let privateKey: Curve25519.Signing.PrivateKey
+
+    var peerIdentity: RemotePeerIdentity {
+        RemotePeerIdentity(
+            id: id,
+            displayName: displayName,
+            publicKey: privateKey.publicKey.rawRepresentation
+        )
+    }
+
+    func signature(for data: Data) throws -> Data {
+        try privateKey.signature(for: data)
+    }
+}
+
+private nonisolated struct StoredRemoteIdentity: Codable {
+    let id: String
+    let privateKey: Data
+}
+
+nonisolated struct RemoteIdentityStore: Sendable {
+    private let account = "local-device"
+    private let store = KeychainDataStore(
+        service: "jp.pronama.kiririn.remote.identity",
+        label: "kiririn Remote Control Identity",
+        accessibility: .afterFirstUnlockThisDeviceOnly
+    )
+
+    func loadOrCreate(displayName: String) throws -> RemoteLocalIdentity {
+        if let stored = try load() {
+            let privateKey = try Curve25519.Signing.PrivateKey(
+                rawRepresentation: stored.privateKey
+            )
+            return RemoteLocalIdentity(
+                id: stored.id,
+                displayName: displayName,
+                privateKey: privateKey
+            )
+        }
+
+        let privateKey = Curve25519.Signing.PrivateKey()
+        let stored = StoredRemoteIdentity(
+            id: UUID().uuidString,
+            privateKey: privateKey.rawRepresentation
+        )
+        try save(stored)
+        return RemoteLocalIdentity(
+            id: stored.id,
+            displayName: displayName,
+            privateKey: privateKey
+        )
+    }
+
+    private func load() throws -> StoredRemoteIdentity? {
+        guard let data = try store.load(account: account) else { return nil }
+        return try JSONDecoder().decode(StoredRemoteIdentity.self, from: data)
+    }
+
+    private func save(_ identity: StoredRemoteIdentity) throws {
+        let data = try JSONEncoder().encode(identity)
+        try store.save(data, account: account)
+    }
+}

--- a/kiririn/Features/RemoteControl/RemotePlayerCommandDispatcher.swift
+++ b/kiririn/Features/RemoteControl/RemotePlayerCommandDispatcher.swift
@@ -171,6 +171,7 @@ final class RemotePlayerCommandDispatcher {
             isRecording: state.isRecording,
             isSubtitleEnabled: state.isSubtitleEnabled,
             isPipEnabled: state.isPipEnabled,
+            isDataBroadcastVisible: state.bmlContentVisible,
             isFullscreen: windowSnapshot?.isFullscreen,
             isAlwaysOnTop: windowSnapshot?.isAlwaysOnTop,
             capabilities: capabilities,

--- a/kiririn/Features/RemoteControl/RemotePlayerCommandDispatcher.swift
+++ b/kiririn/Features/RemoteControl/RemotePlayerCommandDispatcher.swift
@@ -1,0 +1,245 @@
+import Foundation
+import VLCKit
+
+@MainActor
+protocol RemotePlayerWindowEndpoint: AnyObject {
+    var snapshot: RemoteWindowSnapshot { get }
+
+    func showVolumeFeedback()
+    func setFullscreen(_ enabled: Bool) -> RemoteCommandError?
+    func setAlwaysOnTop(_ enabled: Bool) -> RemoteCommandError?
+    func close() -> RemoteCommandError?
+}
+
+@MainActor
+final class RemotePlayerCommandDispatcher {
+    private weak var appModel: AppModel?
+    private var windowEndpoints: [String: any RemotePlayerWindowEndpoint] = [:]
+
+    func configure(appModel: AppModel) {
+        self.appModel = appModel
+    }
+
+    func register(
+        _ endpoint: any RemotePlayerWindowEndpoint,
+        forPlayerID playerID: String
+    ) {
+        windowEndpoints[playerID] = endpoint
+    }
+
+    func unregisterWindowEndpoint(forPlayerID playerID: String) {
+        windowEndpoints.removeValue(forKey: playerID)
+    }
+
+    func snapshots() -> [RemotePlayerSnapshot] {
+        guard let appModel else { return [] }
+        return appModel.activePlayerStates.compactMap { state in
+            guard state.currentPlayable != nil else { return nil }
+            return makeSnapshot(for: state)
+        }
+    }
+
+    func execute(_ request: RemotePlayerCommandRequest) -> RemoteCommandError? {
+        guard let state = playerState(id: request.playerID) else {
+            return .playerNotFound
+        }
+
+        switch request.command {
+        case .setPlaying(let enabled):
+            guard state.player != nil else { return .unavailable }
+            state.setPlaying(enabled)
+        case .seekToTime(let time):
+            guard time.isFinite, time >= 0 else { return .invalidValue }
+            guard state.player?.isSeekable == true else { return .unavailable }
+            state.seek(toTime: time)
+        case .skipBy(let seconds):
+            guard seconds.isFinite else { return .invalidValue }
+            guard state.player?.isSeekable == true else { return .unavailable }
+            state.skip(by: seconds)
+        case .setRate(let rate):
+            guard PlayerPlaybackOptionCatalog.rateOptions.contains(rate) else {
+                return .invalidValue
+            }
+            state.setRate(rate)
+        case .setVolume(let volume):
+            guard volume.isFinite, (0...200).contains(volume) else { return .invalidValue }
+            state.setVolume(volume)
+            windowEndpoints[request.playerID]?.showVolumeFeedback()
+        case .setMuted(let enabled):
+            state.setMuted(enabled)
+            windowEndpoints[request.playerID]?.showVolumeFeedback()
+        case .selectAudioTrack(let remoteSelection):
+            if let remoteSelection {
+                guard
+                    let track = state.availableAudioTracks.first(where: {
+                        $0.id == remoteSelection.trackID
+                    }),
+                    let selection = playerAudioTrackSelection(
+                        remoteSelection,
+                        track: track
+                    )
+                else {
+                    return .invalidValue
+                }
+                state.selectAudioTrack(selection)
+            } else {
+                state.selectAudioTrack(nil)
+            }
+        case .selectVideoTrack(let trackID):
+            guard let track = state.availableVideoTracks.first(where: { $0.id == trackID }) else {
+                return .invalidValue
+            }
+            state.selectVideoTrack(track)
+        case .setSubtitleEnabled(let enabled):
+            state.setSubtitleEnabled(enabled)
+        case .setPipEnabled(let enabled):
+            guard state.isPipAvailable else { return .unavailable }
+            state.setPipEnabled(enabled)
+        case .takeCapture:
+            guard state.player != nil else { return .unavailable }
+            state.takeCapture()
+        case .setRecording(let enabled):
+            guard !enabled || state.isPlaying else { return .unavailable }
+            state.setRecording(enabled)
+        case .reload:
+            state.reloadCurrentPlayable()
+        case .pressBMLKey(let keyCode):
+            guard state.pressBMLKey(keyCode) else { return .unavailable }
+        case .setFullscreen(let enabled):
+            guard let endpoint = windowEndpoints[request.playerID] else {
+                return .unsupported
+            }
+            return endpoint.setFullscreen(enabled)
+        case .setAlwaysOnTop(let enabled):
+            guard let endpoint = windowEndpoints[request.playerID] else {
+                return .unsupported
+            }
+            return endpoint.setAlwaysOnTop(enabled)
+        case .close:
+            guard let endpoint = windowEndpoints[request.playerID] else {
+                return .unsupported
+            }
+            return endpoint.close()
+        }
+        return nil
+    }
+
+    private func playerState(id: String) -> PlayerState? {
+        appModel?.activePlayerStates.first { state in
+            state.id == id && state.currentPlayable != nil
+        }
+    }
+
+    private func makeSnapshot(for state: PlayerState) -> RemotePlayerSnapshot {
+        let windowSnapshot = windowEndpoints[state.id]?.snapshot
+        let status = state.playbackStatus
+        let duration = state.currentPlayable?.length ?? 0
+
+        var capabilities: Set<RemoteControlCapability> = [
+            .playback, .rate, .volume, .subtitle, .capture, .recording, .reload,
+        ]
+        if state.player?.isSeekable == true {
+            capabilities.insert(.seek)
+        }
+        if !state.availableAudioTracks.isEmpty {
+            capabilities.insert(.audioTrack)
+        }
+        if !state.availableVideoTracks.isEmpty {
+            capabilities.insert(.videoTrack)
+        }
+        if state.isPipAvailable {
+            capabilities.insert(.pictureInPicture)
+        }
+        if state.bmlAvailable {
+            capabilities.insert(.dataBroadcast)
+        }
+        if windowSnapshot != nil {
+            capabilities.formUnion([.fullscreen, .alwaysOnTop, .close])
+        }
+
+        return RemotePlayerSnapshot(
+            id: state.id,
+            title: state.currentPlayable?.title ?? "プレイヤー",
+            serviceName: state.currentPlayable?.serviceName,
+            isPlaying: state.isPlaying,
+            isSeekable: state.player?.isSeekable ?? false,
+            time: status.time,
+            duration: duration,
+            rate: state.playbackRate,
+            volume: state.volume,
+            isMuted: state.isMuted,
+            isRecording: state.isRecording,
+            isSubtitleEnabled: state.isSubtitleEnabled,
+            isPipEnabled: state.isPipEnabled,
+            isFullscreen: windowSnapshot?.isFullscreen,
+            isAlwaysOnTop: windowSnapshot?.isAlwaysOnTop,
+            capabilities: capabilities,
+            audioTracks: state.availableAudioTracks.enumerated().flatMap { index, track in
+                PlayerAudioTrackSelection.options(for: track).map { selection in
+                    RemoteControlAudioTrackOption(
+                        selection: remoteAudioTrackSelection(selection),
+                        label: PlayerPlaybackOptionCatalog.audioTrackLabel(
+                            index: index,
+                            selection: selection
+                        )
+                    )
+                }
+            },
+            selectedAudioTrackSelection: state.selectedAudioTrackSelection.map(
+                remoteAudioTrackSelection
+            ),
+            videoTracks: state.availableVideoTracks.enumerated().map { index, track in
+                RemoteControlTrack(
+                    id: track.id,
+                    name: PlayerPlaybackOptionCatalog.videoTrackLabel(
+                        index: index,
+                        track: track
+                    ),
+                    detail: nil
+                )
+            },
+            selectedVideoTrackID: state.selectedVideoTrack?.id,
+            bmlKeyGroups: state.bmlContentVisible
+                ? Set(
+                    state.dataBroadcastSession?.usedKeyGroups.compactMap(
+                        BMLKeyGroup.init(rawValue:)
+                    ) ?? []
+                )
+                : []
+        )
+    }
+
+    private func playerAudioTrackSelection(
+        _ selection: RemoteAudioTrackSelection,
+        track: PlayerAudioTrack
+    ) -> PlayerAudioTrackSelection? {
+        switch (track.isDualMono, selection.role) {
+        case (false, nil):
+            PlayerAudioTrackSelection.current(track: track, stereoMode: .unset)
+        case (true, .main):
+            PlayerAudioTrackSelection.current(track: track, stereoMode: .left)
+        case (true, .sub):
+            PlayerAudioTrackSelection.current(track: track, stereoMode: .right)
+        case (false, .main), (false, .sub), (true, nil):
+            nil
+        }
+    }
+
+    private func remoteAudioTrackSelection(
+        _ selection: PlayerAudioTrackSelection
+    ) -> RemoteAudioTrackSelection {
+        let role: RemoteAudioTrackSelection.Role? =
+            switch selection.dualMonoRole {
+            case .main:
+                .main
+            case .sub:
+                .sub
+            case nil:
+                nil
+            }
+        return RemoteAudioTrackSelection(
+            trackID: selection.track.id,
+            role: role
+        )
+    }
+}

--- a/kiririn/Features/RemoteControl/RemoteTrustedPeerStore.swift
+++ b/kiririn/Features/RemoteControl/RemoteTrustedPeerStore.swift
@@ -1,8 +1,16 @@
 import Foundation
 
+nonisolated protocol RemoteTrustedPeerDataStoring: Sendable {
+    func load(account: String) throws -> Data?
+    func save(_ data: Data, account: String) throws
+    func delete(account: String) throws
+}
+
+extension KeychainDataStore: RemoteTrustedPeerDataStoring {}
+
 nonisolated struct RemoteTrustedPeerStore {
     private let account = "trusted-peers"
-    private let store: KeychainDataStore
+    private let store: any RemoteTrustedPeerDataStoring
 
     init(service: String = "jp.pronama.kiririn.remote.trust") {
         store = KeychainDataStore(
@@ -10,6 +18,10 @@ nonisolated struct RemoteTrustedPeerStore {
             label: "kiririn Remote Control Trusted Peers",
             accessibility: .afterFirstUnlockThisDeviceOnly
         )
+    }
+
+    init(store: any RemoteTrustedPeerDataStoring) {
+        self.store = store
     }
 
     func load() throws -> [RemoteTrustedPeer] {

--- a/kiririn/Features/RemoteControl/RemoteTrustedPeerStore.swift
+++ b/kiririn/Features/RemoteControl/RemoteTrustedPeerStore.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+nonisolated struct RemoteTrustedPeerStore {
+    private let account = "trusted-peers"
+    private let store: KeychainDataStore
+
+    init(service: String = "jp.pronama.kiririn.remote.trust") {
+        store = KeychainDataStore(
+            service: service,
+            label: "kiririn Remote Control Trusted Peers",
+            accessibility: .afterFirstUnlockThisDeviceOnly
+        )
+    }
+
+    func load() throws -> [RemoteTrustedPeer] {
+        guard let data = try store.load(account: account) else { return [] }
+        let peers = try JSONDecoder().decode([RemoteTrustedPeer].self, from: data)
+        return peers.sorted { $0.pairedAt < $1.pairedAt }
+    }
+
+    func save(_ peers: [RemoteTrustedPeer]) throws {
+        let data = try JSONEncoder().encode(peers)
+        try store.save(data, account: account)
+    }
+
+    func removeAll() throws {
+        try store.delete(account: account)
+    }
+}

--- a/kiririn/Features/RemoteControl/iOS/PlayerRemoteControlView.swift
+++ b/kiririn/Features/RemoteControl/iOS/PlayerRemoteControlView.swift
@@ -1,0 +1,48 @@
+#if os(iOS)
+    import SwiftUI
+
+    struct PlayerRemoteControlView: View {
+        @Environment(\.dismiss) private var dismiss
+
+        let service: RemoteControlService
+        let playerID: String
+
+        var body: some View {
+            Group {
+                if let player {
+                    ScrollView {
+                        RemotePlayerControlPanel(
+                            service: service,
+                            player: player,
+                            send: { command in
+                                service.sendCommand(command, playerID: playerID)
+                            }
+                        )
+                        .padding(.horizontal)
+                        .padding(.bottom)
+                    }
+                } else {
+                    ContentUnavailableView(
+                        "プレイヤーを操作できません",
+                        systemImage: "play.slash",
+                        description: Text("プレイヤーが終了した可能性があります")
+                    )
+                }
+            }
+            .navigationTitle("リモコン")
+            .navigationBarTitleDisplayMode(.inline)
+            .onChange(of: isPlayerAvailable, initial: true) { _, isAvailable in
+                guard !isAvailable else { return }
+                dismiss()
+            }
+        }
+
+        private var player: RemotePlayerSnapshot? {
+            service.remotePlayers.first { $0.id == playerID }
+        }
+
+        private var isPlayerAvailable: Bool {
+            player != nil
+        }
+    }
+#endif

--- a/kiririn/Features/RemoteControl/iOS/RemoteActionButton.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemoteActionButton.swift
@@ -1,0 +1,39 @@
+#if os(iOS)
+    import SwiftUI
+
+    struct RemoteActionButton: View {
+        let title: String
+        let systemImage: String
+        var isActive = false
+        var isDisabled = false
+        var role: ButtonRole?
+        let action: () -> Void
+
+        var body: some View {
+            Button(role: role, action: action) {
+                VStack(spacing: 5) {
+                    Image(systemName: systemImage)
+                        .font(.title3)
+                        .frame(height: 22)
+                        .overlay(alignment: .topTrailing) {
+                            if isActive {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .font(.caption)
+                                    .symbolRenderingMode(.palette)
+                                    .foregroundStyle(.white, Color.accentColor)
+                                    .offset(x: 8, y: -5)
+                            }
+                        }
+                    Text(title)
+                        .font(.caption)
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity, minHeight: 58)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.bordered)
+            .tint(role == .destructive ? .red : nil)
+            .disabled(isDisabled)
+        }
+    }
+#endif

--- a/kiririn/Features/RemoteControl/iOS/RemoteControlCardModifier.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemoteControlCardModifier.swift
@@ -1,0 +1,17 @@
+#if os(iOS)
+    import SwiftUI
+
+    struct RemoteControlCardModifier: ViewModifier {
+        func body(content: Content) -> some View {
+            content
+                .padding(14)
+                .background(.quaternary, in: RoundedRectangle(cornerRadius: 16))
+        }
+    }
+
+    extension View {
+        func remoteControlCard() -> some View {
+            modifier(RemoteControlCardModifier())
+        }
+    }
+#endif

--- a/kiririn/Features/RemoteControl/iOS/RemoteDataBroadcastControlView.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemoteDataBroadcastControlView.swift
@@ -39,7 +39,8 @@
             let isAvailable = player.capabilities.contains(.dataBroadcast)
             return BMLRemoteControlAvailability(
                 isDataButtonEnabled: isAvailable,
-                enabledGroups: isAvailable ? player.bmlKeyGroups : []
+                enabledGroups: isAvailable && player.isDataBroadcastVisible
+                    ? player.bmlKeyGroups : []
             )
         }
     }

--- a/kiririn/Features/RemoteControl/iOS/RemoteDataBroadcastControlView.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemoteDataBroadcastControlView.swift
@@ -1,0 +1,46 @@
+#if os(iOS)
+    import SwiftUI
+
+    struct RemoteDataBroadcastControlView: View {
+        let service: RemoteControlService
+        let playerID: String
+
+        var body: some View {
+            Group {
+                if let player {
+                    ScrollView {
+                        BMLRemoteControlPad(
+                            layout: .touch,
+                            availability: availability(for: player)
+                        ) { key in
+                            service.sendCommand(.pressBMLKey(key), playerID: playerID)
+                        }
+                        .padding()
+                    }
+                } else {
+                    ContentUnavailableView(
+                        "プレイヤーを操作できません",
+                        systemImage: "play.slash",
+                        description: Text("プレイヤーが終了した可能性があります")
+                    )
+                }
+            }
+            .navigationTitle("データ放送")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+
+        private var player: RemotePlayerSnapshot? {
+            service.remotePlayers.first { $0.id == playerID }
+        }
+
+        private func availability(
+            for player: RemotePlayerSnapshot
+        ) -> BMLRemoteControlAvailability {
+            let isAvailable = player.capabilities.contains(.dataBroadcast)
+            return BMLRemoteControlAvailability(
+                isDataButtonEnabled: isAvailable,
+                enabledGroups: isAvailable ? player.bmlKeyGroups : []
+            )
+        }
+    }
+#endif

--- a/kiririn/Features/RemoteControl/iOS/RemoteDataBroadcastNavigationButton.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemoteDataBroadcastNavigationButton.swift
@@ -1,0 +1,34 @@
+#if os(iOS)
+    import SwiftUI
+
+    struct RemoteDataBroadcastNavigationButton: View {
+        let service: RemoteControlService
+        let playerID: String
+        let isAvailable: Bool
+
+        var body: some View {
+            NavigationLink {
+                RemoteDataBroadcastControlView(
+                    service: service,
+                    playerID: playerID
+                )
+            } label: {
+                VStack(spacing: 5) {
+                    Text("d")
+                        .italic()
+                        .bold()
+                        .font(.title3)
+                        .frame(height: 22)
+                    Text("データ")
+                        .font(.caption)
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity, minHeight: 58)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.bordered)
+            .disabled(!isAvailable)
+            .accessibilityLabel("データ放送リモコン")
+        }
+    }
+#endif

--- a/kiririn/Features/RemoteControl/iOS/RemoteDestinationListView.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemoteDestinationListView.swift
@@ -121,7 +121,7 @@
                 "停止中"
             case .browsing:
                 "検索中"
-            case .connecting(let name):
+            case .connecting(_, let name):
                 "\(name)へ接続中"
             case .pairing(let name):
                 "\(name)とペアリング中"
@@ -142,10 +142,10 @@
         }
 
         private func isConnecting(to peer: RemoteDiscoveredPeer) -> Bool {
-            guard case .connecting(let name) = service.connectionStatus else {
+            guard case .connecting(let peerID, _) = service.connectionStatus else {
                 return false
             }
-            return name == peer.displayName
+            return peerID == peer.id
         }
 
         private var errorPresentationBinding: Binding<Bool> {

--- a/kiririn/Features/RemoteControl/iOS/RemoteDestinationListView.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemoteDestinationListView.swift
@@ -85,7 +85,7 @@
                     ContentUnavailableView(
                         "接続先が見つかりません",
                         systemImage: "macbook.trianglebadge.exclamationmark",
-                        description: Text("接続するにはリモコン機能を有効化する必要があります")
+                        description: Text("接続するには接続先でリモコン機能を有効化する必要があります")
                     )
                 } else {
                     ForEach(service.discoveredPeers) { peer in

--- a/kiririn/Features/RemoteControl/iOS/RemoteDestinationListView.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemoteDestinationListView.swift
@@ -1,0 +1,174 @@
+#if os(iOS)
+    import SwiftUI
+
+    struct RemoteDestinationListView: View {
+        let service: RemoteControlService
+        @State private var presentedPairingRequest: RemotePairingRequest?
+        @State private var pairingPIN = ""
+        @State private var isPairingAlertPresented = false
+        @State private var presentedErrorMessage: String?
+
+        var body: some View {
+            List {
+                connectionSection
+                if isConnected {
+                    RemotePlayerSection(service: service)
+                } else {
+                    destinationsSection
+                }
+            }
+            .navigationTitle("リモコン")
+            .task {
+                service.startBrowsing()
+            }
+            .onDisappear {
+                service.stopBrowsing()
+            }
+            .onChange(of: service.pairingRequest) { _, request in
+                presentedPairingRequest = request
+                pairingPIN = ""
+                isPairingAlertPresented = request != nil
+            }
+            .onChange(of: service.lastErrorMessage) { _, message in
+                presentedErrorMessage = message
+            }
+            .alert(
+                "PINコードを入力",
+                isPresented: $isPairingAlertPresented,
+                presenting: presentedPairingRequest
+            ) { _ in
+                TextField("6桁のPINコード", text: $pairingPIN)
+                    .keyboardType(.numberPad)
+                    .textContentType(.oneTimeCode)
+                    .onChange(of: pairingPIN) { _, newValue in
+                        pairingPIN = String(newValue.filter(\.isNumber).prefix(6))
+                    }
+
+                Button("キャンセル", role: .cancel, action: cancelPairing)
+                Button("接続", action: submitPairingPIN)
+                    .disabled(pairingPIN.count != 6)
+            } message: { request in
+                Text("\(request.displayName)に表示されている6桁の番号を入力してください")
+            }
+            .alert(
+                "リモコン接続エラー",
+                isPresented: errorPresentationBinding
+            ) {
+                Button("OK") {
+                    service.clearError()
+                }
+            } message: {
+                Text(presentedErrorMessage ?? "")
+            }
+        }
+
+        @ViewBuilder
+        private var connectionSection: some View {
+            Section {
+                LabeledContent("状態") {
+                    Text(statusText)
+                        .foregroundStyle(.secondary)
+                }
+
+                if case .connected = service.connectionStatus {
+                    Button("切断", role: .destructive) {
+                        service.disconnect()
+                    }
+                }
+            }
+        }
+
+        @ViewBuilder
+        private var destinationsSection: some View {
+            Section("接続先") {
+                if service.discoveredPeers.isEmpty {
+                    ContentUnavailableView(
+                        "接続先が見つかりません",
+                        systemImage: "macbook.trianglebadge.exclamationmark",
+                        description: Text("接続するにはリモコン機能を有効化する必要があります")
+                    )
+                } else {
+                    ForEach(service.discoveredPeers) { peer in
+                        Button {
+                            service.connect(to: peer)
+                        } label: {
+                            HStack {
+                                Label(peer.displayName, systemImage: "macbook")
+                                Spacer()
+                                if isConnecting(to: peer) {
+                                    ProgressView()
+                                }
+                            }
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(isBusy)
+                    }
+                }
+            }
+        }
+
+        private var isConnected: Bool {
+            guard case .connected = service.connectionStatus else {
+                return false
+            }
+            return true
+        }
+
+        private var statusText: String {
+            switch service.connectionStatus {
+            case .idle:
+                "停止中"
+            case .browsing:
+                "検索中"
+            case .connecting(let name):
+                "\(name)へ接続中"
+            case .pairing(let name):
+                "\(name)とペアリング中"
+            case .connected(let name):
+                "\(name)へ接続済み"
+            case .failed:
+                "接続できませんでした"
+            }
+        }
+
+        private var isBusy: Bool {
+            switch service.connectionStatus {
+            case .connecting, .pairing, .connected:
+                true
+            default:
+                false
+            }
+        }
+
+        private func isConnecting(to peer: RemoteDiscoveredPeer) -> Bool {
+            guard case .connecting(let name) = service.connectionStatus else {
+                return false
+            }
+            return name == peer.displayName
+        }
+
+        private var errorPresentationBinding: Binding<Bool> {
+            Binding(
+                get: { presentedErrorMessage != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        presentedErrorMessage = nil
+                        service.clearError()
+                    }
+                }
+            )
+        }
+
+        private func submitPairingPIN() {
+            guard pairingPIN.count == 6 else { return }
+            service.submitPairingPIN(pairingPIN)
+        }
+
+        private func cancelPairing() {
+            presentedPairingRequest = nil
+            pairingPIN = ""
+            service.cancelPairing()
+        }
+    }
+#endif

--- a/kiririn/Features/RemoteControl/iOS/RemoteOptionControls.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemoteOptionControls.swift
@@ -1,0 +1,116 @@
+#if os(iOS)
+    import SwiftUI
+
+    struct RemoteOptionControls: View {
+        let player: RemotePlayerSnapshot
+        let send: (RemoteControlCommand) -> Void
+
+        var body: some View {
+            HStack(spacing: 8) {
+                if player.capabilities.contains(.rate) {
+                    Menu {
+                        ForEach(PlayerPlaybackOptionCatalog.rateOptions, id: \.self) { rate in
+                            Button(PlayerPlaybackOptionCatalog.rateLabel(rate)) {
+                                send(.setRate(rate))
+                            }
+                        }
+                    } label: {
+                        optionLabel(
+                            title: "速度",
+                            value: PlayerPlaybackOptionCatalog.rateLabel(player.rate),
+                            systemImage: "speedometer"
+                        )
+                    }
+                }
+
+                if player.capabilities.contains(.audioTrack) {
+                    Menu {
+                        Picker(
+                            "音声トラック",
+                            selection: Binding<RemoteAudioTrackSelection?>(
+                                get: { player.selectedAudioTrackSelection },
+                                set: { send(.selectAudioTrack($0)) }
+                            )
+                        ) {
+                            Text("トラックなし")
+                                .tag(RemoteAudioTrackSelection?.none)
+                                .disabled(true)
+                                .selectionDisabled()
+                            ForEach(player.audioTracks) { track in
+                                Text(track.label)
+                                    .tag(RemoteAudioTrackSelection?.some(track.selection))
+                            }
+                        }
+                        .labelsHidden()
+                    } label: {
+                        optionLabel(
+                            title: "音声",
+                            value: selectedAudioTrackName,
+                            systemImage: "waveform"
+                        )
+                    }
+                }
+
+                if player.capabilities.contains(.videoTrack) {
+                    Menu {
+                        Picker(
+                            "映像トラック",
+                            selection: Binding<String?>(
+                                get: { player.selectedVideoTrackID },
+                                set: {
+                                    guard let trackID = $0 else { return }
+                                    send(.selectVideoTrack(trackID))
+                                }
+                            )
+                        ) {
+                            Text("トラックなし")
+                                .tag(String?.none)
+                                .disabled(true)
+                                .selectionDisabled()
+                            ForEach(player.videoTracks) { track in
+                                Text(track.name)
+                                    .tag(String?.some(track.id))
+                            }
+                        }
+                        .labelsHidden()
+                    } label: {
+                        optionLabel(
+                            title: "映像",
+                            value: selectedVideoTrackName,
+                            systemImage: "film"
+                        )
+                    }
+                }
+            }
+            .remoteControlCard()
+        }
+
+        private func optionLabel(
+            title: String,
+            value: String,
+            systemImage: String
+        ) -> some View {
+            VStack(spacing: 4) {
+                Label(title, systemImage: systemImage)
+                    .font(.subheadline)
+                Text(value)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, minHeight: 48)
+            .contentShape(Rectangle())
+        }
+
+        private var selectedAudioTrackName: String {
+            player.audioTracks.first {
+                $0.selection == player.selectedAudioTrackSelection
+            }?.label ?? "トラックなし"
+        }
+
+        private var selectedVideoTrackName: String {
+            player.videoTracks.first { $0.id == player.selectedVideoTrackID }?.name
+                ?? "トラックなし"
+        }
+    }
+#endif

--- a/kiririn/Features/RemoteControl/iOS/RemotePlaybackControls.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemotePlaybackControls.swift
@@ -1,0 +1,83 @@
+#if os(iOS)
+    import SwiftUI
+
+    struct RemotePlaybackControls: View {
+        let player: RemotePlayerSnapshot
+        let send: (RemoteControlCommand) -> Void
+        @State private var seekTime = 0.0
+        @State private var isSeeking = false
+
+        var body: some View {
+            VStack(spacing: 10) {
+                if player.isSeekable {
+                    HStack {
+                        Text(seekTime.playerTimeString)
+                        Spacer()
+                        Text(player.duration.playerTimeString)
+                    }
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+
+                    Slider(
+                        value: $seekTime,
+                        in: 0...max(player.duration, 1),
+                        onEditingChanged: seekEditingChanged
+                    )
+                    .accessibilityLabel("再生位置")
+                }
+
+                HStack(spacing: 14) {
+                    RemoteTransportButton(
+                        title: "10秒戻る",
+                        systemImage: "gobackward.10",
+                        isDisabled: !player.isSeekable,
+                        action: skipBackward
+                    )
+
+                    RemoteTransportButton(
+                        title: player.isPlaying ? "一時停止" : "再生",
+                        systemImage: player.isPlaying ? "pause.fill" : "play.fill",
+                        isPrimary: true,
+                        action: togglePlayback
+                    )
+
+                    RemoteTransportButton(
+                        title: "10秒進む",
+                        systemImage: "goforward.10",
+                        isDisabled: !player.isSeekable,
+                        action: skipForward
+                    )
+                }
+            }
+            .onAppear {
+                seekTime = player.time
+            }
+            .onChange(of: player.time) { _, time in
+                if !isSeeking {
+                    seekTime = time
+                }
+            }
+            .remoteControlCard()
+        }
+
+        private func seekEditingChanged(_ editing: Bool) {
+            isSeeking = editing
+            if !editing {
+                send(.seekToTime(seekTime))
+            }
+        }
+
+        private func skipBackward() {
+            send(.skipBy(-10))
+        }
+
+        private func togglePlayback() {
+            send(.setPlaying(!player.isPlaying))
+        }
+
+        private func skipForward() {
+            send(.skipBy(10))
+        }
+    }
+
+#endif

--- a/kiririn/Features/RemoteControl/iOS/RemotePlayerControlPanel.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemotePlayerControlPanel.swift
@@ -1,0 +1,23 @@
+#if os(iOS)
+    import SwiftUI
+
+    struct RemotePlayerControlPanel: View {
+        let service: RemoteControlService
+        let player: RemotePlayerSnapshot
+        let send: (RemoteControlCommand) -> Void
+
+        var body: some View {
+            VStack(spacing: 12) {
+                RemotePlayerHeaderView(player: player)
+                RemotePlaybackControls(player: player, send: send)
+                RemoteVolumeControls(player: player, send: send)
+                RemoteOptionControls(player: player, send: send)
+                RemoteQuickActionsView(
+                    service: service,
+                    player: player,
+                    send: send
+                )
+            }
+        }
+    }
+#endif

--- a/kiririn/Features/RemoteControl/iOS/RemotePlayerHeaderView.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemotePlayerHeaderView.swift
@@ -1,0 +1,42 @@
+#if os(iOS)
+    import SwiftUI
+
+    struct RemotePlayerHeaderView: View {
+        let player: RemotePlayerSnapshot
+
+        var body: some View {
+            HStack(spacing: 12) {
+                Image(systemName: "tv")
+                    .font(.title2)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 36, height: 36)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    BroadcastText(
+                        player.title,
+                        style: .headline,
+                        weight: .semibold
+                    )
+                    .lineLimit(2)
+                    if let serviceName = player.serviceName {
+                        Text(serviceName)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer(minLength: 8)
+
+                if player.isRecording {
+                    Label("録画中", systemImage: "record.circle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .labelStyle(.iconOnly)
+                        .accessibilityLabel("録画中")
+                }
+            }
+            .remoteControlCard()
+        }
+    }
+#endif

--- a/kiririn/Features/RemoteControl/iOS/RemotePlayerSection.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemotePlayerSection.swift
@@ -1,0 +1,50 @@
+#if os(iOS)
+    import SwiftUI
+
+    struct RemotePlayerSection: View {
+        let service: RemoteControlService
+
+        var body: some View {
+            Section("プレイヤー") {
+                if service.remotePlayers.isEmpty {
+                    ContentUnavailableView(
+                        "プレイヤーがありません",
+                        systemImage: "play.slash",
+                        description: Text("接続先で番組またはファイルを再生してください")
+                    )
+                } else {
+                    ForEach(service.remotePlayers) { player in
+                        NavigationLink {
+                            PlayerRemoteControlView(
+                                service: service,
+                                playerID: player.id
+                            )
+                        } label: {
+                            HStack(spacing: 12) {
+                                Image(
+                                    systemName: player.isPlaying
+                                        ? "play.circle.fill"
+                                        : "pause.circle"
+                                )
+                                .font(.title2)
+                                .foregroundStyle(player.isPlaying ? Color.accentColor : .secondary)
+
+                                VStack(alignment: .leading, spacing: 3) {
+                                    BroadcastText(player.title)
+                                        .lineLimit(2)
+                                    if let serviceName = player.serviceName {
+                                        Text(serviceName)
+                                            .font(.subheadline)
+                                            .foregroundStyle(.secondary)
+                                            .lineLimit(1)
+                                    }
+                                }
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+            }
+        }
+    }
+#endif

--- a/kiririn/Features/RemoteControl/iOS/RemoteQuickActionsView.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemoteQuickActionsView.swift
@@ -1,0 +1,115 @@
+#if os(iOS)
+    import SwiftUI
+
+    struct RemoteQuickActionsView: View {
+        let service: RemoteControlService
+        let player: RemotePlayerSnapshot
+        let send: (RemoteControlCommand) -> Void
+        @State private var isCloseConfirmationPresented = false
+
+        private let columns = [
+            GridItem(.flexible()),
+            GridItem(.flexible()),
+            GridItem(.flexible()),
+            GridItem(.flexible()),
+        ]
+
+        var body: some View {
+            LazyVGrid(columns: columns, spacing: 8) {
+                if player.capabilities.contains(.subtitle) {
+                    RemoteActionButton(
+                        title: "字幕",
+                        systemImage: "captions.bubble",
+                        isActive: player.isSubtitleEnabled
+                    ) {
+                        send(.setSubtitleEnabled(!player.isSubtitleEnabled))
+                    }
+                }
+
+                if player.capabilities.contains(.pictureInPicture) {
+                    RemoteActionButton(
+                        title: "PiP",
+                        systemImage: "pip",
+                        isActive: player.isPipEnabled
+                    ) {
+                        send(.setPipEnabled(!player.isPipEnabled))
+                    }
+                }
+
+                if player.capabilities.contains(.capture) {
+                    RemoteActionButton(title: "撮影", systemImage: "camera") {
+                        send(.takeCapture)
+                    }
+                }
+
+                if player.capabilities.contains(.recording) {
+                    RemoteActionButton(
+                        title: "録画",
+                        systemImage: player.isRecording ? "stop.circle.fill" : "record.circle",
+                        isActive: player.isRecording
+                    ) {
+                        send(.setRecording(!player.isRecording))
+                    }
+                }
+
+                if player.capabilities.contains(.reload) {
+                    RemoteActionButton(title: "再読込", systemImage: "arrow.clockwise") {
+                        send(.reload)
+                    }
+                }
+
+                if player.capabilities.contains(.fullscreen),
+                    let isFullscreen = player.isFullscreen
+                {
+                    RemoteActionButton(
+                        title: "全画面",
+                        systemImage: "arrow.up.left.and.arrow.down.right",
+                        isActive: isFullscreen
+                    ) {
+                        send(.setFullscreen(!isFullscreen))
+                    }
+                }
+
+                if player.capabilities.contains(.alwaysOnTop),
+                    let isAlwaysOnTop = player.isAlwaysOnTop
+                {
+                    RemoteActionButton(
+                        title: "最前面",
+                        systemImage: "macwindow.on.rectangle",
+                        isActive: isAlwaysOnTop,
+                        isDisabled: player.isFullscreen == true
+                    ) {
+                        send(.setAlwaysOnTop(!isAlwaysOnTop))
+                    }
+                }
+
+                RemoteDataBroadcastNavigationButton(
+                    service: service,
+                    playerID: player.id,
+                    isAvailable: player.capabilities.contains(.dataBroadcast)
+                )
+
+                if player.capabilities.contains(.close) {
+                    RemoteActionButton(
+                        title: "閉じる",
+                        systemImage: "power",
+                        role: .destructive
+                    ) {
+                        isCloseConfirmationPresented = true
+                    }
+                }
+            }
+            .confirmationDialog(
+                "プレイヤーを閉じますか？",
+                isPresented: $isCloseConfirmationPresented,
+                titleVisibility: .visible
+            ) {
+                Button("閉じる", role: .destructive) {
+                    send(.close)
+                }
+                Button("キャンセル", role: .cancel) {}
+            }
+            .remoteControlCard()
+        }
+    }
+#endif

--- a/kiririn/Features/RemoteControl/iOS/RemoteQuickActionsView.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemoteQuickActionsView.swift
@@ -5,6 +5,7 @@
         let service: RemoteControlService
         let player: RemotePlayerSnapshot
         let send: (RemoteControlCommand) -> Void
+        @State private var isReloadConfirmationPresented = false
         @State private var isCloseConfirmationPresented = false
 
         private let columns = [
@@ -54,7 +55,17 @@
 
                 if player.capabilities.contains(.reload) {
                     RemoteActionButton(title: "再読込", systemImage: "arrow.clockwise") {
-                        send(.reload)
+                        isReloadConfirmationPresented = true
+                    }
+                    .confirmationDialog(
+                        "プレイヤーを再読み込みしますか？",
+                        isPresented: $isReloadConfirmationPresented,
+                        titleVisibility: .visible
+                    ) {
+                        Button("再読み込み") {
+                            send(.reload)
+                        }
+                        Button("キャンセル", role: .cancel) {}
                     }
                 }
 

--- a/kiririn/Features/RemoteControl/iOS/RemoteTransportButton.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemoteTransportButton.swift
@@ -1,0 +1,39 @@
+#if os(iOS)
+    import SwiftUI
+
+    struct RemoteTransportButton: View {
+        let title: String
+        let systemImage: String
+        var isPrimary = false
+        var isDisabled = false
+        let action: () -> Void
+
+        var body: some View {
+            Button(action: action) {
+                VStack(spacing: 5) {
+                    Image(systemName: systemImage)
+                        .font(isPrimary ? .title : .title2)
+                    Text(title)
+                        .font(.caption)
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity, minHeight: isPrimary ? 72 : 64)
+                .foregroundStyle(isPrimary ? Color.white : Color.primary)
+                .background(
+                    isPrimary ? Color.accentColor : Color.primary.opacity(0.08),
+                    in: RoundedRectangle(cornerRadius: 14)
+                )
+                .overlay {
+                    if !isPrimary {
+                        RoundedRectangle(cornerRadius: 14)
+                            .stroke(.secondary.opacity(0.3), lineWidth: 1)
+                    }
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(isDisabled)
+            .opacity(isDisabled ? 0.4 : 1)
+        }
+    }
+#endif

--- a/kiririn/Features/RemoteControl/iOS/RemoteVolumeControls.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemoteVolumeControls.swift
@@ -1,0 +1,74 @@
+#if os(iOS)
+    import SwiftUI
+
+    struct RemoteVolumeControls: View {
+        let player: RemotePlayerSnapshot
+        let send: (RemoteControlCommand) -> Void
+        @State private var volume = 100.0
+        @State private var isAdjustingVolume = false
+
+        var body: some View {
+            HStack(spacing: 10) {
+                Button("音量を下げる", systemImage: "minus", action: decreaseVolume)
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.bordered)
+                    .frame(minWidth: 44, minHeight: 44)
+
+                Slider(
+                    value: $volume,
+                    in: 0...200,
+                    onEditingChanged: volumeEditingChanged
+                )
+                .accessibilityLabel("音量")
+                .accessibilityValue("\(Int(volume.rounded()))パーセント")
+
+                Button("音量を上げる", systemImage: "plus", action: increaseVolume)
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.bordered)
+                    .frame(minWidth: 44, minHeight: 44)
+
+                Button(
+                    player.isMuted ? "ミュート解除" : "ミュート",
+                    systemImage: player.isMuted ? "speaker.wave.2.fill" : "speaker.slash.fill",
+                    action: toggleMute
+                )
+                .labelStyle(.iconOnly)
+                .buttonStyle(.bordered)
+                .frame(minWidth: 44, minHeight: 44)
+            }
+            .onAppear {
+                volume = Double(player.volume)
+            }
+            .onChange(of: player.volume) { _, newVolume in
+                if !isAdjustingVolume {
+                    volume = Double(newVolume)
+                }
+            }
+            .remoteControlCard()
+        }
+
+        private func toggleMute() {
+            send(.setMuted(!player.isMuted))
+        }
+
+        private func decreaseVolume() {
+            updateVolume(to: volume - 5)
+        }
+
+        private func increaseVolume() {
+            updateVolume(to: volume + 5)
+        }
+
+        private func updateVolume(to newValue: Double) {
+            volume = min(max(newValue, 0), 200)
+            send(.setVolume(Float(volume)))
+        }
+
+        private func volumeEditingChanged(_ editing: Bool) {
+            isAdjustingVolume = editing
+            if !editing {
+                send(.setVolume(Float(volume)))
+            }
+        }
+    }
+#endif

--- a/kiririn/Features/RemoteControl/macOS/PlayerWindowRemoteEndpoint.swift
+++ b/kiririn/Features/RemoteControl/macOS/PlayerWindowRemoteEndpoint.swift
@@ -1,0 +1,58 @@
+#if os(macOS)
+    import AppKit
+
+    @MainActor
+    final class PlayerWindowRemoteEndpoint_macOS: RemotePlayerWindowEndpoint {
+        private let windowReference: WindowReference_macOS
+        private let isAlwaysOnTopProvider: () -> Bool
+        private let setAlwaysOnTopHandler: (Bool) -> Void
+        private let showVolumeFeedbackHandler: () -> Void
+        private let closeHandler: () -> Void
+
+        init(
+            windowReference: WindowReference_macOS,
+            isAlwaysOnTop: @escaping () -> Bool,
+            setAlwaysOnTop: @escaping (Bool) -> Void,
+            showVolumeFeedback: @escaping () -> Void,
+            close: @escaping () -> Void
+        ) {
+            self.windowReference = windowReference
+            isAlwaysOnTopProvider = isAlwaysOnTop
+            setAlwaysOnTopHandler = setAlwaysOnTop
+            showVolumeFeedbackHandler = showVolumeFeedback
+            closeHandler = close
+        }
+
+        var snapshot: RemoteWindowSnapshot {
+            RemoteWindowSnapshot(
+                isFullscreen: windowReference.window?.styleMask.contains(.fullScreen) ?? false,
+                isAlwaysOnTop: isAlwaysOnTopProvider()
+            )
+        }
+
+        func showVolumeFeedback() {
+            showVolumeFeedbackHandler()
+        }
+
+        func setFullscreen(_ enabled: Bool) -> RemoteCommandError? {
+            guard let window = windowReference.window else { return .unavailable }
+            let isFullscreen = window.styleMask.contains(.fullScreen)
+            guard enabled != isFullscreen else { return nil }
+            window.toggleFullScreen(nil)
+            return nil
+        }
+
+        func setAlwaysOnTop(_ enabled: Bool) -> RemoteCommandError? {
+            guard windowReference.window != nil else { return .unavailable }
+            guard !enabled || snapshot.isFullscreen == false else { return .unavailable }
+            setAlwaysOnTopHandler(enabled)
+            return nil
+        }
+
+        func close() -> RemoteCommandError? {
+            guard windowReference.window != nil else { return .unavailable }
+            closeHandler()
+            return nil
+        }
+    }
+#endif

--- a/kiririn/Features/RemoteControl/macOS/RemoteReceiverSettingsView.swift
+++ b/kiririn/Features/RemoteControl/macOS/RemoteReceiverSettingsView.swift
@@ -1,0 +1,110 @@
+#if os(macOS)
+    import SwiftUI
+
+    struct RemoteReceiverSettingsView: View {
+        let service: RemoteControlService
+        @State private var isReceiverEnabled: Bool
+
+        init(service: RemoteControlService) {
+            self.service = service
+            _isReceiverEnabled = State(initialValue: service.isReceiverEnabled)
+        }
+
+        var body: some View {
+            Form {
+                Section {
+                    Toggle("有効化", isOn: $isReceiverEnabled)
+                        .onChange(of: isReceiverEnabled) { _, enabled in
+                            service.setReceiverEnabled(enabled)
+                        }
+
+                    LabeledContent("状態") {
+                        Text(statusText)
+                            .foregroundStyle(statusStyle)
+                    }
+                } footer: {
+                    Text("同じローカルネットワーク上のiPhoneまたはiPadのkiririnアプリからプレイヤーを操作できます。")
+                }
+
+                if isReceiverEnabled {
+                    Section {
+                        LabeledContent("PINコード") {
+                            Text(service.pairingPIN)
+                                .font(.title2.monospacedDigit())
+                                .bold()
+                                .textSelection(.enabled)
+                        }
+
+                        LabeledContent("有効期限") {
+                            Text(
+                                timerInterval: pairingPINCountdownInterval,
+                                countsDown: true
+                            )
+                            .monospacedDigit()
+                        }
+
+                        Button("PINコードを再生成", systemImage: "arrow.clockwise") {
+                            service.rotatePairingPIN()
+                        }
+                        .buttonStyle(.plain)
+                    } header: {
+                        Text("ペアリング")
+                    } footer: {
+                        Text("初回接続時にはPINコードが必要です。")
+                    }
+                }
+
+                Section("登録済み端末") {
+                    if service.trustedPeers.isEmpty {
+                        Text("登録済み端末はありません")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(service.trustedPeers) { peer in
+                            TrustedRemotePeerRow(
+                                peer: peer,
+                                onForget: {
+                                    service.forgetTrustedPeer(id: peer.id)
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+            .formStyle(.grouped)
+            .navigationTitle("リモコン")
+            .onChange(of: service.isReceiverEnabled) { _, enabled in
+                isReceiverEnabled = enabled
+            }
+        }
+
+        private var pairingPINCountdownInterval: ClosedRange<Date> {
+            let expiration = service.pairingPINExpiresAt
+            return min(Date(), expiration)...expiration
+        }
+
+        private var statusText: String {
+            guard isReceiverEnabled else { return "停止中" }
+            switch service.connectionStatus {
+            case .connected(let name):
+                return "\(name)から接続中"
+            case .pairing(let name):
+                return "\(name)をペアリング中"
+            case .failed:
+                return "エラー"
+            default:
+                return "受信中"
+            }
+        }
+
+        private var statusStyle: HierarchicalShapeStyle {
+            switch service.connectionStatus {
+            case .failed:
+                return .secondary
+            case .connected:
+                return .primary
+            default:
+                return .secondary
+            }
+        }
+    }
+#endif

--- a/kiririn/Features/RemoteControl/macOS/TrustedRemotePeerRow.swift
+++ b/kiririn/Features/RemoteControl/macOS/TrustedRemotePeerRow.swift
@@ -1,0 +1,34 @@
+#if os(macOS)
+    import SwiftUI
+
+    struct TrustedRemotePeerRow: View {
+        let peer: RemoteTrustedPeer
+        let onForget: () -> Void
+        @State private var isForgetConfirmationPresented = false
+
+        var body: some View {
+            LabeledContent {
+                Button("解除", role: .destructive) {
+                    isForgetConfirmationPresented = true
+                }
+                .confirmationDialog(
+                    "「\(peer.displayName)」の信頼を解除しますか？",
+                    isPresented: $isForgetConfirmationPresented,
+                    titleVisibility: .visible
+                ) {
+                    Button("解除", role: .destructive, action: onForget)
+                    Button("キャンセル", role: .cancel) {}
+                } message: {
+                    Text("次回の接続時にPINコードの入力が必要になります。")
+                }
+            } label: {
+                VStack(alignment: .leading) {
+                    Text(peer.displayName)
+                    Text(peer.pairedAt, format: .dateTime.year().month().day())
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+#endif

--- a/kiririn/Features/Settings/SettingsView.swift
+++ b/kiririn/Features/Settings/SettingsView.swift
@@ -134,6 +134,12 @@ struct SettingsView: View {
                 }
 
                 NavigationLink {
+                    RemoteControlSettingsView(service: appModel.remoteControlService)
+                } label: {
+                    Label("リモコン", systemImage: "appletvremote.gen4")
+                }
+
+                NavigationLink {
                     AboutAppView()
                 } label: {
                     Label("このアプリについて", systemImage: "info.circle")

--- a/kiririn/Info.plist
+++ b/kiririn/Info.plist
@@ -5,7 +5,11 @@
 	<key>KiririnTemporaryMarketingVersion</key>
 	<string>$(KIRIRIN_TEMPORARY_MARKETING_VERSION)</string>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>ローカルネットワーク上のサーバーと通信します。</string>
+	<string>ローカルネットワーク上のサーバーとの通信と、リモコンに使用します。</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_kiririn-rc._tcp</string>
+	</array>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>

--- a/kiririn/Shared/Infrastructure/KeychainCredentialStore.swift
+++ b/kiririn/Shared/Infrastructure/KeychainCredentialStore.swift
@@ -1,57 +1,28 @@
 import Foundation
-import Security
 
 struct KeychainCredentialStore {
-    private let service = "jp.pronama.kiririn.server.auth"
-    private let label = "kiririn Server Credential"
+    private let store = KeychainDataStore(
+        service: "jp.pronama.kiririn.server.auth",
+        label: "kiririn Server Credential",
+        accessibility: .afterFirstUnlock
+    )
 
     func save(_ auth: ServerAuth, forServerId serverId: String) {
         guard case .none = auth else {
             guard let data = try? JSONEncoder().encode(auth) else { return }
 
-            let query: [CFString: Any] = [
-                kSecClass: kSecClassGenericPassword,
-                kSecAttrService: service,
-                kSecAttrAccount: serverId,
-            ]
-            let attributes: [CFString: Any] = [
-                kSecValueData: data,
-                kSecAttrLabel: label,
-            ]
-            let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
-
-            if updateStatus == errSecItemNotFound {
-                var addQuery = query
-                addQuery[kSecValueData] = data
-                addQuery[kSecAttrLabel] = label
-                addQuery[kSecAttrAccessible] = kSecAttrAccessibleAfterFirstUnlock
-                SecItemAdd(addQuery as CFDictionary, nil)
-            }
+            try? store.save(data, account: serverId)
             return
         }
         delete(forServerId: serverId)
     }
 
     func load(forServerId serverId: String) -> ServerAuth? {
-        let query: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: service,
-            kSecAttrAccount: serverId,
-            kSecReturnData: true,
-            kSecMatchLimit: kSecMatchLimitOne,
-        ]
-        var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        guard let data = try? store.load(account: serverId) else { return nil }
         return try? JSONDecoder().decode(ServerAuth.self, from: data)
     }
 
     func delete(forServerId serverId: String) {
-        let query: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: service,
-            kSecAttrAccount: serverId,
-        ]
-        SecItemDelete(query as CFDictionary)
+        try? store.delete(account: serverId)
     }
 }

--- a/kiririn/Shared/Infrastructure/KeychainDataStore.swift
+++ b/kiririn/Shared/Infrastructure/KeychainDataStore.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Security
+
+nonisolated struct KeychainDataStore: Sendable {
+    enum Accessibility: Sendable {
+        case afterFirstUnlock
+        case afterFirstUnlockThisDeviceOnly
+
+        fileprivate var value: CFString {
+            switch self {
+            case .afterFirstUnlock:
+                kSecAttrAccessibleAfterFirstUnlock
+            case .afterFirstUnlockThisDeviceOnly:
+                kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            }
+        }
+    }
+
+    let service: String
+    let label: String
+    let accessibility: Accessibility
+
+    func load(account: String) throws -> Data? {
+        var query = baseQuery(account: account)
+        query[kSecReturnData] = true
+        query[kSecMatchLimit] = kSecMatchLimitOne
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound {
+            return nil
+        }
+        guard status == errSecSuccess, let data = result as? Data else {
+            throw KeychainDataStoreError.operationFailed(status)
+        }
+        return data
+    }
+
+    func save(_ data: Data, account: String) throws {
+        let query = baseQuery(account: account)
+        let attributes: [CFString: Any] = [
+            kSecValueData: data,
+            kSecAttrLabel: label,
+        ]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        if updateStatus == errSecSuccess {
+            return
+        }
+        guard updateStatus == errSecItemNotFound else {
+            throw KeychainDataStoreError.operationFailed(updateStatus)
+        }
+
+        var addQuery = query
+        addQuery[kSecValueData] = data
+        addQuery[kSecAttrLabel] = label
+        addQuery[kSecAttrAccessible] = accessibility.value
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        guard addStatus == errSecSuccess else {
+            throw KeychainDataStoreError.operationFailed(addStatus)
+        }
+    }
+
+    func delete(account: String) throws {
+        let status = SecItemDelete(baseQuery(account: account) as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainDataStoreError.operationFailed(status)
+        }
+    }
+
+    private func baseQuery(account: String) -> [CFString: Any] {
+        [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+        ]
+    }
+}
+
+nonisolated enum KeychainDataStoreError: Error {
+    case operationFailed(OSStatus)
+}

--- a/kiririn/kiririn.entitlements
+++ b/kiririn/kiririn.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
 </dict>
 </plist>

--- a/kiririnTests/RemoteControlTests.swift
+++ b/kiririnTests/RemoteControlTests.swift
@@ -1,0 +1,165 @@
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import kiririn
+
+struct RemoteControlTests {
+    @Test func protocolEnvelopeRoundTripsCommands() throws {
+        let requestID = UUID()
+        let envelope = RemoteControlEnvelope(
+            messageID: requestID,
+            payload: .command(
+                RemotePlayerCommandRequest(
+                    playerID: "player",
+                    command: .setVolume(125)
+                )
+            )
+        )
+
+        let data = try JSONEncoder().encode(envelope)
+        let decoded = try JSONDecoder().decode(RemoteControlEnvelope.self, from: data)
+
+        #expect(decoded == envelope)
+        #expect(decoded.messageID == requestID)
+    }
+
+    @Test func protocolEnvelopeRoundTripsDualMonoSelection() throws {
+        let selection = RemoteAudioTrackSelection(
+            trackID: "audio-track",
+            role: .sub
+        )
+        let envelope = RemoteControlEnvelope(
+            payload: .command(
+                RemotePlayerCommandRequest(
+                    playerID: "player",
+                    command: .selectAudioTrack(selection)
+                )
+            )
+        )
+
+        let data = try JSONEncoder().encode(envelope)
+        let decoded = try JSONDecoder().decode(RemoteControlEnvelope.self, from: data)
+
+        #expect(decoded == envelope)
+    }
+
+    @Test func playerTrackLabelsIncludeDualMonoRoles() {
+        let track = PlayerAudioTrack(
+            id: "audio-track",
+            name: "VLC track",
+            channels: 2,
+            isDualMono: true
+        )
+        let labels = PlayerAudioTrackSelection.options(for: track).map {
+            PlayerPlaybackOptionCatalog.audioTrackLabel(
+                index: 0,
+                selection: $0
+            )
+        }
+
+        #expect(labels == ["トラック1（2ch）主音声", "トラック1（2ch）副音声"])
+        #expect(
+            PlayerPlaybackOptionCatalog.videoTrackLabel(
+                index: 1,
+                track: PlayerVideoTrack(id: "video-track", name: "VLC track")
+            ) == "トラック2"
+        )
+    }
+
+    @Test func authenticationSignaturesBindBothPeerIdentities() throws {
+        let privateKey = Curve25519.Signing.PrivateKey()
+        let nonce = Data("nonce".utf8)
+        let data = RemoteControlCryptography.authenticationData(
+            nonce: nonce,
+            receiverID: "receiver",
+            controllerID: "controller"
+        )
+        let signature = try privateKey.signature(for: data)
+
+        #expect(
+            RemoteControlCryptography.verify(
+                signature: signature,
+                data: data,
+                publicKey: privateKey.publicKey.rawRepresentation
+            )
+        )
+
+        let altered = RemoteControlCryptography.authenticationData(
+            nonce: nonce,
+            receiverID: "other-receiver",
+            controllerID: "controller"
+        )
+        #expect(
+            !RemoteControlCryptography.verify(
+                signature: signature,
+                data: altered,
+                publicKey: privateKey.publicKey.rawRepresentation
+            )
+        )
+    }
+
+    @Test func pairingProofDoesNotExposeOrAcceptAnotherPIN() {
+        let data = RemoteControlCryptography.pairingData(
+            nonce: Data("nonce".utf8),
+            receiverID: "receiver",
+            controllerID: "controller"
+        )
+        let proof = RemoteControlCryptography.pairingProof(pin: "123456", data: data)
+
+        #expect(
+            RemoteControlCryptography.verifyPairingProof(
+                proof,
+                pin: "123456",
+                data: data
+            )
+        )
+        #expect(
+            !RemoteControlCryptography.verifyPairingProof(
+                proof,
+                pin: "654321",
+                data: data
+            )
+        )
+    }
+
+    @Test func bmlRemoteControlAvailabilityUsesDeclaredKeyGroups() {
+        let availability = BMLRemoteControlAvailability(
+            isDataButtonEnabled: true,
+            enabledGroups: [.basic, .dataButton]
+        )
+
+        #expect(availability.isEnabled(.data))
+        #expect(availability.isEnabled(.up))
+        #expect(availability.isEnabled(.red))
+        #expect(!availability.isEnabled(.digit1))
+    }
+
+    @Test func unavailableBMLRemoteControlDisablesEveryKey() {
+        let availability = BMLRemoteControlAvailability(
+            isDataButtonEnabled: false,
+            enabledGroups: [.basic]
+        )
+
+        #expect(!availability.isEnabled(.data))
+        #expect(!availability.isEnabled(.enter))
+    }
+
+    @Test func trustedPeerStorePersistsAndRemovesPeers() throws {
+        let service = "jp.pronama.kiririn.remote.tests.\(UUID().uuidString)"
+        let store = RemoteTrustedPeerStore(service: service)
+        defer { try? store.removeAll() }
+        let peer = RemoteTrustedPeer(
+            id: "peer",
+            displayName: "Mac",
+            publicKey: Data([1, 2, 3]),
+            pairedAt: Date(timeIntervalSince1970: 1_000)
+        )
+
+        try store.save([peer])
+        #expect(try store.load() == [peer])
+
+        try store.save([])
+        #expect(try store.load().isEmpty)
+    }
+}

--- a/kiririnTests/RemoteControlTests.swift
+++ b/kiririnTests/RemoteControlTests.swift
@@ -1,8 +1,27 @@
 import CryptoKit
 import Foundation
+import Synchronization
 import Testing
 
 @testable import kiririn
+
+private nonisolated final class InMemoryRemoteTrustedPeerDataStore:
+    RemoteTrustedPeerDataStoring, Sendable
+{
+    private let values = Mutex<[String: Data]>([:])
+
+    func load(account: String) -> Data? {
+        values.withLock { $0[account] }
+    }
+
+    func save(_ data: Data, account: String) {
+        values.withLock { $0[account] = data }
+    }
+
+    func delete(account: String) {
+        values.withLock { $0[account] = nil }
+    }
+}
 
 struct RemoteControlTests {
     @Test func protocolEnvelopeRoundTripsCommands() throws {
@@ -146,9 +165,7 @@ struct RemoteControlTests {
     }
 
     @Test func trustedPeerStorePersistsAndRemovesPeers() throws {
-        let service = "jp.pronama.kiririn.remote.tests.\(UUID().uuidString)"
-        let store = RemoteTrustedPeerStore(service: service)
-        defer { try? store.removeAll() }
+        let store = RemoteTrustedPeerStore(store: InMemoryRemoteTrustedPeerDataStore())
         let peer = RemoteTrustedPeer(
             id: "peer",
             displayName: "Mac",
@@ -159,7 +176,7 @@ struct RemoteControlTests {
         try store.save([peer])
         #expect(try store.load() == [peer])
 
-        try store.save([])
+        try store.removeAll()
         #expect(try store.load().isEmpty)
     }
 }

--- a/web/bml/src/index.ts
+++ b/web/bml/src/index.ts
@@ -227,6 +227,9 @@ function applyStageScale(width: number, height: number): void {
 }
 
 let lastResolution: { width: number; height: number } | null = null;
+let isDocumentLoaded = false;
+let requestedPresentationVisible: boolean | null = null;
+
 function reapplyStageScale(): void {
     if (lastResolution != null) {
         applyStageScale(lastResolution.width, lastResolution.height);
@@ -263,6 +266,7 @@ function postLayoutRects(): void {
 }
 
 bmlBrowser.addEventListener("load", (evt) => {
+    isDocumentLoaded = true;
     lastResolution = evt.detail.resolution;
     applyStageScale(evt.detail.resolution.width, evt.detail.resolution.height);
     console.info(
@@ -280,6 +284,7 @@ bmlBrowser.addEventListener("load", (evt) => {
         height: evt.detail.resolution.height,
         profile: evt.detail.profile,
     });
+    applyRequestedPresentationVisibility();
 });
 
 bmlBrowser.addEventListener("videochanged", (evt) => {
@@ -296,8 +301,52 @@ bmlBrowser.addEventListener("invisible", (evt) => {
 });
 
 bmlBrowser.addEventListener("usedkeylistchanged", (evt) => {
-    postToNative({ type: "usedKeyList", groups: [...evt.detail.usedKeyList] });
+    const declaredGroups = [...evt.detail.usedKeyList];
+    const effectiveGroups =
+        declaredGroups.length === 0 ? ["basic", "data-button"] : declaredGroups;
+    postToNative({ type: "usedKeyList", groups: effectiveGroups });
 });
+
+function synchronizePresentation(): void {
+    reapplyStageScale();
+    const isInvisible = bmlBrowser.content.invisible;
+    if (isInvisible != null) {
+        postToNative({ type: "invisible", value: isInvisible });
+    }
+}
+
+function synchronizePresentationAfterLayout(): void {
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            synchronizePresentation();
+            window.setTimeout(synchronizePresentation, 300);
+        });
+    });
+}
+
+function applyRequestedPresentationVisibility(): void {
+    if (requestedPresentationVisible == null) {
+        return;
+    }
+    if (requestedPresentationVisible && audioContext.state === "suspended") {
+        void audioContext.resume().catch((error) => {
+            log("warn", `BML audio resume failed: ${String(error)}`);
+        });
+    }
+    if (!isDocumentLoaded) {
+        return;
+    }
+    const shouldShow = requestedPresentationVisible;
+    const isInvisible = bmlBrowser.content.invisible;
+    if (isInvisible == null) {
+        return;
+    }
+    if (shouldShow === isInvisible) {
+        bmlBrowser.content.processKeyDown(AribKeyCode.DataButton);
+        bmlBrowser.content.processKeyUp(AribKeyCode.DataButton);
+    }
+    synchronizePresentationAfterLayout();
+}
 
 window.kiririnBML = {
     onNativeMessage(raw: unknown) {
@@ -337,6 +386,10 @@ window.kiririnBML = {
                 }
                 break;
             }
+            case "setPresentationVisible":
+                requestedPresentationVisible = message.visible;
+                applyRequestedPresentationVisibility();
+                break;
             case "audioOutput":
                 audioGain.gain.value = message.muted ? 0 : message.volume / 100;
                 break;

--- a/web/bml/src/types.ts
+++ b/web/bml/src/types.ts
@@ -20,6 +20,7 @@ export type NativeToWebMessage =
     | { type: "audioOutput"; volume: number; muted: boolean }
     | { type: "inputResult"; requestId: number; value: string }
     | { type: "inputCancel"; requestId: number }
+    | { type: "setPresentationVisible"; visible: boolean }
     | { type: "reset" };
 
 // JS -> Swift (webkit.messageHandlers.bml.postMessage)


### PR DESCRIPTION
Fixes #6 

## Summary by Sourcery

iOS から Mac プレイヤーを制御するための安全なリモートコントロールシステムを導入し、キーのモデルや利用可能状態のロジックを共有できるように BML リモートコントロール処理をリファクタリングするとともに、再生・スキップ・PiP/ミュート/録画トグルといった各種プレイヤー操作を集約します。

新機能:
- MultipeerConnectivity を利用したクロスプラットフォームのリモートコントロールサービスを追加。ペアリング、認証、Keychain によるアイデンティティおよび信頼済みピアの保存、さらにリモートコントロールの設定と利用のための iOS/macOS 向け UI を含みます。
- 再利用可能な ARIB リモートキーおよび BML キーグループのモデルを導入し、プレイヤー内 UI とリモートデータブロードキャスト用 UI の両方で共有される BMLRemoteControlPad を追加します。

バグ修正:
- 要求された再生状態を追跡し、非同期のヘッダー更新および再生開始を保護することで、古い状態や矛盾した再生/一時停止の遷移を防ぎます。
- シークおよびスキップ操作が VLC のジャンプコマンドを発行する前に、レンジとプレイヤーの利用可能性を検証するようにします。

改善:
- BML キーボードおよび画面上のリモート処理をリファクタリングし、型付きの ARIBRemoteKey と BMLKeyGroup の enum、および共有の利用可能状態モデルを使うように変更することで、キーボード操作とタッチ/リモート操作との一貫性を向上させます。
- リモートおよびローカルの制御フローをサポートするため、PlayerState にミュート、PiP、録画フラグ用の便利なセッターを追加します。
- 共通の Keychain アクセス処理を再利用可能な KeychainDataStore に切り出し、認証情報ストレージおよび新しいリモートコントロール用ストアがそれを使用するように更新します。
- プレイヤーウィンドウの状態を RemotePlayerWindowEndpoint に接続し、フルスクリーン、常に前面表示、ウィンドウのクローズ、および音量フィードバックをリモートコントロール経由で公開します。

ビルド:
- Info.plist に新しいリモートコントロール受信機のための Bonjour サービス種別とローカルネットワーク利用宣言を追加します。

テスト:
- プロトコルエンベロープのエンコード/デコード、オーディオトラックラベル、暗号証明、BML の利用可能状態、および信頼済みピアの永続化をカバーする RemoteControlTests を追加します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a secure remote control system for controlling Mac players from iOS, refactor BML remote control handling to share key models and availability logic, and centralize various player control operations such as playback, skipping, and PiP/mute/recording toggles.

New Features:
- Add a cross-platform remote control service using MultipeerConnectivity, including pairing, authentication, keychain-backed identity and trusted peer storage, and iOS/macOS UI for configuring and using remote control.
- Introduce reusable ARIB remote key and BML key group models, plus a shared BMLRemoteControlPad for both in-player and remote data broadcast control UIs.

Bug Fixes:
- Prevent stale or conflicting play/pause transitions by tracking requested playing state and guarding asynchronous header refresh and playback start.
- Ensure seek and skip operations validate ranges and player availability before issuing VLC jump commands.

Enhancements:
- Refactor BML keyboard and on-screen remote handling to use typed ARIBRemoteKey and BMLKeyGroup enums and a shared availability model, improving consistency between keyboard and touch/remote controls.
- Add convenience setters for mute, PiP, and recording flags in PlayerState to support remote and local control flows.
- Factor common Keychain access into a reusable KeychainDataStore and update credential storage and new remote control stores to use it.
- Wire player window state into a RemotePlayerWindowEndpoint to expose fullscreen, always-on-top, close, and volume feedback over remote control.

Build:
- Declare Bonjour service type and local network usage for the new remote control receiver in Info.plist.

Tests:
- Add RemoteControlTests covering protocol envelope encoding/decoding, audio track labels, cryptographic proofs, BML availability, and trusted peer persistence.

</details>

## Summary by Sourcery

iOS から Mac プレーヤーを制御するための、安全でクロスプラットフォームなリモートコントロールシステムを追加し、BML データのブロードキャスト制御とキー処理を共有モデルおよび利用可能性ロジックを用いる形にリファクタリングします。

New Features:
- iOS および macOS 上でのリモートコントロール設定・利用のための UI を含む、ペアリング・認証・信頼済みデバイス管理機能を備えた MultipeerConnectivity ベースのリモートコントロールサービスを導入。
- プレーヤー内 UI とリモート UI の両方で利用される再利用可能な ARIB/BML リモートキーのモデルと、共有の BMLRemoteControlPad を追加。

Bug Fixes:
- 要求された再生状態を追跡し、非同期のヘッダー再読み込みおよび再生開始を保護することで、再生/一時停止トグルの安定性を向上。
- 無効なシークを防ぐため、VLC のジャンプコマンドを発行する前にスキップ/シーク範囲とプレーヤーの利用可能性を検証。

Enhancements:
- BML キーボードおよびオンスクリーンリモートのロジックを、型付きの ARIBRemoteKey/BMLKeyGroup enum と共有の利用可能性モデルを用いる構成にリファクタリングし、一貫したキー処理を実現。
- ローカルおよびリモートの両方の制御フローをサポートするため、PlayerState にミュート、PiP、録画フラグ向けの便利なセッターを追加。
- 共通の Keychain アクセス処理を再利用可能な KeychainDataStore に切り出し、認証情報およびリモートコントロール関連ストアをそれを使うように更新。
- リモートコントロール経由でフルスクリーン切り替え、常に最前面表示、ウィンドウクローズ、音量フィードバックを可能にするため、RemotePlayerWindowEndpoint を通じてプレーヤーウィンドウ状態を公開。

Build:
- Info.plist 内で新しいリモートコントロール受信機のための Bonjour サービスタイプを宣言し、ローカルネットワーク使用説明を更新。

Tests:
- プロトコルのエンコード/デコード、オーディオトラックのラベリング、暗号証明、BML キーの利用可能性、および信頼済みピアの永続化を対象とする RemoteControlTests を追加。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a secure cross-platform remote control system for controlling Mac players from iOS and refactor BML data broadcast controls and key handling to use shared models and availability logic.

New Features:
- Introduce a MultipeerConnectivity-based remote control service with pairing, authentication, trusted device management, and UI for configuring and using remote control on iOS and macOS.
- Add reusable ARIB/BML remote key models and a shared BMLRemoteControlPad used by both in-player and remote UIs.

Bug Fixes:
- Stabilize play/pause toggling by tracking requested playing state and guarding asynchronous header refresh and playback start.
- Validate skip/seek ranges and player availability before issuing VLC jump commands to avoid invalid seeks.

Enhancements:
- Refactor BML keyboard and on-screen remote logic to use typed ARIBRemoteKey/BMLKeyGroup enums and a shared availability model for consistent key handling.
- Add convenience setters for mute, PiP, and recording flags in PlayerState to support both local and remote control flows.
- Factor common Keychain access into a reusable KeychainDataStore and update credential and remote-control-related stores to use it.
- Expose player window state via a RemotePlayerWindowEndpoint to allow fullscreen, always-on-top, close, and volume feedback over remote control.

Build:
- Declare Bonjour service type and update local network usage description for the new remote control receiver in Info.plist.

Tests:
- Add RemoteControlTests covering protocol encoding/decoding, audio track labelling, crypto proofs, BML key availability, and trusted peer persistence.

</details>