### PR TITLE
feat: データ放送の「データ取得中...」を初回読み込みでも表示する

### DIFF
--- a/kiririn/Features/Player/DataBroadcast/BMLReceivingIndicator.swift
+++ b/kiririn/Features/Player/DataBroadcast/BMLReceivingIndicator.swift
@@ -1,0 +1,31 @@
+/// 実機の画面下に出る「データ取得中...」「通信中...」表示。
+enum BMLReceivingIndicator: Equatable {
+    case receiving
+    case networking
+
+    var displayText: String {
+        switch self {
+        case .receiving: "データ取得中..."
+        case .networking: "通信中..."
+        }
+    }
+
+    /// どちらの表示を出すか(出さないならnil)を決める。
+    ///
+    /// コンテンツ表示中だけでなく`isPresentationPending`も対象にするのが要点で、
+    /// 選局後に初めてdボタンを押したときは起動文書のモジュール取得が終わるまで
+    /// コンテンツが出ない - コンテンツ表示中だけを条件にすると、いちばん待たされる
+    /// 初回読み込みでこそ何も出ないことになる。
+    /// 両方進行中なら実機と同様に通信中を優先。
+    static func current(
+        isContentVisible: Bool,
+        isPresentationPending: Bool,
+        isReceiving: Bool,
+        isNetworking: Bool
+    ) -> BMLReceivingIndicator? {
+        guard isContentVisible || isPresentationPending else { return nil }
+        if isNetworking { return .networking }
+        if isReceiving { return .receiving }
+        return nil
+    }
+}

--- a/kiririn/Features/Player/DataBroadcast/DataBroadcastSession.swift
+++ b/kiririn/Features/Player/DataBroadcast/DataBroadcastSession.swift
@@ -108,6 +108,18 @@ final class DataBroadcastSession {
         !isInvisible && !isPresentationSuppressed
     }
 
