### PR TITLE
chore: 仮マーケティングバージョンを廃止

### DIFF
--- a/kiririn.xcodeproj/project.pbxproj
+++ b/kiririn.xcodeproj/project.pbxproj
@@ -590,7 +590,6 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 18.4;
-				KIRIRIN_TEMPORARY_MARKETING_VERSION = 0.3.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.4;
@@ -666,7 +665,6 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 18.4;
-				KIRIRIN_TEMPORARY_MARKETING_VERSION = 0.3.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.4;

--- a/kiririn/Info.plist
+++ b/kiririn/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>KiririnTemporaryMarketingVersion</key>
-	<string>$(KIRIRIN_TEMPORARY_MARKETING_VERSION)</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>ローカルネットワーク上のサーバーとの通信と、リモコンに使用します。</string>
 	<key>NSBonjourServices</key>

--- a/kiririn/Shared/Models/AppBuildInfo.swift
+++ b/kiririn/Shared/Models/AppBuildInfo.swift
@@ -3,20 +3,15 @@ import Foundation
 struct AppBuildInfo {
     let appName: String
     let version: String
-    let temporaryMarketingVersion: String?
     let buildNumber: String
     let gitCommitHash: String
 
-    private var displayedVersion: String {
-        temporaryMarketingVersion ?? version
-    }
-
     var versionDescription: String {
-        "\(displayedVersion) (\(buildNumber), \(gitCommitHash))"
+        "\(version) (\(buildNumber), \(gitCommitHash))"
     }
 
     var versionWithGitCommitHashDescription: String {
-        "\(displayedVersion) (\(gitCommitHash))"
+        "\(version) (\(gitCommitHash))"
     }
 
     var appVersionDescription: String {
@@ -34,10 +29,6 @@ struct AppBuildInfo {
     init(bundle: Bundle) {
         appName = Self.infoValue("CFBundleDisplayName", from: bundle, fallback: "kiririn")
         version = Self.infoValue("CFBundleShortVersionString", from: bundle)
-        temporaryMarketingVersion = Self.optionalInfoValue(
-            "KiririnTemporaryMarketingVersion",
-            from: bundle
-        )
         buildNumber = Self.infoValue("CFBundleVersion", from: bundle)
         gitCommitHash = Self.infoValue("KiririnGitCommitHash", from: bundle)
     }
@@ -47,14 +38,6 @@ struct AppBuildInfo {
     {
         guard let value = bundle.object(forInfoDictionaryKey: key) as? String, !value.isEmpty else {
             return fallback
-        }
-
-        return value
-    }
-
-    private static func optionalInfoValue(_ key: String, from bundle: Bundle) -> String? {
-        guard let value = bundle.object(forInfoDictionaryKey: key) as? String, !value.isEmpty else {
-            return nil
         }
 
         return value


### PR DESCRIPTION
This reverts commit 2ee3b70064c81a94ed6127c4484dc0cd6f7fd131.

仮マーケティングバージョンを廃止。そこまでの頻度でTF投げたいこと無いので。

## Summary by Sourcery

一時的なマーケティング用バージョンの個別サポートを廃止し、通常のアプリバージョンのメタデータのみに依存するようにします。

改善点:
- 一時的なマーケティング用バージョンのフィールドおよび関連する参照ロジックを削除し、`AppBuildInfo` を簡素化します。
- `Info.plist` から `KiririnTemporaryMarketingVersion` 設定キーを削除し、クリーンアップします。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove support for a separate temporary marketing version and rely solely on the normal app version metadata.

Enhancements:
- Simplify AppBuildInfo by dropping the temporary marketing version field and related lookup logic.
- Clean up Info.plist by removing the KiririnTemporaryMarketingVersion configuration key.

</details>