### PR TITLE
chore: VLCKitを更新 (forward complete unit loss as a discontinuity)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # VLCKit
 # https://github.com/neneka/vlckit/releases
-REVISION="202607180216"
+REVISION="202608031120"
 VLCKIT_URL="https://github.com/neneka/vlckit/releases/download/$REVISION/VLCKit-iOS-REPLACEWITHVERSION.dmg"
 VLCKIT_DEST="./Packages/VLCKit"
 FRAMEWORK_DEST="${VLCKIT_DEST}/VLCKit.xcframework"


### PR DESCRIPTION
Fixes #63 

## Summary by Sourcery

Build:
- `setup.sh` 内の VLCKit ダウンロードリビジョンを更新し、最新の VLCKit-iOS リリースを参照するようにしました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Bump VLCKit download revision in setup.sh to point to the latest VLCKit-iOS release.

</details>