+    /// dボタンで表示を要求済みだが、まだコンテンツが出ていない状態。web-bmlは
+    /// 起動文書がロードされるまで表示要求を保留する(applyRequestedPresentation-
+    /// Visibilityのメイン文書待ち)ので、選局後の初回読み込みはまるごとここに入る。
+    var isPresentationPending: Bool {
+        switch status {
+        case .unsupported, .failed:
+            return false
+        case .idle, .connecting, .active:
+            return requestedPresentationVisible == true && !isContentVisible
+        }
+    }
+
     func pressDataButton() {
         let shouldShow = !isContentVisible
         requestedPresentationVisible = shouldShow

--- a/kiririn/Features/Player/DataBroadcast/DataBroadcastSettings.swift
+++ b/kiririn/Features/Player/DataBroadcast/DataBroadcastSettings.swift
@@ -4,6 +4,7 @@ enum DataBroadcastSettings {
     static let enabledKey = "dataBroadcast.enabled"
     static let postalCodeKey = "dataBroadcast.receiverInfo.postalCode"
     static let internetAccessKey = "dataBroadcast.internetAccess"
+    static let receivingIndicatorKey = "dataBroadcast.receivingIndicator"
     static let webStorageKey = "dataBroadcast.webStorage"
 
     /// web-bmlが郵便番号NVRAMに使うlocalStorageキー
@@ -14,6 +15,14 @@ enum DataBroadcastSettings {
     /// コンテンツが放送局などの外部サーバーへHTTP接続するためデフォルトOFF。
     static func internetAccessEnabled(in defaults: UserDefaults = .standard) -> Bool {
         defaults.bool(forKey: internetAccessKey)
+    }
+
+    /// 「データ取得中...」「通信中...」表示を出すか。実機に合わせて既定はON
+    /// (未設定=trueなのでdefaults.boolは使えない)。
+    static let receivingIndicatorDefault = true
+
+    static func receivingIndicatorEnabled(in defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: receivingIndicatorKey) as? Bool ?? receivingIndicatorDefault
     }
 
     static func postalCode(in defaults: UserDefaults = .standard) -> String? {

--- a/kiririn/Features/Player/DataBroadcast/DataBroadcastSettingsView.swift
+++ b/kiririn/Features/Player/DataBroadcast/DataBroadcastSettingsView.swift
@@ -4,6 +4,8 @@ struct DataBroadcastSettingsView: View {
     @AppStorage(DataBroadcastSettings.enabledKey) private var isDataBroadcastEnabled = false
     @AppStorage(DataBroadcastSettings.internetAccessKey) private var isInternetAccessEnabled =
         false
+    @AppStorage(DataBroadcastSettings.receivingIndicatorKey)
+    private var isReceivingIndicatorEnabled = DataBroadcastSettings.receivingIndicatorDefault
     @State private var postalCode = ""
 
     private var isPostalCodeValid: Bool {
@@ -17,6 +19,15 @@ struct DataBroadcastSettingsView: View {
             } footer: {
                 Text(
                     "利用には[Mahiron](https://github.com/rokoucha/Mahiron)のデータ放送用拡張APIが必要です。"
+                )
+            }
+            Section {
+                Toggle("データ取得中の表示", isOn: $isReceivingIndicatorEnabled)
+            } header: {
+                Text("表示")
+            } footer: {
+                Text(
+                    "モジュールの取得中や通信中に、受信機と同じ「データ取得中...」「通信中...」を画面右下へ表示します。"
                 )
             }
             Section {

--- a/kiririn/Features/Player/PlayerState.swift
+++ b/kiririn/Features/Player/PlayerState.swift
@@ -265,6 +265,17 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
         guard let session = dataBroadcastSession else { return false }
         return session.status == .active && session.isContentVisible
     }
+    /// 実機の画面下に出る「データ取得中...」「通信中...」相当の表示(不要ならnil)。
+    /// 設定でのオン/オフは表示側で見る。
+    var bmlReceivingIndicator: BMLReceivingIndicator? {
+        guard let session = dataBroadcastSession else { return nil }
+        return BMLReceivingIndicator.current(
+            isContentVisible: bmlContentVisible,
+            isPresentationPending: session.isPresentationPending,
+            isReceiving: session.isReceiving,
+            isNetworking: session.isNetworking
+        )
+    }
     var isRecording = false
     var caption: String = ""
     var captionHistory: [CaptionHistoryItem] = []

--- a/kiririn/Features/Player/macOS/DetachedPlayerOverlayView.swift
+++ b/kiririn/Features/Player/macOS/DetachedPlayerOverlayView.swift
@@ -41,6 +41,9 @@
         @State private var playbackErrorAlertMessage = ""
         @State private var bmlKeyMonitor: BMLKeyMonitor?
         @State private var bmlRemotePanel: BMLRemotePanelController?
+        @AppStorage(DataBroadcastSettings.receivingIndicatorKey)
+        private var isBMLReceivingIndicatorEnabled =
+            DataBroadcastSettings.receivingIndicatorDefault
 
         private var playerWindow: NSWindow? {
             playerWindowReference.window
@@ -525,23 +528,19 @@
                 .transition(.opacity)
         }
 
-        /// 実機の画面下に出る「データ取得中...」「通信中...」表示。BMLコンテンツが
-        /// 表示中で、かつ待ちのモジュール取得または通信コンテンツのHTTP通信がある
-        /// あいだだけ、受信機風に右下へ出す。両方進行中なら通信中を優先。
+        /// 実機の画面下に出る「データ取得中...」「通信中...」表示。待ちのモジュール
+        /// 取得または通信コンテンツのHTTP通信があるあいだだけ、受信機風に右下へ出す。
+        /// 表示条件はBMLReceivingIndicatorを参照。
         @ViewBuilder
         private func bmlReceivingOverlay(scale: CGFloat) -> some View {
-            let isNetworking =
-                playerState.bmlContentVisible
-                && playerState.dataBroadcastSession?.isNetworking == true
-            let isReceiving =
-                playerState.bmlContentVisible
-                && playerState.dataBroadcastSession?.isReceiving == true
+            let indicator =
+                isBMLReceivingIndicatorEnabled ? playerState.bmlReceivingIndicator : nil
             VStack {
                 Spacer()
                 HStack {
                     Spacer()
-                    if isNetworking || isReceiving {
-                        Text(isNetworking ? "通信中..." : "データ取得中...")
+                    if let indicator {
+                        Text(indicator.displayText)
                             .font(.system(size: 21 * scale, weight: .medium))
                             .foregroundStyle(.white)
                             .padding(.horizontal, 15 * scale)
@@ -557,7 +556,7 @@
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .animation(.easeInOut(duration: 0.15), value: isNetworking || isReceiving)
+            .animation(.easeInOut(duration: 0.15), value: indicator)
             .allowsHitTesting(false)
         }
 

--- a/kiririnTests/DataBroadcastCaptureLayoutTests.swift
+++ b/kiririnTests/DataBroadcastCaptureLayoutTests.swift
@@ -36,3 +36,40 @@ struct DataBroadcastCaptureLayoutTests {
         #expect(layout.videoFrame.height == 1080)
     }
 }
+
+struct BMLReceivingIndicatorTests {
+    @Test func showsNothingWhileContentIsNeitherVisibleNorRequested() {
+        #expect(
+            BMLReceivingIndicator.current(
+                isContentVisible: false, isPresentationPending: false,
+                isReceiving: true, isNetworking: true) == nil)
+    }
+
+    @Test func showsReceivingDuringFirstLoadBeforeContentAppears() {
+        // 選局後の初回dボタン: 起動文書がまだ出ていない(コンテンツ非表示)が、
+        // モジュール取得待ちなので実機同様「データ取得中...」を出す。
+        #expect(
+            BMLReceivingIndicator.current(
+                isContentVisible: false, isPresentationPending: true,
+                isReceiving: true, isNetworking: false) == .receiving)
+    }
+
+    @Test func showsNothingWhileIdleWithContentVisible() {
+        #expect(
+            BMLReceivingIndicator.current(
+                isContentVisible: true, isPresentationPending: false,
+                isReceiving: false, isNetworking: false) == nil)
+    }
+
+    @Test func prefersNetworkingOverReceiving() {
+        #expect(
+            BMLReceivingIndicator.current(
+                isContentVisible: true, isPresentationPending: false,
+                isReceiving: true, isNetworking: true) == .networking)
+    }
+
+    @Test func usesReceiverWordingForEachState() {
+        #expect(BMLReceivingIndicator.receiving.displayText == "データ取得中...")
+        #expect(BMLReceivingIndicator.networking.displayText == "通信中...")
+    }
+}

--- a/kiririnTests/StoreBehaviorTests.swift
+++ b/kiririnTests/StoreBehaviorTests.swift
@@ -24,6 +24,16 @@ struct StoreBehaviorTests {
         #expect(DataBroadcastSettings.postalCode(in: defaults) == "0123456")
     }
 
+    @Test func dataBroadcastReceivingIndicatorDefaultsToOn() {
+        let (defaults, suiteName) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(DataBroadcastSettings.receivingIndicatorEnabled(in: defaults))
+
+        defaults.set(false, forKey: DataBroadcastSettings.receivingIndicatorKey)
+        #expect(!DataBroadcastSettings.receivingIndicatorEnabled(in: defaults))
+    }
+
     @Test func dataBroadcastSettingsRejectsInvalidPostalCodes() {
         #expect(DataBroadcastSettings.validatedPostalCode(nil) == nil)
         #expect(DataBroadcastSettings.validatedPostalCode("") == nil)


### PR DESCRIPTION
## 概要

データ放送の「データ取得中...」「通信中...」表示が、選局後に初めてdボタンを押したときだけ出ていなかったのを修正します。あわせて表示のオン/オフ設定を追加しました。

## 出ていなかった理由

表示条件が `bmlContentVisible`(= `status == .active && !isInvisible && !isPresentationSuppressed`)だけでした。web-bmlは起動文書がロードされるまで表示要求を保留する(`applyRequestedPresentationVisibility()` の `if (!isDocumentLoaded) return;`)ため、**いちばん待たされる起動モジュールの取得中はコンテンツ非表示のまま**で、そこだけ判定から漏れていました。

`DataBroadcastSession.isPresentationPending`(dボタンで表示要求済みだがまだ出ていない状態)を追加し、表示条件を「コンテンツ表示中 **または** 表示待ち」に広げています。判定は `BMLReceivingIndicator` に純粋関数として切り出したのでユニットテストが書けます。

## 設定の追加

`dataBroadcast.receivingIndicator`(既定ON、実機に合わせています)をデータ放送設定に「表示」セクションのトグルとして追加。`@AppStorage` なので切り替えは即反映されます。

## 備考

このバッジは元々 `DetachedPlayerOverlayView_macOS` にしかなく、iOS側(`PlayerOverlayView_iOS`)には実装がありません。今回はそこは触っていません(`playerState.bmlReceivingIndicator` を読むだけなので移植は容易です)。

## テスト

- `xcodebuild test -only-testing:kiririnTests` → TEST SUCCEEDED
- 追加: `BMLReceivingIndicatorTests` 5件、`StoreBehaviorTests.dataBroadcastReceivingIndicatorDefaultsToOn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

初回ロード時に受信・通信中インジケーターを正しく表示し、その表示を設定で切り替え可能にすることで、データ放送のユーザー体験を改善します。

New Features:
- 「データ取得中...」/「通信中...」データ放送受信インジケーターの表示・非表示をユーザーが切り替え可能な設定を追加（デフォルトは表示オン）。

Bug Fixes:
- BMLコンテンツがまだ表示されていない状態でも、プレゼンテーションが要求された初回チャンネルロード時に、データ放送受信インジケーターが表示されるように修正。

Enhancements:
- データ放送受信インジケーターの状態判定ロジックを集約し、プレイヤーオーバーレイで使用される専用の `BMLReceivingIndicator` ヘルパーに統合。

Tests:
- `BMLReceivingIndicator` の挙動および、受信インジケーター設定のデフォルト状態に関するユニットテストを追加。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve data broadcast UX by correctly showing the receiving/networking indicator during initial loads and making its display configurable.

New Features:
- Add a user-toggleable setting to show or hide the "データ取得中..." / "通信中..." data broadcast receiving indicator, defaulting to on.

Bug Fixes:
- Ensure the data broadcast receiving indicator appears even during the initial channel load when the BML content is not yet visible but presentation has been requested.

Enhancements:
- Centralize the logic for determining the data broadcast receiving indicator state into a dedicated BMLReceivingIndicator helper used by the player overlay.

Tests:
- Add unit tests for BMLReceivingIndicator behavior and for the default state of the receiving indicator setting.

</details>