### PR TITLE
fix: データ放送のdボタンが一部の放送局で3回押さないと開かない問題を修正

### DIFF
--- a/kiririn/Features/Player/DataBroadcast/DataBroadcastSession.swift
+++ b/kiririn/Features/Player/DataBroadcast/DataBroadcastSession.swift
@@ -78,9 +78,13 @@ final class DataBroadcastSession {
     private(set) var status: Status = .idle
     private(set) var stageRect: CGRect?
     private(set) var videoRect: CGRect?
-    private(set) var isInvisible = false
-    private var isPresentationSuppressed = true
-    private var requestedPresentationVisible: Bool?
+    /// コンテンツのbody@invisible。文書が提示されるまでは「非提示」が正しい
+    /// 初期値なのでtrueから始める(falseで始めると提示直前に一瞬合成される)。
+    private(set) var isInvisible = true
+    /// 文書がひとつでも提示されたか。BMLエンジン起動前は合成しない。
+    private var hasPresentedDocument = false
+    /// dボタンを押したがまだ文書が提示されていない状態(「データ取得中...」用)。
+    private var isAwaitingPresentation = false
     /// 実機の「データ取得中...」に相当。コンテンツが待っているモジュール取得が
     /// 保留中のあいだtrue (web-bmlのIndicator.setReceivingStatus由来)。
     private(set) var isReceiving = false
@@ -104,30 +108,40 @@ final class DataBroadcastSession {
         )
     }
 
+    /// データ放送面を合成するか。受信機側のゲートは持たず、コンテンツの
+    /// `invisible`だけに従う (TR-B14 第三編 2.1.10.4)。
+    ///
+    /// 「invisible=false」は「データ放送が見えている」とは限らない点に注意:
+    /// 多くの局は選局後、映像を全画面のまま何も描かない透過の待機文書
+    /// (NTVなら/40/0001/tvdata.bml)をinvisible=falseで提示し、dボタンで
+    /// 実体の文書へ遷移する。合成しても見た目は変わらないので、受信機側が
+    /// 「まだ出さない」と抑える必要はない。抑えると押下が状態合わせに消費
+    /// されて、実機なら1回で済むところが3回必要になる(実測)。
     var isContentVisible: Bool {
-        !isInvisible && !isPresentationSuppressed
+        hasPresentedDocument && !isInvisible
     }
 
-    /// dボタンで表示を要求済みだが、まだコンテンツが出ていない状態。web-bmlは
-    /// 起動文書がロードされるまで表示要求を保留する(applyRequestedPresentation-
-    /// Visibilityのメイン文書待ち)ので、選局後の初回読み込みはまるごとここに入る。
+    /// dボタンを押したが、起動文書がまだ提示されていない状態。選局直後は
+    /// カルーセルの取得待ちでまるごとここに入る(「データ取得中...」を出す)。
     var isPresentationPending: Bool {
         switch status {
         case .unsupported, .failed:
             return false
         case .idle, .connecting, .active:
-            return requestedPresentationVisible == true && !isContentVisible
+            return isAwaitingPresentation && !isContentVisible
         }
     }
 
