### PR TITLE
chore: GoogleDrive連携でmimeTypeのvideo絞り込みを外す

### DIFF
--- a/kiririn/Features/Server/GoogleDriveProvider.swift
+++ b/kiririn/Features/Server/GoogleDriveProvider.swift
@@ -165,7 +165,7 @@ final class GoogleDriveProvider: RecordingServerProvider {
     func fetchRecords(pageToken: String?, limit: Int, keyword: String?) async throws
         -> RecordsResult
     {
-        var query = "mimeType contains 'video/' and trashed = false"
+        var query = "not mimeType contains 'application/vnd.google' and trashed = false"
         if let keyword, !keyword.isEmpty {
             let escapedKeyword = keyword.replacingOccurrences(of: "'", with: "\\'")
             query += " and fullText contains '\(escapedKeyword)'"


### PR DESCRIPTION
Fixes #71 

mmtsとかはvideo判定にならないので

## Summary by Sourcery

バグ修正:
- MMTS ファイルなどの非動画録画が、動画のみの MIME タイプ制約によってフィルタリングされるのではなく、Google ドライブの記録取得に含まれるようにしました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure non-video recordings such as MMTS files are included in Google Drive record fetching instead of being filtered out by video-only mime type constraints.

</details>