### PR TITLE
feat: データ放送のcacheスナップショットで初期表示を高速化

### DIFF
--- a/kiririn/Features/Player/DataBroadcast/DataBroadcastBridgeTypes.swift
+++ b/kiririn/Features/Player/DataBroadcast/DataBroadcastBridgeTypes.swift
@@ -101,6 +101,14 @@ nonisolated struct MahironModuleList: Decodable, Sendable {
 nonisolated struct MahironSnapshot: Decodable, Sendable {
     let pmt: MahironPMT?
     let components: [MahironComponent]?
+    /// `live` (session actively tuned) or `cache` (rebuilt from persisted
+    /// PMT/DII without a tuner). Present both on the SSE `snapshot` event
+    /// (always `live`) and on GET `/data-broadcast/state` (see
+    /// DataBroadcastSession.fetchInitialState, which decodes the flat state
+    /// response body directly as a MahironSnapshot).
+    let origin: String?
+    /// Non-nil only when `origin == "cache"`.
+    let storedAt: Double?
 }
 
 // Mahiron wraps each SSE `data:` payload in a per-type envelope:

--- a/kiririn/Features/Player/DataBroadcast/DataBroadcastSession.swift
+++ b/kiririn/Features/Player/DataBroadcast/DataBroadcastSession.swift
@@ -316,10 +316,18 @@ final class DataBroadcastSession {
             let data: Data
             do {
                 let (responseData, response) = try await URLSession.shared.data(for: request)
-                guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode)
-                else { return }
+                guard let http = response as? HTTPURLResponse else {
+                    self.logger.debug("initial state fetch: non-HTTP response")
+                    return
+                }
+                guard (200...299).contains(http.statusCode) else {
+                    self.logger.debug(
+                        "initial state fetch: non-2xx status \(http.statusCode)")
+                    return
+                }
                 data = responseData
             } catch {
+                self.logger.debug("initial state fetch failed: \(error)")
                 return
             }
             guard !Task.isCancelled, self.started, !self.hasReceivedLiveSnapshot else { return }

--- a/kiririn/Features/Player/DataBroadcast/DataBroadcastSession.swift
+++ b/kiririn/Features/Player/DataBroadcast/DataBroadcastSession.swift
@@ -147,10 +147,16 @@ final class DataBroadcastSession {
     private let logger = Logger(label: "DataBroadcastSession")
 
     private var sseTask: Task<Void, Never>?
+    private var stateFetchTask: Task<Void, Never>?
     private var started = false
     private var isReady = false
     private var pendingMessages: [String] = []
     private var consecutiveFailures = 0
+    /// Set once the SSE `snapshot` event (always `origin: "live"`) has been
+    /// applied, so a slow-arriving `fetchInitialState()` response - which may
+    /// be a stale `cache` snapshot - is discarded instead of clobbering
+    /// live/newer module state.
+    private var hasReceivedLiveSnapshot = false
 
     // Module fetch scheduling.
     private struct FetchRequest {
@@ -232,12 +238,16 @@ final class DataBroadcastSession {
         started = true
         status = .connecting
         sendProgramInfo(asInit: true)
+        fetchInitialState()
         connectSSE()
         startReconciliation()
     }
 
     func stop() {
         started = false
+        stateFetchTask?.cancel()
+        stateFetchTask = nil
+        hasReceivedLiveSnapshot = false
         sseTask?.cancel()
         sseTask = nil
         reconcileTask?.cancel()
@@ -285,6 +295,42 @@ final class DataBroadcastSession {
         post(
             #"{"type":"audioOutput","volume":\#(volume),"muted":\#(isMuted)}"#
         )
+    }
+
+    // MARK: - Initial state fast path
+
+    /// Fetches GET `/data-broadcast/state` once, in parallel with opening
+    /// SSE. If Mahiron has a `cache`-origin snapshot rebuilt from persisted
+    /// PMT/DII (tuner not yet acquired) or an already-`live` one, this lets
+    /// module prefetch start immediately instead of waiting for the first
+    /// SSE `snapshot` event. Best-effort: a 404 (no live session, no cache)
+    /// or any transport error just falls back to the SSE-only path.
+    private func fetchInitialState() {
+        stateFetchTask?.cancel()
+        stateFetchTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            var request = URLRequest(url: self.endpoint.stateURL)
+            for (field, value) in self.endpoint.headers {
+                request.setValue(value, forHTTPHeaderField: field)
+            }
+            let data: Data
+            do {
+                let (responseData, response) = try await URLSession.shared.data(for: request)
+                guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode)
+                else { return }
+                data = responseData
+            } catch {
+                return
+            }
+            guard !Task.isCancelled, self.started, !self.hasReceivedLiveSnapshot else { return }
+            guard let snapshot = try? JSONDecoder().decode(MahironSnapshot.self, from: data) else {
+                self.logger.warning("failed to decode initial state response")
+                return
+            }
+            self.logger.info(
+                "data-broadcast initial state fetched origin=\(snapshot.origin ?? "unknown")")
+            self.scheduleAll(components: snapshot.components ?? snapshot.pmt?.components ?? [])
+        }
     }
 
     // MARK: - SSE
@@ -369,6 +415,7 @@ final class DataBroadcastSession {
                 logger.warning("failed to decode snapshot event")
                 return
             }
+            hasReceivedLiveSnapshot = true
             knownModules.removeAll()
             scheduleAll(components: snapshot.components ?? snapshot.pmt?.components ?? [])
         case "pmt":

--- a/kiririn/Features/Player/DataBroadcast/DataBroadcastSource.swift
+++ b/kiririn/Features/Player/DataBroadcast/DataBroadcastSource.swift
@@ -10,9 +10,12 @@ protocol DataBroadcastProviding {
 
 nonisolated struct DataBroadcastEndpoint: Sendable {
     let eventsURL: URL
-    /// Authoritative carousel state without opening SSE. Unused by the session
-    /// today (every SSE connection starts with a `snapshot` event), kept for
-    /// diagnostics.
+    /// Authoritative carousel state without opening SSE. Fetched once on
+    /// `startIfIdle()` as a fast path (see
+    /// DataBroadcastSession.fetchInitialState) so module prefetch can start
+    /// from a `cache`-origin snapshot while the tuner is still being
+    /// acquired; the SSE `snapshot` event (always `live`) unconditionally
+    /// supersedes it once it arrives.
     let stateURL: URL
     let headers: [String: String]
     private let baseURL: URL


### PR DESCRIPTION
https://github.com/rokoucha/Mahiron/pull/85 より高速にデータ放送を開けるようにする

## Summary by Sourcery

SSE 接続の確立と並行して、キャッシュまたはライブスナップショットから初期の data-broadcast ステートをプリフェッチし、その後に取得されるライブスナップショットが古いキャッシュ状態を必ず上書きするようにします。

New Features:
- SSE が準備できる前に、キャッシュまたはライブスナップショットを用いて最初の data-broadcast レンダリングを高速化するため、初期状態取得エンドポイントの利用を追加。

Enhancements:
- ライブスナップショットイベントの受信を追跡し、古いキャッシュ由来のスナップショットが、より新しいモジュールステートを上書きしないように防止。
- Mahiron のスナップショットペイロードを拡張し、ライブかキャッシュかを区別するためのオリジンメタデータと、それに紐づくタイムスタンプを付加。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prefetch initial data-broadcast state from a cached or live snapshot in parallel with establishing the SSE connection, while ensuring later live snapshots supersede any stale cached state.

New Features:
- Add an initial state fetch endpoint usage to accelerate first data-broadcast rendering using cached or live snapshots before SSE is ready.

Enhancements:
- Track reception of live snapshot events to prevent stale cache-origin snapshots from overwriting newer module state.
- Extend Mahiron snapshot payloads with origin metadata to distinguish live vs cache snapshots and associated timestamps.

</details>

新機能:
- モジュールを事前取得するために、SSE 接続と並行してデータブロードキャスト状態のワンショット HTTP フェッチをトリガーし、キャッシュまたはライブスナップショットからプリフェッチできるようにします。

改善点:
- 一度ライブ SSE スナップショットが適用された後は古いキャッシュスナップショットを追跡して破棄し、古い状態が新しいライブデータを上書きしないようにします。
- Mahiron スナップショットブリッジの型にオリジンメタデータを拡張して追加し、ライブとキャッシュスナップショットを区別できるようにするとともに、キャッシュ状態へのタイムスタンプ付与をサポートします。
- セッション起動時のモジュールプリフェッチ用高速パスとしての、データブロードキャスト状態エンドポイントの役割を文書化します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

SSE 接続の確立と並行して、キャッシュまたはライブスナップショットから初期の data-broadcast ステートをプリフェッチし、その後に取得されるライブスナップショットが古いキャッシュ状態を必ず上書きするようにします。

New Features:
- SSE が準備できる前に、キャッシュまたはライブスナップショットを用いて最初の data-broadcast レンダリングを高速化するため、初期状態取得エンドポイントの利用を追加。

Enhancements:
- ライブスナップショットイベントの受信を追跡し、古いキャッシュ由来のスナップショットが、より新しいモジュールステートを上書きしないように防止。
- Mahiron のスナップショットペイロードを拡張し、ライブかキャッシュかを区別するためのオリジンメタデータと、それに紐づくタイムスタンプを付加。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prefetch initial data-broadcast state from a cached or live snapshot in parallel with establishing the SSE connection, while ensuring later live snapshots supersede any stale cached state.

New Features:
- Add an initial state fetch endpoint usage to accelerate first data-broadcast rendering using cached or live snapshots before SSE is ready.

Enhancements:
- Track reception of live snapshot events to prevent stale cache-origin snapshots from overwriting newer module state.
- Extend Mahiron snapshot payloads with origin metadata to distinguish live vs cache snapshots and associated timestamps.

</details>

</details>