+    /// dボタン押下。TR-B14 第三編 2.1.10.4 / 5.3.1のとおり、BMLエンジン起動後の
+    /// 押下はそのままコンテンツへ渡す。出す/消すはコンテンツの責務 - NTVは
+    /// 待機文書と実体文書の間をlaunchDocumentで往復して実現している。
+    /// 起動文書がまだ提示されていない場合はJS側が保留し、提示され次第渡す。
     func pressDataButton() {
-        let shouldShow = !isContentVisible
-        requestedPresentationVisible = shouldShow
-        if !shouldShow {
-            isPresentationSuppressed = true
+        if !hasPresentedDocument {
+            isAwaitingPresentation = true
         }
-        logger.info("BML presentation requested: visible=\(shouldShow)")
-        post(#"{"type":"setPresentationVisible","visible":\#(shouldShow)}"#)
+        logger.info("BML data button pressed (presented=\(hasPresentedDocument))")
+        post(#"{"type":"dataButton"}"#)
     }
 
     func takeCaptureSnapshot(layout: DataBroadcastCaptureLayout) async
@@ -274,9 +288,9 @@ final class DataBroadcastSession {
         invisibleUpdateTask = nil
         stageRect = nil
         videoRect = nil
-        isInvisible = false
-        isPresentationSuppressed = true
-        requestedPresentationVisible = nil
+        isInvisible = true
+        hasPresentedDocument = false
+        isAwaitingPresentation = false
         usedKeyGroups.removeAll()
         inputRequest = nil
         consecutiveFailures = 0
@@ -874,6 +888,10 @@ final class DataBroadcastSession {
             }
         case "invisible":
             let nextValue = (body["value"] as? Bool) ?? false
+            logger.debug(
+                "BML invisible msg: \(nextValue) (current=\(isInvisible) presented=\(hasPresentedDocument))"
+            )
+            // 文書遷移中のtrue→falseでちらつかないよう少し待ってから反映する。
             invisibleUpdateTask?.cancel()
             invisibleUpdateTask = Task { @MainActor [weak self] in
                 try? await Task.sleep(for: .milliseconds(300))
@@ -882,10 +900,9 @@ final class DataBroadcastSession {
                     self.isInvisible = nextValue
                     self.logger.info("BML invisible: \(nextValue)")
                 }
-                if self.requestedPresentationVisible == !nextValue {
-                    self.isPresentationSuppressed = nextValue
-                    self.requestedPresentationVisible = nil
-                }
+                self.logger.debug(
+                    "BML presentation state: status=\(String(describing: self.status)) invisible=\(self.isInvisible) presented=\(self.hasPresentedDocument) contentVisible=\(self.isContentVisible)"
+                )
             }
         case "receiving":
             receivingClearTask?.cancel()
@@ -954,6 +971,10 @@ final class DataBroadcastSession {
         case "log":
             logger.debug("[bml] \(body["message"] as? String ?? "")")
         case "loaded":
+            // 文書がひとつでも提示された。以降はコンテンツのinvisibleだけで
+            // 合成可否が決まる。
+            hasPresentedDocument = true
+            isAwaitingPresentation = false
             logger.info(
                 "BML loaded: \(body["width"] as? Double ?? 0)x\(body["height"] as? Double ?? 0) profile=\(body["profile"] as? String ?? "?")"
             )

--- a/kiririn/Features/Player/PlayerState.swift
+++ b/kiririn/Features/Player/PlayerState.swift
@@ -258,9 +258,11 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
             return true
         }
     }
-    /// Whether the BML content is currently presenting itself. A newly
-    /// created session stays closed until the next DataButton press, then
-    /// follows web-bml's `invisible` state.
+    /// Whether the BML content is currently presenting itself - purely
+    /// web-bml's `invisible` state once a document has been presented. There
+    /// is deliberately no receiver-side "not until the user presses d" gate;
+    /// see DataBroadcastSession.isContentVisible for why one breaks the
+    /// d button.
     var bmlContentVisible: Bool {
         guard let session = dataBroadcastSession else { return false }
         return session.status == .active && session.isContentVisible

--- a/web/bml/src/index.ts
+++ b/web/bml/src/index.ts
@@ -192,7 +192,19 @@ const bmlBrowser = new BMLBrowser({
     // 未対応の受信機として正しく振る舞う(getBrowserSupportも0を返す)。
     ip: window.kiririnBMLConfig?.internetAccess === true ? createIP() : undefined,
     indicator: {
-        setUrl() {},
+        // Content.loadDocument()は最後に(loading=false)で、
+        // launchDocument()は遷移開始時に(loading=true)でこれを呼ぶ。
+        // web-bmlが公開している中でこれだけが「文書のスクリプトが評価され
+        // onloadも走り終わった」ことを示すので、保留中のdボタンを渡す
+        // タイミングとして使う。
+        setUrl(name: string, loading: boolean) {
+            console.info(`[kiririn-bml] setUrl: ${name} loading=${loading}`);
+            cancelDocumentReadyFallback();
+            isDocumentReady = !loading;
+            if (!loading) {
+                applyPresentationRequest("setUrl");
+            }
+        },
         // 実機でいう画面下の「データ取得中...」表示 - ネイティブ側でバッジ表示する
         setReceivingStatus(receiving: boolean) {
             if (receiving !== lastReceivingStatus) {
@@ -227,8 +239,20 @@ function applyStageScale(width: number, height: number): void {
 }
 
 let lastResolution: { width: number; height: number } | null = null;
-let isDocumentLoaded = false;
-let requestedPresentationVisible: boolean | null = null;
+// Content.loadDocument()を最後まで走り切った(onload実行・beitemのsubscribe
+// 適用・イベントキュー処理まで終わった)文書が提示されているか。web-bmlの
+// "load"イベントはloadDocument()の途中(スクリプト評価前)に飛んでくるので、
+// dボタンを渡してよいかの判断にはそちらを使えない - indicator.setUrlを参照。
+let isDocumentReady = false;
+let documentReadyFallbackTimer: number | undefined;
+// dボタン押下を保留しているか。選局直後は起動文書がまだ届いていないので、
+// 提示できるようになるまでここで持っておいて、届いたら渡す。
+let hasPendingDataButton = false;
+// loadDocument()がスクリプト内のlaunchDocument等で途中returnするとsetUrl
+// (loading=false)が来ないので、loadから一定時間で提示済みとみなす保険。
+// 通常はモジュールがキャッシュ済みで即座にsetUrl(false)が来るため、これが
+// 効くのは異常系だけ - 早すぎるとスクリプト評価前に渡してしまうので長め。
+const documentReadyFallbackMs = 3000;
 
 function reapplyStageScale(): void {
     if (lastResolution != null) {
@@ -266,7 +290,6 @@ function postLayoutRects(): void {
 }
 
 bmlBrowser.addEventListener("load", (evt) => {
-    isDocumentLoaded = true;
     lastResolution = evt.detail.resolution;
     applyStageScale(evt.detail.resolution.width, evt.detail.resolution.height);
     console.info(
@@ -284,7 +307,15 @@ bmlBrowser.addEventListener("load", (evt) => {
         height: evt.detail.resolution.height,
         profile: evt.detail.profile,
     });
-    applyRequestedPresentationVisibility();
+    // ここでdボタンを渡してはいけない。このイベントはloadDocument()の途中
+    // (arib-scriptの評価前・onloadの前)で発火するため、DataButtonPressedの
+    // onoccurが未定義の関数を指してしまい押下が握り潰される
+    // (STD-B24 第二分冊(2/2) 第二編 付属1 5.1.3: onloadが実行されるまで
+    // イベントは実行されない)。保留分はindicator.setUrl(loading=false)から
+    // 渡す。
+    isDocumentReady = false;
+    armDocumentReadyFallback();
+    synchronizePresentationAfterLayout();
 });
 
 bmlBrowser.addEventListener("videochanged", (evt) => {
@@ -324,27 +355,55 @@ function synchronizePresentationAfterLayout(): void {
     });
 }
 
-function applyRequestedPresentationVisibility(): void {
-    if (requestedPresentationVisible == null) {
+function cancelDocumentReadyFallback(): void {
+    if (documentReadyFallbackTimer != null) {
+        window.clearTimeout(documentReadyFallbackTimer);
+        documentReadyFallbackTimer = undefined;
+    }
+}
+
+function armDocumentReadyFallback(): void {
+    cancelDocumentReadyFallback();
+    documentReadyFallbackTimer = window.setTimeout(() => {
+        documentReadyFallbackTimer = undefined;
+        if (isDocumentReady) {
+            return;
+        }
+        log("warn", "BML document readiness fell back to a timer");
+        isDocumentReady = true;
+        applyPresentationRequest("readyFallback");
+    }, documentReadyFallbackMs);
+}
+
+/// dボタン押下をコンテンツへ渡す。TR-B14 第三編 2.1.10.4 / 5.3.1により、
+/// BMLエンジン起動後の押下はすべてコンテンツへ渡し、出す/消すはコンテンツの
+/// 責務。受信機側が提示状態と突き合わせて握り潰してはいけない - NTVのように
+/// 「invisible=falseだが何も描かない待機文書」を挟むコンテンツでは、
+/// invisibleを見て判断すると押下が無駄になる (実測: 待機文書tvdata.bmlは
+/// invisible=falseで映像フル表示、実体は押下で遷移する/60/配下の文書)。
+///
+/// 渡すのは文書が提示され終わってから (indicator.setUrl(loading=false))。
+/// web-bmlの"load"はloadDocument()の途中でarib-script評価前なので、そこで
+/// 渡すとDataButtonPressedのonoccurが未定義の関数を指して握り潰される。
+function applyPresentationRequest(source: string): void {
+    if (!hasPendingDataButton) {
         return;
     }
-    if (requestedPresentationVisible && audioContext.state === "suspended") {
-        void audioContext.resume().catch((error) => {
-            log("warn", `BML audio resume failed: ${String(error)}`);
-        });
-    }
-    if (!isDocumentLoaded) {
+    console.info(
+        `[kiririn-bml] applyPresentationRequest(${source}): ready=${isDocumentReady}` +
+            ` invisible=${bmlBrowser.content.invisible}`,
+    );
+    if (!isDocumentReady || bmlBrowser.content.invisible == null) {
+        // 起動文書がまだ提示されていない。setUrl(loading=false)か保険タイマ
+        // から呼び直される。
         return;
     }
-    const shouldShow = requestedPresentationVisible;
-    const isInvisible = bmlBrowser.content.invisible;
-    if (isInvisible == null) {
-        return;
-    }
-    if (shouldShow === isInvisible) {
-        bmlBrowser.content.processKeyDown(AribKeyCode.DataButton);
-        bmlBrowser.content.processKeyUp(AribKeyCode.DataButton);
-    }
+    // ワンショット。保留したまま文書遷移をまたぐと遷移先の提示完了でもう一度
+    // 渡してしまう (実測で二重送出を確認済み)。
+    hasPendingDataButton = false;
+    console.info(`[kiririn-bml] delivering DataButton (${source})`);
+    bmlBrowser.content.processKeyDown(AribKeyCode.DataButton);
+    bmlBrowser.content.processKeyUp(AribKeyCode.DataButton);
     synchronizePresentationAfterLayout();
 }
 
@@ -386,10 +445,16 @@ window.kiririnBML = {
                 }
                 break;
             }
-            case "setPresentationVisible":
-                requestedPresentationVisible = message.visible;
-                applyRequestedPresentationVisibility();
+            case "dataButton": {
+                if (audioContext.state === "suspended") {
+                    void audioContext.resume().catch((error) => {
+                        log("warn", `BML audio resume failed: ${String(error)}`);
+                    });
+                }
+                hasPendingDataButton = true;
+                applyPresentationRequest("dataButton");
                 break;
+            }
             case "audioOutput":
                 audioGain.gain.value = message.muted ? 0 : message.volume / 100;
                 break;
@@ -402,6 +467,9 @@ window.kiririnBML = {
             case "reset":
                 lastPMTComponents = null;
                 adapter = new MahironAdapter(emitToBrowser);
+                isDocumentReady = false;
+                hasPendingDataButton = false;
+                cancelDocumentReadyFallback();
                 break;
             default:
                 log("warn", `unhandled native message: ${JSON.stringify(message)}`);

--- a/web/bml/src/types.ts
+++ b/web/bml/src/types.ts
@@ -20,7 +20,10 @@ export type NativeToWebMessage =
     | { type: "audioOutput"; volume: number; muted: boolean }
     | { type: "inputResult"; requestId: number; value: string }
     | { type: "inputCancel"; requestId: number }
-    | { type: "setPresentationVisible"; visible: boolean }
+    // dボタン押下。TR-B14 第三編 2.1.10.4のとおり、そのままコンテンツへ
+    // 渡すだけ。出す/消すはコンテンツの責務なので、ネイティブ側の意図は
+    // 乗せない。
+    | { type: "dataButton" }
     | { type: "reset" };
 
 // JS -> Swift (webkit.messageHandlers.bml.postMessage)


### PR DESCRIPTION
一部の放送局(NTVで再現)で、データ放送のdボタンを3回押さないと開かない問題を修正します。

受信機側の表示ゲート(`isPresentationSuppressed`)を廃止し、コンテンツの `invisible` だけで合成可否を決めるようにしました。dボタンは TR-B14 第三編 2.1.10.4 / 5.3.1 のとおり、そのままコンテンツへ渡します。

## 原因1: `invisible=false` は「データ放送が見えている」ではない

多くの局は選局後、**映像を全画面のまま何も描かない透過の待機文書**を `invisible=false` で提示し、dボタンの `DataButtonPressed` で `launchDocument` して実体の文書へ遷移します。NTV の場合、待機が `/40/0001/tvdata.bml`、実体が `/60/0000/ntv_12_top.bml` で、**往復とも文書遷移**です。

見分けは `layoutRects` の video 矩形で、待機中は全画面 `(0,0,1280,720)`、実体では縮んで `(448,18,800,449)` になります。

このため `invisible` を「見えているか」として受信機側ゲートと突き合わせると:

| | 起きていたこと |
|---|---|
| 押下1 | 「もう望みの状態」と判定 → **キーは渡らず**ゲート解除だけ。画面は待機文書＝空 |
| 押下2 | 表示中のつもりなので非表示要求。キーは渡って**実体へ遷移するのに**同時に opacity 0 |
| 押下3 | ゲート解除。**やっと見える** |

ゲートを外しても待機文書は透過なので見た目は変わりません。`invisible` で待機する局は `invisible=true` なので合成されません。起動文書がいきなり描く局だけ選局直後に出ますが、実機と同じ挙動です。

## 原因2: web-bml の `load` イベントは `loadDocument()` の途中

`Content.loadDocument()` は `dispatchEvent("load")` → arib-script 評価 → onload 実行 → beitem の subscribe 適用、の順です。つまり `load` リスナでキーを流し込むと **`DataButtonPressed` の `onoccur` がまだ未定義の関数を指していて握り潰されます**(STD-B24 第二分冊(2/2) 第二編 付属1 5.1.3「onload が実行されるまでイベントは実行されない」)。

文書が提示され終わった合図として使えるのは `indicator.setUrl(name, false)`(`loadDocument()` の最終行)だけなので、保留中の押下はそこから渡すようにしました。スクリプト内 `launchDocument` などで途中 return して `setUrl(false)` が来ない経路のために、保険タイマも張っています。

## その他の変更

- **押下はワンショット。** 渡した時点で保留を降ろします。保留したまま文書遷移をまたぐと遷移先の提示完了で再送し、その `DataButtonPressed` がデータ放送の先頭へ戻すため「押しても開かない」ように見えていました(romSound が2回鳴るので気付けました)
- **`isInvisible` の初期値を `true` に。** 未提示＝非提示が正しく、`false` 始まりだと文書提示の直前に空の WKWebView が一瞬合成されます。旧ゲートはこれを潰していた面もあるので、押下を消費しない形で解決し直しました
- `hasPresentedDocument` を合成条件に追加

## 経緯

表示ゲートは #64 の `b0e62687`「fix: リロード後にデータ放送出せるように」で入ったものです。同コミットの他の3つの修正(`.id(ObjectIdentifier(session.webView))`、dキーの `status == .active` 迂回、usedKeyList のフォールバック)はいずれも正当なので**変更していません**。初版(#38)は今回と同じくゲート無しで `invisible` に追従する設計でした。

## レビュアーへ

- **挙動変更です。** 「選局直後はデータ放送面を隠す」という既存の意図的な仕様を外しています。上記のとおり実害は無いと判断していますが、意図と違えば指摘してください
- 調査用のログを残してあります。JS 側は `console.info` のみでブリッジには流れません。Swift 側は `debug` レベルです。不要なら落とします
- **メモリ**: 参照の輪(`session → webView → contentController → LeakAversionBMLMessageHandler --weak--> session`)は維持、`Task {` の strong self 捕捉はゼロ、追加したJSタイマーは同時に1本以上にならないことを確認済み。ただし **Instruments での実測はしていません**

## 動作確認

- NTV で1回押しで開くこと、もう一度押すと閉じることを実機確認済み
- `xcodebuild build` / `xcodebuild test -only-testing:kiririnTests` ともに成功

なお `web/bml` を変更したので、`setup.sh` を再実行するか `web/bml/dist` を `kiririn/Features/Player/DataBroadcast/Web/dist` へコピーしないとアプリ側に反映されません(コピー先は gitignore されており、`npm run build` だけでは古いバンドルのまま動きます)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

データ放送における d ボタンの扱いの誤りを修正し、コンテンツの表示状態と入力が受信機側のゲートではなく BML コンテンツの状態に従うようにすることで、局をまたいでもデータ放送が初回のボタン押下で確実に開くようにしました。

Bug Fixes:
- 一部の局でデータ放送の d ボタンを複数回押さないとコンテンツが表示されない問題を、BML コンテンツの準備完了後はすべてのボタン押下を直接 BML コンテンツに転送することで解消しました。
- 初期ドキュメント読み込み中に発生した d ボタン押下が失われるのではなく、ドキュメントとそのスクリプトが完全に準備完了したタイミングでキューから配信されるようにしました。

Enhancements:
- BML の表示制御を、コンテンツの `invisible` フラグと初回ドキュメントの表示状態のみに依存させ、受信機側に存在していた余分な表示ゲートを削除して簡素化しました。
- BML の表示状態トラッキングにおける初期状態およびリセット時の状態を調整し、最初のドキュメントが表示される前に一瞬だけ合成面が空白になるようなフラッシュが発生しないようにしました。
- BML ドキュメントの準備完了、不可視状態の変化、および d ボタン配送に関するログを改善し、診断しやすくしました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix incorrect d-button handling in data broadcasting so that content visibility and input follow BML content state instead of a receiver-side gate, ensuring data broadcasting opens reliably on first press across stations.

Bug Fixes:
- Resolve an issue where the data broadcast d-button had to be pressed multiple times on some stations before the content appeared by forwarding all presses directly to the BML content after it is ready.
- Ensure d-button presses that occur while the initial document is loading are queued and delivered once the document and its scripts are fully ready instead of being lost.

Enhancements:
- Simplify BML presentation control to rely solely on the content's `invisible` flag and first-document presentation state, removing the extra receiver-side visibility gate.
- Adjust initial and reset state for BML visibility tracking to avoid transient blank-composite flashes before the first document is presented.
- Improve logging around BML document readiness, invisibility changes, and d-button delivery to aid diagnostics.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

データ放送における d ボタンの扱いの誤りを修正し、コンテンツの表示状態と入力が受信機側のゲートではなく BML コンテンツの状態に従うようにすることで、局をまたいでもデータ放送が初回のボタン押下で確実に開くようにしました。

Bug Fixes:
- 一部の局でデータ放送の d ボタンを複数回押さないとコンテンツが表示されない問題を、BML コンテンツの準備完了後はすべてのボタン押下を直接 BML コンテンツに転送することで解消しました。
- 初期ドキュメント読み込み中に発生した d ボタン押下が失われるのではなく、ドキュメントとそのスクリプトが完全に準備完了したタイミングでキューから配信されるようにしました。

Enhancements:
- BML の表示制御を、コンテンツの `invisible` フラグと初回ドキュメントの表示状態のみに依存させ、受信機側に存在していた余分な表示ゲートを削除して簡素化しました。
- BML の表示状態トラッキングにおける初期状態およびリセット時の状態を調整し、最初のドキュメントが表示される前に一瞬だけ合成面が空白になるようなフラッシュが発生しないようにしました。
- BML ドキュメントの準備完了、不可視状態の変化、および d ボタン配送に関するログを改善し、診断しやすくしました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix incorrect d-button handling in data broadcasting so that content visibility and input follow BML content state instead of a receiver-side gate, ensuring data broadcasting opens reliably on first press across stations.

Bug Fixes:
- Resolve an issue where the data broadcast d-button had to be pressed multiple times on some stations before the content appeared by forwarding all presses directly to the BML content after it is ready.
- Ensure d-button presses that occur while the initial document is loading are queued and delivered once the document and its scripts are fully ready instead of being lost.

Enhancements:
- Simplify BML presentation control to rely solely on the content's `invisible` flag and first-document presentation state, removing the extra receiver-side visibility gate.
- Adjust initial and reset state for BML visibility tracking to avoid transient blank-composite flashes before the first document is presented.
- Improve logging around BML document readiness, invisibility changes, and d-button delivery to aid diagnostics.

</details>

</details>