### PR TITLE
fix: 番組更新関連の負荷を最適化

### DIFF
--- a/kiririn/Features/Player/PlayerState.swift
+++ b/kiririn/Features/Player/PlayerState.swift
@@ -1154,21 +1154,79 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
                 playable.displayService ?? manager.service(serviceUniqueId: serviceUniqueId)
             guard let resolvedService else {
                 guard currentPlayable?.id == expectedPlayableID else { return }
-                nextProgram = nil
+                if nextProgram != nil {
+                    nextProgram = nil
+                }
                 return
             }
             let current = await manager.currentProgram(for: resolvedService)
             guard currentPlayable?.id == expectedPlayableID else { return }
-            currentPlayable?.program = current
-            dataBroadcastSession?.refreshProgramInfo()
-
             let next = await manager.nextProgram(for: resolvedService, currentProgram: current)
-            guard currentPlayable?.id == expectedPlayableID else { return }
-            nextProgram = next
+            applyProgramInfo(
+                current: current,
+                next: next,
+                expectedPlayableID: expectedPlayableID
+            )
         default:
             guard currentPlayable?.id == expectedPlayableID else { return }
-            nextProgram = nil
+            if nextProgram != nil {
+                nextProgram = nil
+            }
             break
+        }
+    }
+
+    func refreshProgramInfo(
+        using snapshot: ProgramDisplaySnapshot,
+        expectedPlayableID: String
+    ) async {
+        guard let manager, let playable = currentPlayable,
+            playable.id == expectedPlayableID
+        else { return }
+        switch playable.source {
+        case .liveService(let serviceUniqueId):
+            let resolvedService =
+                playable.displayService ?? manager.service(serviceUniqueId: serviceUniqueId)
+            guard let resolvedService else {
+                guard currentPlayable?.id == expectedPlayableID else { return }
+                if nextProgram != nil {
+                    nextProgram = nil
+                }
+                return
+            }
+
+            let key = ProgramServiceKey(
+                serviceId: resolvedService.serviceId,
+                networkId: resolvedService.networkId
+            )
+            guard currentPlayable?.id == expectedPlayableID else { return }
+            let current = snapshot.currentPrograms[key]
+            let next = await manager.nextProgram(for: resolvedService, currentProgram: current)
+            applyProgramInfo(
+                current: current,
+                next: next,
+                expectedPlayableID: expectedPlayableID
+            )
+        default:
+            guard currentPlayable?.id == expectedPlayableID else { return }
+            if nextProgram != nil {
+                nextProgram = nil
+            }
+        }
+    }
+
+    private func applyProgramInfo(
+        current: Program?,
+        next: Program?,
+        expectedPlayableID: String
+    ) {
+        guard currentPlayable?.id == expectedPlayableID else { return }
+        if currentPlayable?.program != current {
+            currentPlayable?.program = current
+            dataBroadcastSession?.refreshProgramInfo()
+        }
+        if nextProgram != next {
+            nextProgram = next
         }
     }
 

--- a/kiririn/Features/ProgramGuide/ProgramGuideChannelGridView.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideChannelGridView.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+struct ProgramGuideChannelGridView: View {
+    let channels: [GuideChannel]
+    let timelineStart: Date
+    let timelineEnd: Date
+    let minuteHeight: CGFloat
+    let channelColumnWidth: CGFloat
+    let timelineHeight: CGFloat
+    let nowLineYOffset: CGFloat
+    let nowLineOpacity: Double
+    let nowLineWidth: CGFloat
+    let viewportModel: ProgramGuideViewportModel
+    @Binding var selectedProgram: ProgramSelection?
+
+    var body: some View {
+        let markerOffsets = timeMarkerOffsets
+
+        ZStack(alignment: .topLeading) {
+            Color.kiririnSystemBackground
+                .frame(width: gridWidth, height: timelineHeight)
+
+            Canvas { context, size in
+                for y in markerOffsets {
+                    context.fill(
+                        Path(CGRect(x: 0, y: y, width: size.width, height: 1)),
+                        with: .color(Color.kiririnSeparator.opacity(0.25))
+                    )
+                }
+            }
+            .frame(width: gridWidth, height: timelineHeight)
+            .allowsHitTesting(false)
+
+            LazyHStack(alignment: .top, spacing: 0) {
+                ForEach(channels) { channel in
+                    ProgramChannelColumnView(
+                        channelId: channel.id,
+                        programs: channel.programs,
+                        timelineStart: timelineStart,
+                        timelineEnd: timelineEnd,
+                        minuteHeight: minuteHeight,
+                        width: channelColumnWidth,
+                        totalHeight: timelineHeight,
+                        visibleRange: viewportModel.visibleRange,
+                        onProgramTapped: { program in
+                            selectedProgram = ProgramSelection(
+                                program: program,
+                                service: channel.service
+                            )
+                        }
+                    )
+                    .equatable()
+                    .id(channel.id)
+                }
+            }
+
+            if nowLineYOffset >= 0 && nowLineYOffset < timelineHeight {
+                Rectangle()
+                    .fill(Color.accentColor)
+                    .opacity(nowLineOpacity)
+                    .frame(width: nowLineWidth, height: 3)
+                    .offset(y: nowLineYOffset - 1.5)
+                    .allowsHitTesting(false)
+                    .zIndex(1800)
+            }
+        }
+    }
+
+    private var gridWidth: CGFloat {
+        CGFloat(channels.count) * channelColumnWidth
+    }
+
+    private var timeMarkerOffsets: [CGFloat] {
+        let count = Int((timelineEnd.timeIntervalSince(timelineStart) / 60) / 30)
+        return (0...count).map { CGFloat($0 * 30) * minuteHeight }
+    }
+}

--- a/kiririn/Features/ProgramGuide/ProgramGuideGridComponents.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideGridComponents.swift
@@ -39,13 +39,15 @@ struct ProgramChannelColumnView: View, Equatable {
     }
 
     var body: some View {
+        let renderedProgramIndices = visibleProgramIndices
+
         ZStack(alignment: .topLeading) {
             // 絶対Y座標で配置する番組セルの原点を列の左上に固定する。
             Color.clear
                 .frame(width: width, height: totalHeight)
                 .allowsHitTesting(false)
 
-            ForEach(visibleProgramIndices, id: \.self) { index in
+            ForEach(renderedProgramIndices, id: \.self) { index in
                 ProgramCellWrapper(
                     program: programs[index],
                     timelineStart: timelineStart,
@@ -67,14 +69,15 @@ struct ProgramChannelColumnView: View, Equatable {
         }
         .onTapGesture(coordinateSpace: .local) { location in
             let tappedY = location.y
-            if let program = programs.first(where: { program in
+            if let index = renderedProgramIndices.first(where: { index in
+                let program = programs[index]
                 let start = max(program.startAt, timelineStart)
                 let rawEnd = program.endAt > program.startAt ? program.endAt : timelineEnd
                 let end = min(rawEnd, timelineEnd)
                 guard end > start else { return false }
                 return tappedY >= yOffset(for: start) && tappedY < yOffset(for: end)
             }) {
-                onProgramTapped(program)
+                onProgramTapped(programs[index])
             }
         }
     }

--- a/kiririn/Features/ProgramGuide/ProgramGuideGridComponents.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideGridComponents.swift
@@ -40,6 +40,11 @@ struct ProgramChannelColumnView: View, Equatable {
 
     var body: some View {
         ZStack(alignment: .topLeading) {
+            // 絶対Y座標で配置する番組セルの原点を列の左上に固定する。
+            Color.clear
+                .frame(width: width, height: totalHeight)
+                .allowsHitTesting(false)
+
             ForEach(visibleProgramIndices, id: \.self) { index in
                 ProgramCellWrapper(
                     program: programs[index],
@@ -51,8 +56,9 @@ struct ProgramChannelColumnView: View, Equatable {
                 .equatable()
             }
         }
-        .frame(width: width, height: totalHeight)
+        .frame(width: width, height: totalHeight, alignment: .topLeading)
         .clipped()
+        .contentShape(.rect)
         .overlay(alignment: .leading) {
             Rectangle()
                 .fill(Color.kiririnSeparator.opacity(0.6))

--- a/kiririn/Features/ProgramGuide/ProgramGuideGridComponents.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideGridComponents.swift
@@ -107,7 +107,7 @@ struct ProgramCellWrapper: View, Equatable {
         let height = CGFloat(duration) * minuteHeight
 
         if height > 0 {
-            ProgramCellView(program: program)
+            ProgramCellView(program: program, availableHeight: height)
                 .frame(width: width - 8, height: height, alignment: .topLeading)
                 .offset(x: 4, y: y)
                 .contentShape(.rect)
@@ -117,10 +117,13 @@ struct ProgramCellWrapper: View, Equatable {
 
 struct ProgramCellView: View, Equatable {
     @Environment(\.colorScheme) private var colorScheme
+    @ScaledMetric(relativeTo: .subheadline) private var minimumHeightForTimeRange: CGFloat = 68
+    @ScaledMetric(relativeTo: .caption2) private var minimumHeightForDescription: CGFloat = 88
     let program: Program
+    let availableHeight: CGFloat
 
     static func == (lhs: ProgramCellView, rhs: ProgramCellView) -> Bool {
-        lhs.program == rhs.program
+        lhs.program == rhs.program && lhs.availableHeight == rhs.availableHeight
     }
 
     var body: some View {
@@ -137,13 +140,17 @@ struct ProgramCellView: View, Equatable {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
 
-            Text(timeRange)
-                .font(.caption2)
-                .monospacedDigit()
-                .foregroundStyle(.secondary)
-                .frame(maxWidth: .infinity, alignment: .leading)
+            if availableHeight >= minimumHeightForTimeRange {
+                Text(timeRange)
+                    .font(.caption2)
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
 
-            if let desc = compactDescription {
+            if availableHeight >= minimumHeightForDescription,
+                let desc = compactDescription
+            {
                 BroadcastText(desc, style: .caption2)
                     .foregroundStyle(.secondary)
                     .lineLimit(3)

--- a/kiririn/Features/ProgramGuide/ProgramGuideGridComponents.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideGridComponents.swift
@@ -4,6 +4,10 @@ final class HorizontalOffsetTracker {
     var horizontalOffset: CGFloat = 0
 }
 
+final class VerticalOffsetTracker {
+    var verticalOffset: CGFloat = 0
+}
+
 struct ProgramChannelColumnView: View, Equatable {
     let channelId: String
     let programs: [Program]
@@ -12,12 +16,14 @@ struct ProgramChannelColumnView: View, Equatable {
     let minuteHeight: CGFloat
     let width: CGFloat
     let totalHeight: CGFloat
+    let visibleRange: ProgramGuideVisibleRange
     let onProgramTapped: (Program) -> Void
 
     nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.channelId == rhs.channelId && lhs.timelineStart == rhs.timelineStart
             && lhs.timelineEnd == rhs.timelineEnd && lhs.minuteHeight == rhs.minuteHeight
             && lhs.width == rhs.width && lhs.totalHeight == rhs.totalHeight
+            && lhs.visibleRange == rhs.visibleRange
             && lhs.programs == rhs.programs
     }
 
@@ -28,6 +34,17 @@ struct ProgramChannelColumnView: View, Equatable {
     private var timeMarkerOffsets: [CGFloat] {
         let count = Int((timelineEnd.timeIntervalSince(timelineStart) / 60) / 30)
         return (0...count).map { CGFloat($0 * 30) * minuteHeight }
+    }
+
+    private var visibleProgramIndices: [Int] {
+        programs.indices.filter { index in
+            let program = programs[index]
+            return visibleRange.intersects(
+                programStart: program.startAt,
+                programEnd: program.endAt,
+                timelineEnd: timelineEnd
+            )
+        }
     }
 
     var body: some View {
@@ -50,9 +67,9 @@ struct ProgramChannelColumnView: View, Equatable {
             }
             .allowsHitTesting(false)
 
-            ForEach(Array(programs.enumerated()), id: \.offset) { _, program in
+            ForEach(visibleProgramIndices, id: \.self) { index in
                 ProgramCellWrapper(
-                    program: program,
+                    program: programs[index],
                     timelineStart: timelineStart,
                     timelineEnd: timelineEnd,
                     width: width,
@@ -63,7 +80,6 @@ struct ProgramChannelColumnView: View, Equatable {
         }
         .frame(width: width, height: totalHeight)
         .clipped()
-        .drawingGroup()
         .onTapGesture(coordinateSpace: .local) { location in
             let tappedY = location.y
             if let program = programs.first(where: { program in

--- a/kiririn/Features/ProgramGuide/ProgramGuideGridComponents.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideGridComponents.swift
@@ -4,10 +4,6 @@ final class HorizontalOffsetTracker {
     var horizontalOffset: CGFloat = 0
 }
 
-final class VerticalOffsetTracker {
-    var verticalOffset: CGFloat = 0
-}
-
 struct ProgramChannelColumnView: View, Equatable {
     let channelId: String
     let programs: [Program]
@@ -31,11 +27,6 @@ struct ProgramChannelColumnView: View, Equatable {
         CGFloat(date.timeIntervalSince(timelineStart) / 60.0) * minuteHeight
     }
 
-    private var timeMarkerOffsets: [CGFloat] {
-        let count = Int((timelineEnd.timeIntervalSince(timelineStart) / 60) / 30)
-        return (0...count).map { CGFloat($0 * 30) * minuteHeight }
-    }
-
     private var visibleProgramIndices: [Int] {
         programs.indices.filter { index in
             let program = programs[index]
@@ -48,25 +39,7 @@ struct ProgramChannelColumnView: View, Equatable {
     }
 
     var body: some View {
-        let markerOffsets = timeMarkerOffsets
-
         ZStack(alignment: .topLeading) {
-            Color.kiririnSystemBackground
-
-            Canvas { context, size in
-                for y in markerOffsets {
-                    context.fill(
-                        Path(CGRect(x: 0, y: y, width: size.width, height: 1)),
-                        with: .color(Color.kiririnSeparator.opacity(0.25))
-                    )
-                }
-                context.fill(
-                    Path(CGRect(x: 0, y: 0, width: 1, height: size.height)),
-                    with: .color(Color.kiririnSeparator.opacity(0.6))
-                )
-            }
-            .allowsHitTesting(false)
-
             ForEach(visibleProgramIndices, id: \.self) { index in
                 ProgramCellWrapper(
                     program: programs[index],
@@ -80,6 +53,12 @@ struct ProgramChannelColumnView: View, Equatable {
         }
         .frame(width: width, height: totalHeight)
         .clipped()
+        .overlay(alignment: .leading) {
+            Rectangle()
+                .fill(Color.kiririnSeparator.opacity(0.6))
+                .frame(width: 1)
+                .allowsHitTesting(false)
+        }
         .onTapGesture(coordinateSpace: .local) { location in
             let tappedY = location.y
             if let program = programs.first(where: { program in

--- a/kiririn/Features/ProgramGuide/ProgramGuideHorizontalScrollController.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideHorizontalScrollController.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 #if os(iOS)
     import UIKit
+#elseif os(macOS)
+    import AppKit
 #endif
 
 @MainActor
@@ -9,12 +11,45 @@ final class ProgramGuideHorizontalScrollController {
     #if os(iOS)
         weak var resolverView: UIView?
         weak var scrollView: UIScrollView?
+    #elseif os(macOS)
+        weak var resolverView: NSView?
+        weak var scrollView: NSScrollView?
+        private var pendingVerticalScroll: (offset: CGFloat, animated: Bool)?
     #endif
 
     func scrollToLeading(animated: Bool) {
         #if os(iOS)
             DispatchQueue.main.async { [weak self] in
                 self?.performScrollToLeading(animated: animated)
+            }
+        #endif
+    }
+
+    func scrollTo(verticalOffset: CGFloat, animated: Bool) {
+        #if os(macOS)
+            guard let scrollView = resolvedScrollView(), let documentView = scrollView.documentView
+            else {
+                pendingVerticalScroll = (verticalOffset, animated)
+                return
+            }
+            pendingVerticalScroll = nil
+            scrollView.layoutSubtreeIfNeeded()
+
+            let clipView = scrollView.contentView
+            let maximumY = max(documentView.bounds.height - clipView.bounds.height, 0)
+            let origin = NSPoint(
+                x: clipView.bounds.origin.x,
+                y: min(max(verticalOffset, 0), maximumY)
+            )
+
+            if animated {
+                NSAnimationContext.runAnimationGroup { context in
+                    context.duration = 0.25
+                    clipView.animator().setBoundsOrigin(origin)
+                }
+            } else {
+                clipView.setBoundsOrigin(origin)
+                scrollView.reflectScrolledClipView(clipView)
             }
         #endif
     }
@@ -53,6 +88,32 @@ final class ProgramGuideHorizontalScrollController {
             }
             return nil
         }
+    #elseif os(macOS)
+        private func resolvedScrollView() -> NSScrollView? {
+            if let scrollView { return scrollView }
+
+            var view = resolverView?.superview
+            while let current = view {
+                if let scrollView = current as? NSScrollView,
+                    let documentView = scrollView.documentView,
+                    documentView.bounds.width > scrollView.contentView.bounds.width + 1
+                {
+                    self.scrollView = scrollView
+                    return scrollView
+                }
+                view = current.superview
+            }
+            return nil
+        }
+
+        func updateScrollView(_ scrollView: NSScrollView?) {
+            self.scrollView = scrollView
+            guard let pendingVerticalScroll else { return }
+            self.pendingVerticalScroll = nil
+            scrollTo(
+                verticalOffset: pendingVerticalScroll.offset,
+                animated: pendingVerticalScroll.animated)
+        }
     #endif
 }
 
@@ -62,6 +123,8 @@ extension View {
         _ controller: ProgramGuideHorizontalScrollController
     ) -> some View {
         #if os(iOS)
+            background(ProgramGuideScrollViewResolver(controller: controller))
+        #elseif os(macOS)
             background(ProgramGuideScrollViewResolver(controller: controller))
         #else
             self
@@ -158,6 +221,69 @@ extension View {
     extension UIScrollView {
         fileprivate var isHorizontallyScrollable: Bool {
             contentSize.width > bounds.width + 1
+        }
+    }
+#endif
+
+#if os(macOS)
+    private struct ProgramGuideScrollViewResolver: NSViewRepresentable {
+        let controller: ProgramGuideHorizontalScrollController
+
+        func makeNSView(context: Context) -> ResolverView {
+            ResolverView(controller: controller)
+        }
+
+        func updateNSView(_ nsView: ResolverView, context: Context) {
+            nsView.controller = controller
+            nsView.resolveScrollView()
+        }
+
+        final class ResolverView: NSView {
+            var controller: ProgramGuideHorizontalScrollController
+
+            init(controller: ProgramGuideHorizontalScrollController) {
+                self.controller = controller
+                super.init(frame: .zero)
+            }
+
+            @available(*, unavailable)
+            required init?(coder: NSCoder) {
+                fatalError("init(coder:) has not been implemented")
+            }
+
+            override func viewDidMoveToSuperview() {
+                super.viewDidMoveToSuperview()
+                resolveScrollView()
+            }
+
+            override func viewDidMoveToWindow() {
+                super.viewDidMoveToWindow()
+                resolveScrollView()
+            }
+
+            override func layout() {
+                super.layout()
+                resolveScrollView()
+            }
+
+            func resolveScrollView() {
+                controller.resolverView = self
+                controller.updateScrollView(enclosingHorizontallyScrollableScrollView())
+            }
+
+            private func enclosingHorizontallyScrollableScrollView() -> NSScrollView? {
+                var view = superview
+                while let current = view {
+                    if let scrollView = current as? NSScrollView,
+                        let documentView = scrollView.documentView,
+                        documentView.bounds.width > scrollView.contentView.bounds.width + 1
+                    {
+                        return scrollView
+                    }
+                    view = current.superview
+                }
+                return nil
+            }
         }
     }
 #endif

--- a/kiririn/Features/ProgramGuide/ProgramGuideView.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideView.swift
@@ -826,44 +826,77 @@ struct ProgramGuideView: View {
             groupedPrograms[key, default: []].append(program)
         }
 
-        // 各物理放送局のメインサービス番組を収集（サブチャンネル重複フィルタ用）
-        var mainProgramsByBroadcaster: [String: [Program]] = [:]
+        struct MainServiceGroupKey: Hashable {
+            let networkId: Int
+            let remoteControlKeyId: Int?
+        }
+
+        struct BroadcasterKey: Hashable {
+            let networkId: Int
+            let broadcasterId: Int
+        }
+
+        struct ProgramOverlapKey: Hashable {
+            let startAt: Date
+            let endAt: Date
+            let name: String
+        }
+
+        var mainServiceIDByGroup: [MainServiceGroupKey: Int] = [:]
         for service in sorted {
-            let broadcasterKey =
-                "\(service.networkId)-\(service.remoteControlKeyId ?? service.serviceId)"
-            let serviceKey = "\(service.networkId)-\(service.serviceId)"
-            let isMain =
-                sorted
-                .filter {
-                    $0.networkId == service.networkId
-                        && $0.remoteControlKeyId == service.remoteControlKeyId
-                }
-                .map(\.serviceId).min() == service.serviceId
-            if isMain {
-                mainProgramsByBroadcaster[broadcasterKey] = groupedPrograms[serviceKey]
+            let groupKey = MainServiceGroupKey(
+                networkId: service.networkId,
+                remoteControlKeyId: service.remoteControlKeyId
+            )
+            if let currentMainServiceID = mainServiceIDByGroup[groupKey] {
+                mainServiceIDByGroup[groupKey] = min(
+                    currentMainServiceID, service.serviceId)
+            } else {
+                mainServiceIDByGroup[groupKey] = service.serviceId
             }
+        }
+
+        // 各物理放送局のメインサービス番組を収集（サブチャンネル重複フィルタ用）
+        var mainProgramKeysByBroadcaster: [BroadcasterKey: Set<ProgramOverlapKey>] = [:]
+        for service in sorted {
+            let groupKey = MainServiceGroupKey(
+                networkId: service.networkId,
+                remoteControlKeyId: service.remoteControlKeyId
+            )
+            guard mainServiceIDByGroup[groupKey] == service.serviceId else {
+                continue
+            }
+
+            let broadcasterKey = BroadcasterKey(
+                networkId: service.networkId,
+                broadcasterId: service.remoteControlKeyId ?? service.serviceId
+            )
+            let serviceKey = "\(service.networkId)-\(service.serviceId)"
+            let keys = groupedPrograms[serviceKey, default: []].map {
+                ProgramOverlapKey(startAt: $0.startAt, endAt: $0.endAt, name: $0.name)
+            }
+            mainProgramKeysByBroadcaster[broadcasterKey] = Set(keys)
         }
 
         return sorted.compactMap { service in
             let key = "\(service.networkId)-\(service.serviceId)"
-            let broadcasterKey =
-                "\(service.networkId)-\(service.remoteControlKeyId ?? service.serviceId)"
-            let isMain =
-                sorted
-                .filter {
-                    $0.networkId == service.networkId
-                        && $0.remoteControlKeyId == service.remoteControlKeyId
-                }
-                .map(\.serviceId).min() == service.serviceId
+            let groupKey = MainServiceGroupKey(
+                networkId: service.networkId,
+                remoteControlKeyId: service.remoteControlKeyId
+            )
+            let broadcasterKey = BroadcasterKey(
+                networkId: service.networkId,
+                broadcasterId: service.remoteControlKeyId ?? service.serviceId
+            )
+            let isMain = mainServiceIDByGroup[groupKey] == service.serviceId
 
             var grouped = groupedPrograms[key, default: []]
                 .sorted { $0.startAt != $1.startAt ? $0.startAt < $1.startAt : $0.name < $1.name }
 
-            if !isMain, let mainPrograms = mainProgramsByBroadcaster[broadcasterKey] {
+            if !isMain, let mainProgramKeys = mainProgramKeysByBroadcaster[broadcasterKey] {
                 grouped = grouped.filter { sub in
-                    !mainPrograms.contains {
-                        $0.startAt == sub.startAt && $0.endAt == sub.endAt && $0.name == sub.name
-                    }
+                    !mainProgramKeys.contains(
+                        ProgramOverlapKey(startAt: sub.startAt, endAt: sub.endAt, name: sub.name))
                 }
             }
 

--- a/kiririn/Features/ProgramGuide/ProgramGuideView.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideView.swift
@@ -733,7 +733,8 @@ struct ProgramGuideView: View {
     private var timeRuler: some View {
         let markers = timeMarkers()
 
-        return LazyVStack(spacing: 0) {
+        // 48行だけなので、拡大縮小後に古い行高を保持するLazy Stackを使わない。
+        return VStack(spacing: 0) {
             ForEach(markers, id: \.self) { mark in
                 let isHour = Calendar.current.component(.minute, from: mark) == 0
 

--- a/kiririn/Features/ProgramGuide/ProgramGuideView.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideView.swift
@@ -27,7 +27,8 @@ struct ProgramGuideView: View {
     @State private var scrollPosition = ScrollPosition()
     @State private var viewportHeight: CGFloat = 600
     @State private var viewportWidth: CGFloat = 0
-    @State private var verticalScrollOffset: CGFloat = 0
+    @State private var verticalOffsetTracker = VerticalOffsetTracker()
+    @State private var visibleRange: ProgramGuideVisibleRange
     @State private var minuteHeight: CGFloat
     @State private var offsetTracker = HorizontalOffsetTracker()
     @State private var horizontalScrollResetToken = 0
@@ -67,10 +68,10 @@ struct ProgramGuideView: View {
     }
 
     private var anchorTime: Date {
-        anchorTime(for: nowLineDate)
+        Self.anchorTime(for: nowLineDate)
     }
 
-    private func anchorTime(for referenceDate: Date) -> Date {
+    private static func anchorTime(for referenceDate: Date) -> Date {
         let calendar = Calendar.current
         var components = calendar.dateComponents([.year, .month, .day, .hour], from: referenceDate)
         if let hour = components.hour, hour < 4 {
@@ -116,6 +117,23 @@ struct ProgramGuideView: View {
         self.manager = manager
         self._playerState = State(initialValue: playerState)
         self._minuteHeight = State(initialValue: defaultMinuteHeight)
+        let initialTimelineStart = Self.anchorTime(for: Date())
+        let initialTimelineEnd =
+            Calendar.current.date(
+                byAdding: .hour,
+                value: timelineHours,
+                to: initialTimelineStart
+            ) ?? initialTimelineStart
+        self._visibleRange = State(
+            initialValue: ProgramGuideVisibleRange.make(
+                timelineStart: initialTimelineStart,
+                timelineEnd: initialTimelineEnd,
+                minuteHeight: defaultMinuteHeight,
+                verticalScrollOffset: 0,
+                viewportHeight: 600,
+                sectionHeaderHeight: sectionHeaderHeight
+            )
+        )
     }
 
     var body: some View {
@@ -133,7 +151,8 @@ struct ProgramGuideView: View {
                 .onAppear {
                     let currentDate = Date()
                     nowLineDate = currentDate
-                    lastAnchorTime = anchorTime(for: currentDate)
+                    lastAnchorTime = Self.anchorTime(for: currentDate)
+                    updateVisibleRange()
                     if manager.hasFavoriteServices {
                         selectedBroadcastType = favoriteBroadcastType
                     }
@@ -167,6 +186,7 @@ struct ProgramGuideView: View {
                     }
                 }
                 .onChange(of: timelineOffsetHours) { _, _ in
+                    updateVisibleRange()
                     Task {
                         await reloadPrograms()
                         updateDisplayChannels()
@@ -194,7 +214,8 @@ struct ProgramGuideView: View {
                 guard minuteHeight != defaultMinuteHeight else { return }
                 let previousTimelineHeight = CGFloat(timelineHours * 60) * minuteHeight
                 let visibleContentY =
-                    verticalScrollOffset + (viewportHeight - sectionHeaderHeight) / 2
+                    verticalOffsetTracker.verticalOffset
+                    + (viewportHeight - sectionHeaderHeight) / 2
                 let anchorY = min(max(visibleContentY / previousTimelineHeight, 0), 1)
                 let factor = defaultMinuteHeight / minuteHeight
                 scaleTimeline(by: factor, around: UnitPoint(x: 0.5, y: anchorY))
@@ -283,6 +304,7 @@ struct ProgramGuideView: View {
                     geo.containerSize.height
                 } action: { _, new in
                     viewportHeight = new
+                    updateVisibleRange()
                 }
                 .onScrollGeometryChange(for: CGFloat.self) { geo in
                     geo.contentOffset.x
@@ -292,7 +314,7 @@ struct ProgramGuideView: View {
                 .onScrollGeometryChange(for: CGFloat.self) { geo in
                     geo.contentOffset.y
                 } action: { _, new in
-                    verticalScrollOffset = new
+                    updateVerticalOffset(new)
                 }
                 .onChange(of: horizontalScrollResetToken) { _, _ in
                     resetHorizontalScrollPosition(proxy: proxy)
@@ -358,6 +380,7 @@ struct ProgramGuideView: View {
                             minuteHeight: minuteHeight,
                             width: channelColumnWidth,
                             totalHeight: timelineHeight,
+                            visibleRange: visibleRange,
                             onProgramTapped: { program in
                                 selectedProgram = ProgramSelection(
                                     program: program, service: channel.service)
@@ -489,9 +512,10 @@ struct ProgramGuideView: View {
     private func refreshCurrentTime(at date: Date = Date()) async {
         nowLineDate = date
 
-        let currentAnchorTime = anchorTime(for: date)
+        let currentAnchorTime = Self.anchorTime(for: date)
         if let lastAnchorTime, currentAnchorTime != lastAnchorTime {
             self.lastAnchorTime = currentAnchorTime
+            updateVisibleRange()
             await reloadPrograms()
             updateDisplayChannels()
         } else if lastAnchorTime == nil {
@@ -509,6 +533,7 @@ struct ProgramGuideView: View {
         let x = min(max(offsetTracker.horizontalOffset, 0), maxX)
 
         func updateScrollPosition(toY y: CGFloat) {
+            updateVerticalOffset(y)
             if maxX > 0 {
                 scrollPosition = ScrollPosition(x: x, y: y)
             } else {
@@ -560,7 +585,8 @@ struct ProgramGuideView: View {
         )
         let anchorViewportY = min(
             max(
-                sectionHeaderHeight + anchoredTimelineY - verticalScrollOffset,
+                sectionHeaderHeight + anchoredTimelineY
+                    - verticalOffsetTracker.verticalOffset,
                 sectionHeaderHeight
             ),
             viewportHeight
@@ -577,7 +603,7 @@ struct ProgramGuideView: View {
         )
 
         minuteHeight = updatedMinuteHeight
-        verticalScrollOffset = updatedVerticalOffset
+        updateVerticalOffset(updatedVerticalOffset)
 
         let maximumHorizontalOffset = max(contentWidth - viewportWidth, 0)
         let horizontalOffset = min(
@@ -589,6 +615,25 @@ struct ProgramGuideView: View {
         } else {
             scrollPosition = ScrollPosition(y: updatedVerticalOffset)
         }
+    }
+
+    private func updateVerticalOffset(_ offset: CGFloat) {
+        verticalOffsetTracker.verticalOffset = offset
+        updateVisibleRange()
+    }
+
+    private func updateVisibleRange() {
+        guard viewportHeight > sectionHeaderHeight else { return }
+        let updatedRange = ProgramGuideVisibleRange.make(
+            timelineStart: timelineStart,
+            timelineEnd: timelineEnd,
+            minuteHeight: minuteHeight,
+            verticalScrollOffset: verticalOffsetTracker.verticalOffset,
+            viewportHeight: viewportHeight,
+            sectionHeaderHeight: sectionHeaderHeight
+        )
+        guard updatedRange != visibleRange else { return }
+        visibleRange = updatedRange
     }
 
     private func updateDisplayChannels() {

--- a/kiririn/Features/ProgramGuide/ProgramGuideView.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideView.swift
@@ -27,8 +27,7 @@ struct ProgramGuideView: View {
     @State private var scrollPosition = ScrollPosition()
     @State private var viewportHeight: CGFloat = 600
     @State private var viewportWidth: CGFloat = 0
-    @State private var verticalOffsetTracker = VerticalOffsetTracker()
-    @State private var visibleRange: ProgramGuideVisibleRange
+    @State private var viewportModel: ProgramGuideViewportModel
     @State private var minuteHeight: CGFloat
     @State private var offsetTracker = HorizontalOffsetTracker()
     @State private var horizontalScrollResetToken = 0
@@ -124,14 +123,16 @@ struct ProgramGuideView: View {
                 value: timelineHours,
                 to: initialTimelineStart
             ) ?? initialTimelineStart
-        self._visibleRange = State(
-            initialValue: ProgramGuideVisibleRange.make(
-                timelineStart: initialTimelineStart,
-                timelineEnd: initialTimelineEnd,
-                minuteHeight: defaultMinuteHeight,
-                verticalScrollOffset: 0,
-                viewportHeight: 600,
-                sectionHeaderHeight: sectionHeaderHeight
+        self._viewportModel = State(
+            initialValue: ProgramGuideViewportModel(
+                visibleRange: ProgramGuideVisibleRange.make(
+                    timelineStart: initialTimelineStart,
+                    timelineEnd: initialTimelineEnd,
+                    minuteHeight: defaultMinuteHeight,
+                    verticalScrollOffset: 0,
+                    viewportHeight: 600,
+                    sectionHeaderHeight: sectionHeaderHeight
+                )
             )
         )
     }
@@ -214,7 +215,7 @@ struct ProgramGuideView: View {
                 guard minuteHeight != defaultMinuteHeight else { return }
                 let previousTimelineHeight = CGFloat(timelineHours * 60) * minuteHeight
                 let visibleContentY =
-                    verticalOffsetTracker.verticalOffset
+                    viewportModel.verticalOffset
                     + (viewportHeight - sectionHeaderHeight) / 2
                 let anchorY = min(max(visibleContentY / previousTimelineHeight, 0), 1)
                 let factor = defaultMinuteHeight / minuteHeight
@@ -344,7 +345,7 @@ struct ProgramGuideView: View {
                 }
                 .zIndex(3000)
 
-            HStack(spacing: 0) {
+            LazyHStack(spacing: 0) {
                 ForEach(displayChannels) { channel in
                     serviceHeaderCell(for: channel.service)
                         .id(channel.id)
@@ -369,37 +370,19 @@ struct ProgramGuideView: View {
                 }
                 .zIndex(1500)
 
-            ZStack(alignment: .topLeading) {
-                LazyHStack(alignment: .top, spacing: 0) {
-                    ForEach(displayChannels) { channel in
-                        ProgramChannelColumnView(
-                            channelId: channel.id,
-                            programs: channel.programs,
-                            timelineStart: timelineStart,
-                            timelineEnd: timelineEnd,
-                            minuteHeight: minuteHeight,
-                            width: channelColumnWidth,
-                            totalHeight: timelineHeight,
-                            visibleRange: visibleRange,
-                            onProgramTapped: { program in
-                                selectedProgram = ProgramSelection(
-                                    program: program, service: channel.service)
-                            }
-                        )
-                        .equatable()
-                        .id(channel.id)
-                    }
-                }
-                if nowLineYOffset >= 0 && nowLineYOffset < timelineHeight {
-                    Rectangle()
-                        .fill(Color.accentColor)
-                        .opacity(timelineOffsetHours == 0 ? 1.0 : 0.5)
-                        .frame(width: max(viewportWidth, contentWidth) - timeRulerWidth, height: 3)
-                        .offset(y: nowLineYOffset - 1.5)
-                        .allowsHitTesting(false)
-                        .zIndex(1800)
-                }
-            }
+            ProgramGuideChannelGridView(
+                channels: displayChannels,
+                timelineStart: timelineStart,
+                timelineEnd: timelineEnd,
+                minuteHeight: minuteHeight,
+                channelColumnWidth: channelColumnWidth,
+                timelineHeight: timelineHeight,
+                nowLineYOffset: nowLineYOffset,
+                nowLineOpacity: timelineOffsetHours == 0 ? 1.0 : 0.5,
+                nowLineWidth: max(viewportWidth, contentWidth) - timeRulerWidth,
+                viewportModel: viewportModel,
+                selectedProgram: $selectedProgram
+            )
         }
     }
 
@@ -586,7 +569,7 @@ struct ProgramGuideView: View {
         let anchorViewportY = min(
             max(
                 sectionHeaderHeight + anchoredTimelineY
-                    - verticalOffsetTracker.verticalOffset,
+                    - viewportModel.verticalOffset,
                 sectionHeaderHeight
             ),
             viewportHeight
@@ -604,6 +587,7 @@ struct ProgramGuideView: View {
 
         minuteHeight = updatedMinuteHeight
         updateVerticalOffset(updatedVerticalOffset)
+        updateVisibleRange()
 
         let maximumHorizontalOffset = max(contentWidth - viewportWidth, 0)
         let horizontalOffset = min(
@@ -618,22 +602,24 @@ struct ProgramGuideView: View {
     }
 
     private func updateVerticalOffset(_ offset: CGFloat) {
-        verticalOffsetTracker.verticalOffset = offset
-        updateVisibleRange()
-    }
-
-    private func updateVisibleRange() {
-        guard viewportHeight > sectionHeaderHeight else { return }
-        let updatedRange = ProgramGuideVisibleRange.make(
+        viewportModel.updateVerticalOffset(
+            offset,
             timelineStart: timelineStart,
             timelineEnd: timelineEnd,
             minuteHeight: minuteHeight,
-            verticalScrollOffset: verticalOffsetTracker.verticalOffset,
             viewportHeight: viewportHeight,
             sectionHeaderHeight: sectionHeaderHeight
         )
-        guard updatedRange != visibleRange else { return }
-        visibleRange = updatedRange
+    }
+
+    private func updateVisibleRange() {
+        viewportModel.updateVisibleRange(
+            timelineStart: timelineStart,
+            timelineEnd: timelineEnd,
+            minuteHeight: minuteHeight,
+            viewportHeight: viewportHeight,
+            sectionHeaderHeight: sectionHeaderHeight
+        )
     }
 
     private func updateDisplayChannels() {
@@ -747,7 +733,7 @@ struct ProgramGuideView: View {
     private var timeRuler: some View {
         let markers = timeMarkers()
 
-        return VStack(spacing: 0) {
+        return LazyVStack(spacing: 0) {
             ForEach(markers, id: \.self) { mark in
                 let isHour = Calendar.current.component(.minute, from: mark) == 0
 

--- a/kiririn/Features/ProgramGuide/ProgramGuideView.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideView.swift
@@ -20,6 +20,8 @@ struct ProgramGuideView: View {
     @State private var searchQueryResults: [ProgramSearchResult] = []
     @State private var isLoading = false
     @State private var hasAttemptedLoad = false
+    @State private var hasScrolledToCurrentTimeOnInitialDisplay = false
+    @State private var isInitialScrollReady = false
     @State private var channels: [GuideChannel] = []
     @State private var timelineOffsetHours = 0
     @State private var nowLineDate = Date()
@@ -41,6 +43,7 @@ struct ProgramGuideView: View {
     private let channelColumnWidth: CGFloat = 220
     private let timeRulerWidth: CGFloat = 45
     private let sectionHeaderHeight: CGFloat = 52
+    private let currentTimeTopPadding: CGFloat = 32
     private let minimumMinuteHeight: CGFloat = 2.5
     private let maximumMinuteHeight: CGFloat = 9
     private let defaultMinuteHeight: CGFloat = 2.5
@@ -317,10 +320,14 @@ struct ProgramGuideView: View {
                 } action: { _, new in
                     updateVerticalOffset(new)
                 }
+                .task {
+                    await scrollToCurrentTimeOnInitialDisplay()
+                }
                 .onChange(of: horizontalScrollResetToken) { _, _ in
                     resetHorizontalScrollPosition(proxy: proxy)
                 }
                 .background(Color.kiririnSystemBackground)
+                .opacity(isInitialScrollReady ? 1 : 0)
             }
         }
     }
@@ -512,36 +519,67 @@ struct ProgramGuideView: View {
 
     private func scrollToNow(animated: Bool) {
         let now = Date()
-        let maxX = max(contentWidth - viewportWidth, 0)
-        let x = min(max(offsetTracker.horizontalOffset, 0), maxX)
+        let hourStart = Calendar.current.dateInterval(of: .hour, for: now)?.start ?? now
 
-        func updateScrollPosition(toY y: CGFloat) {
-            updateVerticalOffset(y)
-            if maxX > 0 {
-                scrollPosition = ScrollPosition(x: x, y: y)
-            } else {
-                scrollPosition = ScrollPosition(y: y)
-            }
-        }
-
-        if now >= timelineStart && now < timelineEnd {
-            let requestedY =
-                sectionHeaderHeight + yOffset(for: now) - viewportHeight * 0.2
+        if hourStart >= timelineStart && hourStart < timelineEnd {
+            let requestedY = yOffset(for: hourStart) - sectionHeaderHeight - 12
             let maximumY = max(
                 0, sectionHeaderHeight + timelineHeight - viewportHeight)
             let targetY = min(max(0, requestedY), maximumY)
-            if animated {
-                withAnimation { updateScrollPosition(toY: targetY) }
-            } else {
-                updateScrollPosition(toY: targetY)
-            }
+            scrollToVerticalOffset(targetY, animated: animated)
         } else {
-            if animated {
-                withAnimation { updateScrollPosition(toY: 0) }
-            } else {
-                updateScrollPosition(toY: 0)
-            }
+            scrollToVerticalOffset(0, animated: animated)
         }
+    }
+
+    private func scrollToVerticalOffset(_ offset: CGFloat, animated: Bool) {
+        #if os(macOS)
+            let nativeOffset = max(offset - sectionHeaderHeight, 0)
+            updateVerticalOffset(nativeOffset)
+            horizontalScrollController.scrollTo(
+                verticalOffset: nativeOffset,
+                animated: animated
+            )
+        #else
+            updateVerticalOffset(offset)
+            let maximumHorizontalOffset = max(contentWidth - viewportWidth, 0)
+            let horizontalOffset = min(
+                max(offsetTracker.horizontalOffset, 0),
+                maximumHorizontalOffset
+            )
+            let updateScrollPosition = {
+                if maximumHorizontalOffset > 0 {
+                    scrollPosition.scrollTo(x: horizontalOffset, y: offset)
+                } else {
+                    scrollPosition.scrollTo(y: offset)
+                }
+            }
+            if animated {
+                withAnimation { updateScrollPosition() }
+            } else {
+                updateScrollPosition()
+            }
+        #endif
+    }
+
+    @MainActor
+    private func scrollToCurrentTimeOnInitialDisplay() async {
+        guard !hasScrolledToCurrentTimeOnInitialDisplay else {
+            isInitialScrollReady = true
+            return
+        }
+
+        do {
+            try await Task.sleep(for: .milliseconds(100))
+        } catch {
+            return
+        }
+
+        guard !Task.isCancelled, !hasScrolledToCurrentTimeOnInitialDisplay else { return }
+        hasScrolledToCurrentTimeOnInitialDisplay = true
+        scrollToNow(animated: false)
+        await Task.yield()
+        isInitialScrollReady = true
     }
 
     private func resetHorizontalScrollPosition(proxy: ScrollViewProxy) {

--- a/kiririn/Features/ProgramGuide/ProgramGuideViewportModel.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideViewportModel.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+@MainActor
+@Observable
+final class ProgramGuideViewportModel {
+    private(set) var visibleRange: ProgramGuideVisibleRange
+    @ObservationIgnored
+    private(set) var verticalOffset: CGFloat = 0
+
+    init(visibleRange: ProgramGuideVisibleRange) {
+        self.visibleRange = visibleRange
+    }
+
+    func updateVerticalOffset(
+        _ offset: CGFloat,
+        timelineStart: Date,
+        timelineEnd: Date,
+        minuteHeight: CGFloat,
+        viewportHeight: CGFloat,
+        sectionHeaderHeight: CGFloat
+    ) {
+        verticalOffset = offset
+        guard
+            visibleRange.needsRefresh(
+                timelineStart: timelineStart,
+                timelineEnd: timelineEnd,
+                minuteHeight: minuteHeight,
+                verticalScrollOffset: verticalOffset,
+                viewportHeight: viewportHeight,
+                sectionHeaderHeight: sectionHeaderHeight
+            )
+        else { return }
+        updateVisibleRange(
+            timelineStart: timelineStart,
+            timelineEnd: timelineEnd,
+            minuteHeight: minuteHeight,
+            viewportHeight: viewportHeight,
+            sectionHeaderHeight: sectionHeaderHeight
+        )
+    }
+
+    func updateVisibleRange(
+        timelineStart: Date,
+        timelineEnd: Date,
+        minuteHeight: CGFloat,
+        viewportHeight: CGFloat,
+        sectionHeaderHeight: CGFloat
+    ) {
+        guard viewportHeight > sectionHeaderHeight else { return }
+        let updatedRange = ProgramGuideVisibleRange.make(
+            timelineStart: timelineStart,
+            timelineEnd: timelineEnd,
+            minuteHeight: minuteHeight,
+            verticalScrollOffset: verticalOffset,
+            viewportHeight: viewportHeight,
+            sectionHeaderHeight: sectionHeaderHeight
+        )
+        guard updatedRange != visibleRange else { return }
+        visibleRange = updatedRange
+    }
+}

--- a/kiririn/Features/ProgramGuide/ProgramGuideVisibleRange.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideVisibleRange.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 
 nonisolated struct ProgramGuideVisibleRange: Equatable, Sendable {

--- a/kiririn/Features/ProgramGuide/ProgramGuideVisibleRange.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideVisibleRange.swift
@@ -50,4 +50,41 @@ nonisolated struct ProgramGuideVisibleRange: Equatable, Sendable {
         let effectiveEnd = programEnd > programStart ? programEnd : timelineEnd
         return programStart < end && effectiveEnd > start
     }
+
+    func needsRefresh(
+        timelineStart: Date,
+        timelineEnd: Date,
+        minuteHeight: CGFloat,
+        verticalScrollOffset: CGFloat,
+        viewportHeight: CGFloat,
+        sectionHeaderHeight: CGFloat
+    ) -> Bool {
+        guard timelineEnd > timelineStart, minuteHeight > 0 else { return true }
+
+        let visibleHeight = max(viewportHeight - sectionHeaderHeight, 0)
+        guard visibleHeight > 0 else { return false }
+
+        let timelineHeight =
+            CGFloat(timelineEnd.timeIntervalSince(timelineStart) / 60) * minuteHeight
+        let visibleTop = min(
+            max(verticalScrollOffset - sectionHeaderHeight, 0),
+            timelineHeight
+        )
+        let visibleBottom = min(visibleTop + visibleHeight, timelineHeight)
+        let rangeTop = min(
+            max(CGFloat(start.timeIntervalSince(timelineStart) / 60) * minuteHeight, 0),
+            timelineHeight
+        )
+        let rangeBottom = min(
+            max(CGFloat(end.timeIntervalSince(timelineStart) / 60) * minuteHeight, 0),
+            timelineHeight
+        )
+        let updateMargin = visibleHeight * 0.2
+        let needsEarlierPrograms =
+            rangeTop > 0 && visibleTop - rangeTop < updateMargin
+        let needsLaterPrograms =
+            rangeBottom < timelineHeight && rangeBottom - visibleBottom < updateMargin
+
+        return needsEarlierPrograms || needsLaterPrograms
+    }
 }

--- a/kiririn/Features/ProgramGuide/ProgramGuideVisibleRange.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideVisibleRange.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+nonisolated struct ProgramGuideVisibleRange: Equatable, Sendable {
+    let start: Date
+    let end: Date
+
+    static func make(
+        timelineStart: Date,
+        timelineEnd: Date,
+        minuteHeight: CGFloat,
+        verticalScrollOffset: CGFloat,
+        viewportHeight: CGFloat,
+        sectionHeaderHeight: CGFloat
+    ) -> Self {
+        guard timelineEnd > timelineStart, minuteHeight > 0 else {
+            return Self(start: timelineStart, end: timelineEnd)
+        }
+
+        let timelineHeight =
+            CGFloat(timelineEnd.timeIntervalSince(timelineStart) / 60) * minuteHeight
+        let visibleHeight = max(viewportHeight - sectionHeaderHeight, 0)
+        let visibleTop = min(
+            max(verticalScrollOffset - sectionHeaderHeight, 0),
+            timelineHeight
+        )
+        let quantum = 30 * minuteHeight
+        let bufferedTop = max(visibleTop - visibleHeight, 0)
+        let bufferedBottom = min(visibleTop + visibleHeight * 2, timelineHeight)
+        let quantizedTop = floor(bufferedTop / quantum) * quantum
+        let quantizedBottom = min(
+            ceil(bufferedBottom / quantum) * quantum,
+            timelineHeight
+        )
+
+        return Self(
+            start: timelineStart.addingTimeInterval(
+                TimeInterval(quantizedTop / minuteHeight) * 60
+            ),
+            end: timelineStart.addingTimeInterval(
+                TimeInterval(quantizedBottom / minuteHeight) * 60
+            )
+        )
+    }
+
+    func intersects(
+        programStart: Date,
+        programEnd: Date,
+        timelineEnd: Date
+    ) -> Bool {
+        let effectiveEnd = programEnd > programStart ? programEnd : timelineEnd
+        return programStart < end && effectiveEnd > start
+    }
+}

--- a/kiririn/Features/Server/PlaybackServerSelectionDialog.swift
+++ b/kiririn/Features/Server/PlaybackServerSelectionDialog.swift
@@ -19,14 +19,16 @@ private struct PlaybackServerSelectionDialogModifier: ViewModifier {
             ),
             titleVisibility: .visible
         ) {
-            let candidates =
-                showsOnlyConnectedCandidates
-                ? manager.connectedPlaybackCandidates(for: service)
-                : manager.playbackCandidates(for: service)
-            ForEach(candidates, id: \.serverId) { candidate in
-                Button(manager.serverFullDisplayName(candidate.serverId)) {
-                    selectedService = nil
-                    onSelect(candidate)
+            if selectedService?.id == service.id {
+                let candidates =
+                    showsOnlyConnectedCandidates
+                    ? manager.connectedPlaybackCandidates(for: service)
+                    : manager.playbackCandidates(for: service)
+                ForEach(candidates, id: \.serverId) { candidate in
+                    Button(manager.serverFullDisplayName(candidate.serverId)) {
+                        selectedService = nil
+                        onSelect(candidate)
+                    }
                 }
             }
             Button("キャンセル", role: .cancel) {
@@ -54,11 +56,13 @@ private struct ReconnectionServerSelectionDialogModifier: ViewModifier {
             ),
             titleVisibility: .visible
         ) {
-            let candidates = manager.reconnectionCandidates(for: service)
-            ForEach(candidates, id: \.serverId) { candidate in
-                Button(manager.serverFullDisplayName(candidate.serverId)) {
-                    selectedService = nil
-                    onSelect(candidate.serverId)
+            if selectedService?.id == service.id {
+                let candidates = manager.reconnectionCandidates(for: service)
+                ForEach(candidates, id: \.serverId) { candidate in
+                    Button(manager.serverFullDisplayName(candidate.serverId)) {
+                        selectedService = nil
+                        onSelect(candidate.serverId)
+                    }
                 }
             }
             Button("キャンセル", role: .cancel) {

--- a/kiririn/Features/Server/ServerManager.swift
+++ b/kiririn/Features/Server/ServerManager.swift
@@ -141,6 +141,7 @@ class ServerManager {
     func setCacheStore(_ cacheStore: CacheStore) async {
         self.cacheStore = cacheStore
         CaptureService.shared.setCacheStore(cacheStore)
+        await cacheStore.cleanupOldPrograms()
         await loadCachedData()
         startPeriodicProgramRefreshTaskIfNeeded()
     }
@@ -402,6 +403,7 @@ class ServerManager {
                         return .skipped
                     }
                     await cacheStore.cachePrograms(fetchedPrograms, serverId: serverId)
+                    await cacheStore.cleanupOldPrograms()
                     clearLastError(for: state)
                     lastProgramFullFetchDatesByServer[serverId] = Date()
                     pendingProgramFullFetchServerIDs.remove(serverId)
@@ -1146,12 +1148,11 @@ class ServerManager {
         return await cacheStore.fetchNextProgram(for: service, currentProgram: currentProgram)
     }
 
-    func fetchAllCurrentPrograms() async -> [Program] {
-        await cacheStore.fetchAllCurrentPrograms()
-    }
-
-    func fetchAllNextPrograms() async -> [Program] {
-        await cacheStore.fetchAllNextPrograms()
+    func fetchProgramDisplaySnapshot(
+        for services: [TVService],
+        at date: Date = Date()
+    ) async -> ProgramDisplaySnapshot {
+        await cacheStore.fetchProgramDisplaySnapshot(for: services, at: date)
     }
 
     func fetchCachedPrograms(from: Date? = nil, until date: Date) async -> [Program] {

--- a/kiririn/Features/Services/ServiceListRefreshState.swift
+++ b/kiririn/Features/Services/ServiceListRefreshState.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+@MainActor
+final class ServiceListRefreshState {
+    var rebuildTask: Task<Void, Never>?
+    var rebuildGeneration = 0
+    var latestSnapshot: ProgramDisplaySnapshot?
+}

--- a/kiririn/Features/Services/ServiceListView.swift
+++ b/kiririn/Features/Services/ServiceListView.swift
@@ -1,11 +1,17 @@
 import OrderedCollections
 import SwiftUI
+import os.signpost
 
 #if canImport(UIKit)
     import UIKit
 #elseif canImport(AppKit)
     import AppKit
 #endif
+
+private let serviceListPerformanceLog = OSLog(
+    subsystem: "jp.pronama.kiririn",
+    category: "PointsOfInterest"
+)
 
 @Observable
 class ServiceListViewModel {
@@ -24,11 +30,9 @@ struct ServiceListView: View {
     @State private var serviceSelectionForReconnection: TVService?
     @State private var showingFavoriteOrderingSheet = false
     @State private var viewModel = ServiceListViewModel()
-    @State private var minuteRefreshTick = Date()
     @State private var groupedServices: [(String, [ServiceListItem])] = []
-    @State private var rebuildTask: Task<Void, Never>?
+    @State private var refreshState = ServiceListRefreshState()
     @State private var isBuildingList = true
-    @State private var rebuildGeneration = 0
 
     private struct ServiceDisplayGroup {
         let id: String
@@ -39,6 +43,11 @@ struct ServiceListView: View {
         var services: [TVService] {
             [primary] + secondary
         }
+    }
+
+    private enum RebuildSource {
+        case fetch(at: Date)
+        case snapshot(ProgramDisplaySnapshot)
     }
 
     private struct ServiceListItem: Identifiable {
@@ -435,21 +444,55 @@ struct ServiceListView: View {
     }
 
     @MainActor
-    private func triggerRebuild() {
-        rebuildTask?.cancel()
-        rebuildGeneration += 1
-        let generation = rebuildGeneration
-        isBuildingList = true
-        rebuildTask = Task {
-            await buildGroupedServices(generation: generation)
-        }
+    @discardableResult
+    private func triggerRebuild() -> Task<Void, Never> {
+        triggerRebuild(source: .fetch(at: Date()))
     }
 
     @MainActor
-    private func buildGroupedServices(generation: Int) async {
+    @discardableResult
+    private func triggerRebuild(source: RebuildSource) -> Task<Void, Never> {
+        refreshState.rebuildTask?.cancel()
+        refreshState.rebuildGeneration += 1
+        let generation = refreshState.rebuildGeneration
+        if groupedServices.isEmpty {
+            isBuildingList = true
+        }
+        let task = Task {
+            await buildGroupedServices(
+                generation: generation,
+                source: source
+            )
+        }
+        refreshState.rebuildTask = task
+        return task
+    }
+
+    @MainActor
+    private func buildGroupedServices(
+        generation: Int,
+        source: RebuildSource
+    ) async {
         if !manager.isCacheReady {
             return
         }
+
+        let signpostID = OSSignpostID(log: serviceListPerformanceLog)
+        os_signpost(
+            .begin,
+            log: serviceListPerformanceLog,
+            name: "Service List Rebuild",
+            signpostID: signpostID
+        )
+        defer {
+            os_signpost(
+                .end,
+                log: serviceListPerformanceLog,
+                name: "Service List Rebuild",
+                signpostID: signpostID
+            )
+        }
+
         let keyword = viewModel.searchText.normalizedForJapaneseSearch()
         let currentServices = sortedServices
         let favoriteServices = currentServices.filter { $0.favoritedAt != nil }
@@ -458,26 +501,17 @@ struct ServiceListView: View {
 
         var newGroups: [(String, [ServiceListItem])] = []
 
-        // 大量のawaitによるスレッドホップを防ぐため、全サービスの現在の番組情報を一括で取得する
-        var programCache: [String: Program] = [:]
-        var nextProgramCache: [String: Program] = [:]
-        async let allCurrentProgramsTask = manager.fetchAllCurrentPrograms()
-        async let allNextProgramsTask = manager.fetchAllNextPrograms()
-        let allCurrentPrograms = await allCurrentProgramsTask
-        let allNextPrograms = await allNextProgramsTask
-        for program in allCurrentPrograms {
-            let key = "\(program.networkId)-\(program.serviceId)"
-            programCache[key] = program
+        let displaySnapshot: ProgramDisplaySnapshot
+        switch source {
+        case .fetch(let date):
+            displaySnapshot = await manager.fetchProgramDisplaySnapshot(
+                for: currentServices,
+                at: date
+            )
+        case .snapshot(let snapshot):
+            displaySnapshot = snapshot
         }
-        for program in allNextPrograms {
-            let key = "\(program.networkId)-\(program.serviceId)"
-            if nextProgramCache[key] == nil {
-                nextProgramCache[key] = program
-            }
-        }
-
-        // ServiceListItemの生成時に引き当てるためのキーをサービス側でも用意する
-        func serviceKey(_ s: TVService) -> String { "\(s.networkId)-\(s.serviceId)" }
+        guard !Task.isCancelled, generation == refreshState.rebuildGeneration else { return }
 
         func buildItems(
             from services: [TVService],
@@ -494,20 +528,21 @@ struct ServiceListView: View {
 
                 var children: [ServiceListItem] = []
                 for secondary in group.secondary {
-                    if Task.isCancelled { return [] }
-                    let program = programCache[serviceKey(secondary)]
+                    guard !Task.isCancelled else { return [] }
+                    let key = serviceKey(for: secondary)
                     children.append(
                         ServiceListItem(
                             id: "\(group.id)-\(secondary.id)",
                             service: secondary,
-                            currentProgram: program,
-                            nextProgram: nextProgramCache[serviceKey(secondary)],
+                            currentProgram: displaySnapshot.currentPrograms[key],
+                            nextProgram: displaySnapshot.nextPrograms[key],
                             hasDifferentChildProgram: false,
                             children: nil
                         ))
                 }
 
-                let primaryProgram = programCache[serviceKey(group.primary)]
+                let primaryKey = serviceKey(for: group.primary)
+                let primaryProgram = displaySnapshot.currentPrograms[primaryKey]
                 let hasDifferentChildProgram: Bool = {
                     guard let primaryProgram, isKnownProgram(primaryProgram) else { return false }
                     for child in children {
@@ -530,7 +565,7 @@ struct ServiceListView: View {
                 let primaryMatches = matchesSearch(
                     service: group.primary,
                     program: primaryProgram,
-                    nextProgram: nextProgramCache[serviceKey(group.primary)],
+                    nextProgram: displaySnapshot.nextPrograms[primaryKey],
                     keyword: keyword
                 )
                 guard keyword.isEmpty || primaryMatches || !filteredChildren.isEmpty else {
@@ -541,7 +576,7 @@ struct ServiceListView: View {
                         id: group.id,
                         service: group.primary,
                         currentProgram: primaryProgram,
-                        nextProgram: nextProgramCache[serviceKey(group.primary)],
+                        nextProgram: displaySnapshot.nextPrograms[primaryKey],
                         hasDifferentChildProgram: hasDifferentChildProgram,
                         children: filteredChildren.isEmpty ? nil : filteredChildren
                     ))
@@ -563,8 +598,9 @@ struct ServiceListView: View {
             newGroups.append((channelType, items))
         }
 
-        guard generation == rebuildGeneration else { return }
+        guard !Task.isCancelled, generation == refreshState.rebuildGeneration else { return }
 
+        refreshState.latestSnapshot = displaySnapshot
         self.groupedServices =
             newGroups
             .filter { !$0.1.isEmpty }
@@ -574,8 +610,10 @@ struct ServiceListView: View {
                 return ai < bi
             }
 
-        isBuildingList = false
-        rebuildTask = nil
+        if isBuildingList {
+            isBuildingList = false
+        }
+        refreshState.rebuildTask = nil
     }
 
     @MainActor
@@ -596,10 +634,77 @@ struct ServiceListView: View {
             try? await Task.sleep(for: .seconds(wait))
             if Task.isCancelled { break }
 
-            await playerState.refreshProgramInfo()
-            minuteRefreshTick = Date()
-            triggerRebuild()
+            await performMinuteRefresh(at: Date())
         }
+    }
+
+    @MainActor
+    private func performMinuteRefresh(at date: Date) async {
+        let refreshID = OSSignpostID(log: serviceListPerformanceLog)
+        os_signpost(
+            .begin,
+            log: serviceListPerformanceLog,
+            name: "Service List Minute Refresh",
+            signpostID: refreshID
+        )
+        defer {
+            os_signpost(
+                .end,
+                log: serviceListPerformanceLog,
+                name: "Service List Minute Refresh",
+                signpostID: refreshID
+            )
+        }
+
+        let expectedPlayableID = playerState.currentPlayable?.id
+        let snapshotServices = servicesForProgramSnapshot()
+        let snapshotServiceKeys = Set(snapshotServices.map { serviceKey(for: $0) })
+        let snapshot = await manager.fetchProgramDisplaySnapshot(
+            for: snapshotServices,
+            at: date
+        )
+        guard !Task.isCancelled,
+            playerState.currentPlayable?.id == expectedPlayableID,
+            Set(servicesForProgramSnapshot().map { serviceKey(for: $0) }) == snapshotServiceKeys
+        else {
+            await triggerRebuild().value
+            return
+        }
+
+        if let expectedPlayableID {
+            await playerState.refreshProgramInfo(
+                using: snapshot,
+                expectedPlayableID: expectedPlayableID
+            )
+        }
+        guard refreshState.latestSnapshot != snapshot else { return }
+        await triggerRebuild(source: .snapshot(snapshot)).value
+    }
+
+    private func serviceKey(for service: TVService) -> ProgramServiceKey {
+        ProgramServiceKey(serviceId: service.serviceId, networkId: service.networkId)
+    }
+
+    private func servicesForProgramSnapshot() -> [TVService] {
+        var services = manager.serviceListServices
+        guard let playable = playerState.currentPlayable,
+            case .liveService(let serviceUniqueId) = playable.source,
+            let playerService = playable.displayService
+                ?? manager.service(serviceUniqueId: serviceUniqueId)
+        else {
+            return services
+        }
+
+        let playerKey = ProgramServiceKey(
+            serviceId: playerService.serviceId,
+            networkId: playerService.networkId
+        )
+        if !services.contains(where: {
+            ProgramServiceKey(serviceId: $0.serviceId, networkId: $0.networkId) == playerKey
+        }) {
+            services.append(playerService)
+        }
+        return services
     }
 }
 

--- a/kiririn/Features/Services/ServiceListView.swift
+++ b/kiririn/Features/Services/ServiceListView.swift
@@ -12,6 +12,7 @@ private let serviceListPerformanceLog = OSLog(
     subsystem: "jp.pronama.kiririn",
     category: "PointsOfInterest"
 )
+private let serviceListRebuildDebounce: Duration = .milliseconds(250)
 
 @Observable
 class ServiceListViewModel {
@@ -125,7 +126,7 @@ struct ServiceListView: View {
             triggerRebuild()
         }
         .onChange(of: manager.serviceListServices) {
-            triggerRebuild()
+            triggerRebuild(after: serviceListRebuildDebounce)
         }
         .sheet(isPresented: $showingFavoriteOrderingSheet) {
             FavoriteServiceOrderingSheet(
@@ -445,20 +446,31 @@ struct ServiceListView: View {
 
     @MainActor
     @discardableResult
-    private func triggerRebuild() -> Task<Void, Never> {
-        triggerRebuild(source: .fetch(at: Date()))
+    private func triggerRebuild(after delay: Duration? = nil) -> Task<Void, Never> {
+        triggerRebuild(source: .fetch(at: Date()), after: delay)
     }
 
     @MainActor
     @discardableResult
-    private func triggerRebuild(source: RebuildSource) -> Task<Void, Never> {
+    private func triggerRebuild(
+        source: RebuildSource,
+        after delay: Duration? = nil
+    ) -> Task<Void, Never> {
         refreshState.rebuildTask?.cancel()
         refreshState.rebuildGeneration += 1
         let generation = refreshState.rebuildGeneration
         if groupedServices.isEmpty {
             isBuildingList = true
         }
-        let task = Task {
+        let task = Task { @MainActor in
+            if let delay {
+                do {
+                    try await Task.sleep(for: delay)
+                } catch {
+                    return
+                }
+            }
+            guard !Task.isCancelled else { return }
             await buildGroupedServices(
                 generation: generation,
                 source: source

--- a/kiririn/Shared/Infrastructure/CacheStore.swift
+++ b/kiririn/Shared/Infrastructure/CacheStore.swift
@@ -4,6 +4,12 @@ import GRDB
 import ImageIO
 import Logging
 import Observation
+import os.signpost
+
+private let cacheStorePerformanceLog = OSLog(
+    subsystem: "jp.pronama.kiririn",
+    category: "PointsOfInterest"
+)
 
 struct CacheDatabaseFailureFeedback: Identifiable, Equatable {
     let id = UUID()
@@ -413,16 +419,18 @@ class CacheStore {
         }
     }
 
-    func cleanupOldPrograms() async {
-        guard let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())
-        else {
-            return
-        }
+    func cleanupOldPrograms(referenceDate: Date = Date()) async {
+        let cutoffDate = referenceDate.addingTimeInterval(-24 * 60 * 60)
         do {
-            _ = try await dbQueue.write { db in
-                try Program
-                    .filter(Program.Columns.endAt < yesterday)
-                    .deleteAll(db)
+            try await dbQueue.write { db in
+                try db.execute(
+                    sql: """
+                        DELETE FROM program
+                        WHERE (duration = 0 AND startAt <= :cutoffDate)
+                           OR (duration != 0 AND endAt <= :cutoffDate)
+                        """,
+                    arguments: ["cutoffDate": cutoffDate]
+                )
             }
         } catch {
             self.logger.error("Failed to cleanup old programs: \(error)")
@@ -538,57 +546,145 @@ class CacheStore {
         }
     }
 
-    func fetchAllCurrentPrograms() async -> [Program] {
-        let now = Date()
-        do {
-            return try await dbQueue.read { db in
-                let sql = """
-                    SELECT * FROM (
-                        SELECT *, ROW_NUMBER() OVER (PARTITION BY serviceId, networkId, startAt ORDER BY updatedAt DESC) as rn
-                        FROM program
-                        WHERE startAt < :now
-                          AND (endAt > :now OR duration = 0)
-                    ) WHERE rn = 1
-                    """
-                return try Program.fetchAll(
-                    db, sql: sql, arguments: StatementArguments(["now": now]))
-            }
-        } catch {
-            reportDatabaseFailureIfNeeded(operation: "fetch all current programs", error: error)
-            return []
-        }
-    }
+    func fetchProgramDisplaySnapshot(
+        for services: [TVService],
+        at date: Date = Date()
+    ) async -> ProgramDisplaySnapshot {
+        let serviceKeys = Set(
+            services.map { ProgramServiceKey(serviceId: $0.serviceId, networkId: $0.networkId) })
+        guard !serviceKeys.isEmpty else { return .empty }
 
-    func fetchAllNextPrograms() async -> [Program] {
-        let now = Date()
+        let signpostID = OSSignpostID(log: cacheStorePerformanceLog)
+        os_signpost(
+            .begin,
+            log: cacheStorePerformanceLog,
+            name: "Program Display Snapshot Query",
+            signpostID: signpostID
+        )
+        defer {
+            os_signpost(
+                .end,
+                log: cacheStorePerformanceLog,
+                name: "Program Display Snapshot Query",
+                signpostID: signpostID
+            )
+        }
+
+        let sortedServiceKeys = serviceKeys.sorted {
+            if $0.networkId != $1.networkId { return $0.networkId < $1.networkId }
+            return $0.serviceId < $1.serviceId
+        }
+        var arguments: [String: (any DatabaseValueConvertible)?] = ["now": date]
+        let requestedValues = sortedServiceKeys.enumerated().map { index, key -> String in
+            arguments["serviceId\(index)"] = key.serviceId
+            arguments["networkId\(index)"] = key.networkId
+            return "(:serviceId\(index), :networkId\(index))"
+        }.joined(separator: ", ")
+        let statementArguments = StatementArguments(arguments)
+
         do {
-            return try await dbQueue.read { db in
-                let sql = """
-                    SELECT p.*
-                    FROM (
-                        SELECT *, ROW_NUMBER() OVER (PARTITION BY serviceId, networkId, startAt ORDER BY updatedAt DESC) as rn
-                        FROM program
-                    ) p
-                    INNER JOIN (
-                        SELECT networkId, serviceId, MIN(startAt) AS nextStartAt
-                        FROM (
-                            SELECT *, ROW_NUMBER() OVER (PARTITION BY serviceId, networkId, startAt ORDER BY updatedAt DESC) as rn
-                            FROM program
+            let programs = try await dbQueue.read { db in
+                let sql: String = """
+                    WITH requested(serviceId, networkId) AS MATERIALIZED (
+                        VALUES \(requestedValues)
+                    ),
+                    current_start AS MATERIALIZED (
+                        SELECT s.serviceId, s.networkId,
+                               (
+                                   SELECT MIN(candidateStart)
+                                   FROM (
+                                       SELECT MIN(p.startAt) AS candidateStart
+                                       FROM program p INDEXED BY index_program_on_serviceId_networkId_endAt_startAt
+                                       WHERE p.serviceId = s.serviceId
+                                         AND p.networkId = s.networkId
+                                         AND p.startAt < :now
+                                         AND p.endAt > :now
+                                       UNION ALL
+                                       SELECT MIN(p.startAt) AS candidateStart
+                                       FROM program p INDEXED BY index_program_on_serviceId_networkId_zeroDuration_startAt
+                                       WHERE p.serviceId = s.serviceId
+                                         AND p.networkId = s.networkId
+                                         AND p.startAt < :now
+                                         AND p.duration = 0
+                                   )
+                               ) AS startAt
+                        FROM requested s
+                    ),
+                    current_program AS (
+                        SELECT p.*
+                        FROM program p
+                        INNER JOIN current_start s
+                            ON p.serviceId = s.serviceId
+                           AND p.networkId = s.networkId
+                           AND p.startAt = s.startAt
+                        WHERE p.rowid = (
+                            SELECT latest.rowid
+                            FROM program latest
+                            WHERE latest.serviceId = s.serviceId
+                              AND latest.networkId = s.networkId
+                              AND latest.startAt = s.startAt
+                              AND latest.startAt < :now
+                              AND (latest.endAt > :now OR latest.duration = 0)
+                            ORDER BY latest.updatedAt DESC
+                            LIMIT 1
                         )
-                        WHERE rn = 1 AND startAt >= :now
-                        GROUP BY networkId, serviceId
-                    ) n
-                    ON p.networkId = n.networkId
-                    AND p.serviceId = n.serviceId
-                    AND p.startAt = n.nextStartAt
-                    WHERE p.rn = 1
+                    ),
+                    next_start AS MATERIALIZED (
+                        SELECT s.serviceId, s.networkId,
+                               (
+                                   SELECT p.startAt
+                                   FROM program p
+                                   WHERE p.serviceId = s.serviceId
+                                     AND p.networkId = s.networkId
+                                     AND p.startAt >= :now
+                                   ORDER BY p.startAt ASC
+                                   LIMIT 1
+                               ) AS startAt
+                        FROM requested s
+                    ),
+                    next_program AS (
+                        SELECT p.*
+                        FROM program p
+                        INNER JOIN next_start s
+                            ON p.serviceId = s.serviceId
+                           AND p.networkId = s.networkId
+                           AND p.startAt = s.startAt
+                        WHERE p.rowid = (
+                            SELECT latest.rowid
+                            FROM program latest
+                            WHERE latest.serviceId = s.serviceId
+                              AND latest.networkId = s.networkId
+                              AND latest.startAt = s.startAt
+                            ORDER BY latest.updatedAt DESC
+                            LIMIT 1
+                        )
+                    )
+                    SELECT * FROM current_program
+                    UNION ALL
+                    SELECT * FROM next_program
                     """
                 return try Program.fetchAll(
-                    db, sql: sql, arguments: StatementArguments(["now": now]))
+                    db, sql: sql, arguments: statementArguments)
             }
+
+            var currentPrograms: [ProgramServiceKey: Program] = [:]
+            var nextPrograms: [ProgramServiceKey: Program] = [:]
+            for program in programs {
+                let key = ProgramServiceKey(
+                    serviceId: program.serviceId, networkId: program.networkId)
+                if program.startAt < date {
+                    currentPrograms[key] = program
+                } else {
+                    nextPrograms[key] = program
+                }
+            }
+            return ProgramDisplaySnapshot(
+                currentPrograms: currentPrograms,
+                nextPrograms: nextPrograms
+            )
         } catch {
-            reportDatabaseFailureIfNeeded(operation: "fetch all next programs", error: error)
-            return []
+            reportDatabaseFailureIfNeeded(operation: "fetch program display snapshot", error: error)
+            return .empty
         }
     }
 
@@ -970,6 +1066,39 @@ extension CacheStore {
             try db.create(
                 index: "index_program_on_serviceId_networkId_startAt", on: "program",
                 columns: ["serviceId", "networkId", "startAt"])
+        }
+
+        migrator.registerMigration(
+            "program-display-snapshot-current-index-20260801",
+            merging: ["program-display-snapshot-index-20260801"]
+        ) { db, appliedIdentifiers in
+            if !appliedIdentifiers.contains("program-display-snapshot-index-20260801") {
+                try db.create(
+                    index: "index_program_on_serviceId_networkId_startAt_updatedAt",
+                    on: "program",
+                    columns: ["serviceId", "networkId", "startAt", "updatedAt"]
+                )
+            }
+
+            let cutoffDate = Date().addingTimeInterval(-24 * 60 * 60)
+            try db.execute(
+                sql: """
+                    DELETE FROM program
+                    WHERE (duration = 0 AND startAt <= :cutoffDate)
+                       OR (duration != 0 AND endAt <= :cutoffDate)
+                    """,
+                arguments: ["cutoffDate": cutoffDate]
+            )
+            try db.create(
+                index: "index_program_on_serviceId_networkId_endAt_startAt", on: "program",
+                columns: ["serviceId", "networkId", "endAt", "startAt"])
+            try db.execute(
+                sql: """
+                    CREATE INDEX index_program_on_serviceId_networkId_zeroDuration_startAt
+                    ON program(serviceId, networkId, startAt)
+                    WHERE duration = 0
+                    """)
+            try db.drop(index: "index_program_on_serviceId_networkId_startAt")
         }
 
         return migrator

--- a/kiririn/Shared/Infrastructure/CacheStore.swift
+++ b/kiririn/Shared/Infrastructure/CacheStore.swift
@@ -588,80 +588,52 @@ class CacheStore {
                     WITH requested(serviceId, networkId) AS MATERIALIZED (
                         VALUES \(requestedValues)
                     ),
-                    current_start AS MATERIALIZED (
-                        SELECT s.serviceId, s.networkId,
-                               (
-                                   SELECT MIN(candidateStart)
-                                   FROM (
-                                       SELECT MIN(p.startAt) AS candidateStart
-                                       FROM program p INDEXED BY index_program_on_serviceId_networkId_endAt_startAt
-                                       WHERE p.serviceId = s.serviceId
-                                         AND p.networkId = s.networkId
-                                         AND p.startAt < :now
-                                         AND p.endAt > :now
-                                       UNION ALL
-                                       SELECT MIN(p.startAt) AS candidateStart
-                                       FROM program p INDEXED BY index_program_on_serviceId_networkId_zeroDuration_startAt
-                                       WHERE p.serviceId = s.serviceId
-                                         AND p.networkId = s.networkId
-                                         AND p.startAt < :now
-                                         AND p.duration = 0
-                                   )
-                               ) AS startAt
-                        FROM requested s
-                    ),
-                    current_program AS (
-                        SELECT p.*
-                        FROM program p
-                        INNER JOIN current_start s
-                            ON p.serviceId = s.serviceId
-                           AND p.networkId = s.networkId
-                           AND p.startAt = s.startAt
-                        WHERE p.rowid = (
+                    selected(rowid) AS MATERIALIZED (
+                        SELECT (
                             SELECT latest.rowid
                             FROM program latest
                             WHERE latest.serviceId = s.serviceId
                               AND latest.networkId = s.networkId
-                              AND latest.startAt = s.startAt
+                              AND latest.startAt = (
+                                  SELECT MIN(candidateStart)
+                                  FROM (
+                                      SELECT MIN(p.startAt) AS candidateStart
+                                      FROM program p INDEXED BY index_program_on_serviceId_networkId_endAt_startAt
+                                      WHERE p.serviceId = s.serviceId
+                                        AND p.networkId = s.networkId
+                                        AND p.startAt < :now
+                                        AND p.endAt > :now
+                                      UNION ALL
+                                      SELECT MIN(p.startAt) AS candidateStart
+                                      FROM program p INDEXED BY index_program_on_serviceId_networkId_zeroDuration_startAt
+                                      WHERE p.serviceId = s.serviceId
+                                        AND p.networkId = s.networkId
+                                        AND p.startAt < :now
+                                        AND p.duration = 0
+                                  )
+                              )
                               AND latest.startAt < :now
                               AND (latest.endAt > :now OR latest.duration = 0)
-                            ORDER BY latest.updatedAt DESC
+                            ORDER BY latest.updatedAt DESC, latest.rowid DESC
                             LIMIT 1
                         )
-                    ),
-                    next_start AS MATERIALIZED (
-                        SELECT s.serviceId, s.networkId,
-                               (
-                                   SELECT p.startAt
-                                   FROM program p
-                                   WHERE p.serviceId = s.serviceId
-                                     AND p.networkId = s.networkId
-                                     AND p.startAt >= :now
-                                   ORDER BY p.startAt ASC
-                                   LIMIT 1
-                               ) AS startAt
                         FROM requested s
-                    ),
-                    next_program AS (
-                        SELECT p.*
-                        FROM program p
-                        INNER JOIN next_start s
-                            ON p.serviceId = s.serviceId
-                           AND p.networkId = s.networkId
-                           AND p.startAt = s.startAt
-                        WHERE p.rowid = (
-                            SELECT latest.rowid
-                            FROM program latest
-                            WHERE latest.serviceId = s.serviceId
-                              AND latest.networkId = s.networkId
-                              AND latest.startAt = s.startAt
-                            ORDER BY latest.updatedAt DESC
+                        UNION ALL
+                        SELECT (
+                            SELECT p.rowid
+                            FROM program p
+                            WHERE p.serviceId = s.serviceId
+                              AND p.networkId = s.networkId
+                              AND p.startAt >= :now
+                            ORDER BY p.startAt ASC, p.updatedAt DESC, p.rowid DESC
                             LIMIT 1
                         )
+                        FROM requested s
                     )
-                    SELECT * FROM current_program
-                    UNION ALL
-                    SELECT * FROM next_program
+                    SELECT p.*
+                    FROM selected s
+                    INNER JOIN program p ON p.rowid = s.rowid
+                    WHERE s.rowid IS NOT NULL
                     """
                 return try Program.fetchAll(
                     db, sql: sql, arguments: statementArguments)

--- a/kiririn/Shared/Infrastructure/CacheStore.swift
+++ b/kiririn/Shared/Infrastructure/CacheStore.swift
@@ -1069,16 +1069,13 @@ extension CacheStore {
         }
 
         migrator.registerMigration(
-            "program-display-snapshot-current-index-20260801",
-            merging: ["program-display-snapshot-index-20260801"]
-        ) { db, appliedIdentifiers in
-            if !appliedIdentifiers.contains("program-display-snapshot-index-20260801") {
-                try db.create(
-                    index: "index_program_on_serviceId_networkId_startAt_updatedAt",
-                    on: "program",
-                    columns: ["serviceId", "networkId", "startAt", "updatedAt"]
-                )
-            }
+            "program-display-snapshot-current-index-20260801"
+        ) { db in
+            try db.create(
+                index: "index_program_on_serviceId_networkId_startAt_updatedAt",
+                on: "program",
+                columns: ["serviceId", "networkId", "startAt", "updatedAt"]
+            )
 
             let cutoffDate = Date().addingTimeInterval(-24 * 60 * 60)
             try db.execute(

--- a/kiririn/Shared/Models/Program.swift
+++ b/kiririn/Shared/Models/Program.swift
@@ -4,6 +4,18 @@ import GRDB
 import OrderedCollections
 import SwiftUI
 
+nonisolated struct ProgramServiceKey: Hashable, Sendable {
+    let serviceId: Int
+    let networkId: Int
+}
+
+nonisolated struct ProgramDisplaySnapshot: Equatable, Sendable {
+    let currentPrograms: [ProgramServiceKey: Program]
+    let nextPrograms: [ProgramServiceKey: Program]
+
+    static let empty = ProgramDisplaySnapshot(currentPrograms: [:], nextPrograms: [:])
+}
+
 nonisolated struct Program: Codable, Identifiable, Sendable, Equatable, Hashable, FetchableRecord,
     PersistableRecord
 {

--- a/kiririn/Shared/UI/Font+ARIBFallback.swift
+++ b/kiririn/Shared/UI/Font+ARIBFallback.swift
@@ -13,6 +13,14 @@ import SwiftUI
 #endif
 
 extension Font {
+    private struct ARIBFontCacheKey: Hashable {
+        let size: CGFloat
+        let weight: CGFloat
+    }
+
+    @MainActor private static var aribFontCache: [ARIBFontCacheKey: Font] = [:]
+    private static let aribFontCacheLimit = 64
+
     private static let aribFallbackDescriptor: CTFontDescriptor? = {
         guard
             let url = Bundle.main.url(
@@ -32,14 +40,32 @@ extension Font {
         _ style: Font.TextStyle,
         weight: Font.Weight = .regular
     ) -> Font {
-        cascadingARIBFont(from: systemFont(style: style, weight: weight))
+        let preferredFont = PlatformFont.preferredFont(forTextStyle: platformTextStyle(for: style))
+        return cachedARIBFont(size: preferredFont.pointSize, weight: weight)
     }
 
     static func systemWithARIBFallback(
         size: CGFloat,
         weight: Font.Weight = .regular
     ) -> Font {
-        cascadingARIBFont(from: systemFont(size: size, weight: weight))
+        cachedARIBFont(size: size, weight: weight)
+    }
+
+    private static func cachedARIBFont(size: CGFloat, weight: Font.Weight) -> Font {
+        let platformWeight = platformFontWeight(for: weight)
+        let key = ARIBFontCacheKey(size: size, weight: platformWeight.rawValue)
+        if let cachedFont = aribFontCache[key] {
+            return cachedFont
+        }
+
+        let font = cascadingARIBFont(
+            from: PlatformFont.systemFont(ofSize: size, weight: platformWeight)
+        )
+        if aribFontCache.count >= aribFontCacheLimit {
+            aribFontCache.removeAll(keepingCapacity: true)
+        }
+        aribFontCache[key] = font
+        return font
     }
 
     private static func cascadingARIBFont(from baseFont: CTFont) -> Font {
@@ -58,18 +84,6 @@ extension Font {
                 as CFDictionary
         )
         return Font(CTFontCreateWithFontDescriptor(descriptor, size, nil))
-    }
-
-    private static func systemFont(style: Font.TextStyle, weight: Font.Weight) -> CTFont {
-        let preferredFont = PlatformFont.preferredFont(forTextStyle: platformTextStyle(for: style))
-        return PlatformFont.systemFont(
-            ofSize: preferredFont.pointSize,
-            weight: platformFontWeight(for: weight)
-        )
-    }
-
-    private static func systemFont(size: CGFloat, weight: Font.Weight) -> CTFont {
-        PlatformFont.systemFont(ofSize: size, weight: platformFontWeight(for: weight))
     }
 
     private static func platformTextStyle(for style: Font.TextStyle) -> PlatformFont.TextStyle {

--- a/kiririn/Shared/UI/Font+ARIBFallback.swift
+++ b/kiririn/Shared/UI/Font+ARIBFallback.swift
@@ -36,7 +36,7 @@ extension Font {
         return descriptors.first
     }()
 
-    static func systemWithARIBFallback(
+    @MainActor static func systemWithARIBFallback(
         _ style: Font.TextStyle,
         weight: Font.Weight = .regular
     ) -> Font {
@@ -44,14 +44,17 @@ extension Font {
         return cachedARIBFont(size: preferredFont.pointSize, weight: weight)
     }
 
-    static func systemWithARIBFallback(
+    @MainActor static func systemWithARIBFallback(
         size: CGFloat,
         weight: Font.Weight = .regular
     ) -> Font {
         cachedARIBFont(size: size, weight: weight)
     }
 
-    private static func cachedARIBFont(size: CGFloat, weight: Font.Weight) -> Font {
+    @MainActor private static func cachedARIBFont(
+        size: CGFloat,
+        weight: Font.Weight
+    ) -> Font {
         let platformWeight = platformFontWeight(for: weight)
         let key = ARIBFontCacheKey(size: size, weight: platformWeight.rawValue)
         if let cachedFont = aribFontCache[key] {

--- a/kiririnTests/StoreBehaviorTests.swift
+++ b/kiririnTests/StoreBehaviorTests.swift
@@ -15,55 +15,6 @@ private func makeIsolatedDefaults() -> (UserDefaults, String) {
 
 struct StoreBehaviorTests {
 
-    @Test func cacheStoreCreatesConsolidatedProgramIndexes() throws {
-        let queue = try DatabaseQueue()
-        _ = CacheStore(databaseQueue: queue)
-
-        let indexNames = try queue.read { db in
-            try String.fetchSet(
-                db,
-                sql: "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'program'"
-            )
-        }
-
-        #expect(indexNames.contains("index_program_on_serviceId_networkId_startAt_updatedAt"))
-        #expect(indexNames.contains("index_program_on_serviceId_networkId_endAt_startAt"))
-        #expect(indexNames.contains("index_program_on_serviceId_networkId_zeroDuration_startAt"))
-        #expect(!indexNames.contains("index_program_on_serviceId_networkId_startAt"))
-    }
-
-    @Test func cacheStoreMergesPreviouslyAppliedProgramGuideMigrations() throws {
-        let queue = try DatabaseQueue()
-        _ = CacheStore(databaseQueue: queue)
-
-        try queue.write { db in
-            try db.execute(
-                sql: "DELETE FROM grdb_migrations WHERE identifier IN (?, ?)",
-                arguments: [
-                    "program-display-snapshot-index-20260801",
-                    "program-display-snapshot-current-index-20260801",
-                ]
-            )
-            try db.execute(
-                sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
-                arguments: ["program-display-snapshot-index-20260801"]
-            )
-            try db.execute(
-                sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
-                arguments: ["program-display-snapshot-current-index-20260801"]
-            )
-        }
-
-        _ = CacheStore(databaseQueue: queue)
-
-        let appliedIdentifiers = try queue.read { db in
-            try String.fetchSet(db, sql: "SELECT identifier FROM grdb_migrations")
-        }
-
-        #expect(!appliedIdentifiers.contains("program-display-snapshot-index-20260801"))
-        #expect(appliedIdentifiers.contains("program-display-snapshot-current-index-20260801"))
-    }
-
     @Test func dataBroadcastSettingsPersistsValidPostalCode() {
         let (defaults, suiteName) = makeIsolatedDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }

--- a/kiririnTests/StoreBehaviorTests.swift
+++ b/kiririnTests/StoreBehaviorTests.swift
@@ -15,6 +15,55 @@ private func makeIsolatedDefaults() -> (UserDefaults, String) {
 
 struct StoreBehaviorTests {
 
+    @Test func cacheStoreCreatesConsolidatedProgramIndexes() throws {
+        let queue = try DatabaseQueue()
+        _ = CacheStore(databaseQueue: queue)
+
+        let indexNames = try queue.read { db in
+            try String.fetchSet(
+                db,
+                sql: "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'program'"
+            )
+        }
+
+        #expect(indexNames.contains("index_program_on_serviceId_networkId_startAt_updatedAt"))
+        #expect(indexNames.contains("index_program_on_serviceId_networkId_endAt_startAt"))
+        #expect(indexNames.contains("index_program_on_serviceId_networkId_zeroDuration_startAt"))
+        #expect(!indexNames.contains("index_program_on_serviceId_networkId_startAt"))
+    }
+
+    @Test func cacheStoreMergesPreviouslyAppliedProgramGuideMigrations() throws {
+        let queue = try DatabaseQueue()
+        _ = CacheStore(databaseQueue: queue)
+
+        try queue.write { db in
+            try db.execute(
+                sql: "DELETE FROM grdb_migrations WHERE identifier IN (?, ?)",
+                arguments: [
+                    "program-display-snapshot-index-20260801",
+                    "program-display-snapshot-current-index-20260801",
+                ]
+            )
+            try db.execute(
+                sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
+                arguments: ["program-display-snapshot-index-20260801"]
+            )
+            try db.execute(
+                sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
+                arguments: ["program-display-snapshot-current-index-20260801"]
+            )
+        }
+
+        _ = CacheStore(databaseQueue: queue)
+
+        let appliedIdentifiers = try queue.read { db in
+            try String.fetchSet(db, sql: "SELECT identifier FROM grdb_migrations")
+        }
+
+        #expect(!appliedIdentifiers.contains("program-display-snapshot-index-20260801"))
+        #expect(appliedIdentifiers.contains("program-display-snapshot-current-index-20260801"))
+    }
+
     @Test func dataBroadcastSettingsPersistsValidPostalCode() {
         let (defaults, suiteName) = makeIsolatedDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
@@ -294,6 +343,191 @@ struct StoreBehaviorTests {
         #expect(favoriteByKey["1-101"]?.displayOrder == 1)
         #expect(favoriteByKey["1-102"]?.displayOrder == 0)
     }
+
+    @MainActor
+    @Test
+    func cacheStoreBuildsProgramDisplaySnapshotForRequestedServices() async throws {
+        let dbQueue = try DatabaseQueue()
+        let store = CacheStore(databaseQueue: dbQueue)
+        let currentDate = Date(timeIntervalSince1970: 1_000)
+        let service = makeService(networkId: 1, transportStreamId: nil, serviceId: 101)
+        let zeroDurationService = makeService(
+            networkId: 1, transportStreamId: nil, serviceId: 102)
+        let otherService = makeService(networkId: 1, transportStreamId: nil, serviceId: 103)
+
+        let current = Program(
+            id: "current",
+            serverId: "server-1",
+            eventId: 1,
+            serviceId: 101,
+            networkId: 1,
+            startAt: Date(timeIntervalSince1970: 900),
+            endAt: Date(timeIntervalSince1970: 1_100),
+            duration: 200,
+            name: "現在番組",
+            desc: nil,
+            extended: nil,
+            genres: [],
+            updatedAt: nil
+        )
+        let earlierCurrent = Program(
+            id: "earlier-current",
+            serverId: "server-1",
+            eventId: 5,
+            serviceId: 101,
+            networkId: 1,
+            startAt: Date(timeIntervalSince1970: 800),
+            endAt: Date(timeIntervalSince1970: 1_050),
+            duration: 250,
+            name: "先に始まった現在番組",
+            desc: nil,
+            extended: nil,
+            genres: [],
+            updatedAt: Date(timeIntervalSince1970: 1_001)
+        )
+        let next = Program(
+            id: "next",
+            serverId: "server-1",
+            eventId: 2,
+            serviceId: 101,
+            networkId: 1,
+            startAt: Date(timeIntervalSince1970: 1_100),
+            endAt: Date(timeIntervalSince1970: 1_200),
+            duration: 100,
+            name: "次番組",
+            desc: nil,
+            extended: nil,
+            genres: [],
+            updatedAt: nil
+        )
+        let later = Program(
+            id: "later",
+            serverId: "server-1",
+            eventId: 3,
+            serviceId: 101,
+            networkId: 1,
+            startAt: Date(timeIntervalSince1970: 1_200),
+            endAt: Date(timeIntervalSince1970: 1_300),
+            duration: 100,
+            name: "さらに次の番組",
+            desc: nil,
+            extended: nil,
+            genres: [],
+            updatedAt: nil
+        )
+        let unrelated = Program(
+            id: "unrelated",
+            serverId: "server-1",
+            eventId: 4,
+            serviceId: 202,
+            networkId: 2,
+            startAt: Date(timeIntervalSince1970: 900),
+            endAt: Date(timeIntervalSince1970: 1_100),
+            duration: 200,
+            name: "対象外",
+            desc: nil,
+            extended: nil,
+            genres: [],
+            updatedAt: nil
+        )
+        let zeroDuration = Program(
+            id: "zero-duration",
+            serverId: "server-1",
+            eventId: 6,
+            serviceId: 102,
+            networkId: 1,
+            startAt: Date(timeIntervalSince1970: 950),
+            endAt: Date(timeIntervalSince1970: 950),
+            duration: 0,
+            name: "終了時刻不明",
+            desc: nil,
+            extended: nil,
+            genres: [],
+            updatedAt: nil
+        )
+
+        await store.cachePrograms(
+            [current, earlierCurrent, next, later, unrelated, zeroDuration], serverId: "server-1")
+
+        let snapshot = await store.fetchProgramDisplaySnapshot(
+            for: [service, zeroDurationService, otherService], at: currentDate)
+        let key = ProgramServiceKey(serviceId: 101, networkId: 1)
+        let zeroDurationKey = ProgramServiceKey(serviceId: 102, networkId: 1)
+
+        #expect(snapshot.currentPrograms[key]?.id == "earlier-current")
+        #expect(snapshot.currentPrograms[zeroDurationKey]?.id == "zero-duration")
+        #expect(snapshot.nextPrograms[key]?.id == "next")
+        #expect(snapshot.currentPrograms.count == 2)
+        #expect(snapshot.nextPrograms.count == 1)
+    }
+
+    @MainActor @Test func cacheStoreCleansUpProgramsOlderThanOneDay() async throws {
+        let dbQueue = try DatabaseQueue()
+        let store = CacheStore(databaseQueue: dbQueue)
+        let referenceDate = Date(timeIntervalSince1970: 100_000)
+        let cutoffDate = referenceDate.addingTimeInterval(-24 * 60 * 60)
+
+        func makeProgram(
+            id: String,
+            startAt: Date,
+            endAt: Date,
+            duration: TimeInterval
+        ) -> Program {
+            Program(
+                id: id,
+                serverId: "server-1",
+                eventId: nil,
+                serviceId: 101,
+                networkId: 1,
+                startAt: startAt,
+                endAt: endAt,
+                duration: duration,
+                name: id,
+                desc: nil,
+                extended: nil,
+                genres: [],
+                updatedAt: nil
+            )
+        }
+
+        await store.cachePrograms(
+            [
+                makeProgram(
+                    id: "expired-normal",
+                    startAt: cutoffDate.addingTimeInterval(-60),
+                    endAt: cutoffDate,
+                    duration: 60
+                ),
+                makeProgram(
+                    id: "recent-normal",
+                    startAt: cutoffDate,
+                    endAt: cutoffDate.addingTimeInterval(60),
+                    duration: 60
+                ),
+                makeProgram(
+                    id: "expired-zero-duration",
+                    startAt: cutoffDate,
+                    endAt: cutoffDate,
+                    duration: 0
+                ),
+                makeProgram(
+                    id: "recent-zero-duration",
+                    startAt: cutoffDate.addingTimeInterval(1),
+                    endAt: cutoffDate.addingTimeInterval(1),
+                    duration: 0
+                ),
+            ],
+            serverId: "server-1"
+        )
+
+        await store.cleanupOldPrograms(referenceDate: referenceDate)
+
+        let remainingPrograms = await store.loadCachedPrograms(
+            until: referenceDate.addingTimeInterval(1)
+        )
+        #expect(Set(remainingPrograms.map(\.id)) == ["recent-normal", "recent-zero-duration"])
+    }
+
 }
 
 private func makeService(networkId: Int, transportStreamId: Int?, serviceId: Int) -> TVService {

--- a/kiririnTests/kiririnTests.swift
+++ b/kiririnTests/kiririnTests.swift
@@ -374,4 +374,64 @@ struct KiririnTests {
             )
         )
     }
+
+    @Test func programGuideVisibleRangeDoesNotRefreshDuringSmallScrolls() {
+        let timelineStart = Date(timeIntervalSince1970: 0)
+        let timelineEnd = timelineStart.addingTimeInterval(24 * 60 * 60)
+        let initialRange = ProgramGuideVisibleRange.make(
+            timelineStart: timelineStart,
+            timelineEnd: timelineEnd,
+            minuteHeight: 2.5,
+            verticalScrollOffset: 0,
+            viewportHeight: 552,
+            sectionHeaderHeight: 52
+        )
+        let needsRefresh = initialRange.needsRefresh(
+            timelineStart: timelineStart,
+            timelineEnd: timelineEnd,
+            minuteHeight: 2.5,
+            verticalScrollOffset: 52 + 30 * 2.5,
+            viewportHeight: 552,
+            sectionHeaderHeight: 52
+        )
+
+        #expect(!needsRefresh)
+    }
+
+    @Test func programGuideVisibleRangeRefreshesNearBufferEdge() {
+        let timelineStart = Date(timeIntervalSince1970: 0)
+        let timelineEnd = timelineStart.addingTimeInterval(24 * 60 * 60)
+        let initialRange = ProgramGuideVisibleRange.make(
+            timelineStart: timelineStart,
+            timelineEnd: timelineEnd,
+            minuteHeight: 2.5,
+            verticalScrollOffset: 0,
+            viewportHeight: 552,
+            sectionHeaderHeight: 52
+        )
+        let verticalScrollOffset = 52 + 190 * 2.5
+        let needsRefresh = initialRange.needsRefresh(
+            timelineStart: timelineStart,
+            timelineEnd: timelineEnd,
+            minuteHeight: 2.5,
+            verticalScrollOffset: verticalScrollOffset,
+            viewportHeight: 552,
+            sectionHeaderHeight: 52
+        )
+        let refreshedRange = ProgramGuideVisibleRange.make(
+            timelineStart: timelineStart,
+            timelineEnd: timelineEnd,
+            minuteHeight: 2.5,
+            verticalScrollOffset: verticalScrollOffset,
+            viewportHeight: 552,
+            sectionHeaderHeight: 52
+        )
+
+        #expect(needsRefresh)
+        #expect(refreshedRange != initialRange)
+        #expect(
+            refreshedRange.end
+                == timelineStart.addingTimeInterval(600 * 60)
+        )
+    }
 }

--- a/kiririnTests/kiririnTests.swift
+++ b/kiririnTests/kiririnTests.swift
@@ -278,6 +278,10 @@ struct KiririnTests {
             minuteHeight: 1,
             width: 200,
             totalHeight: 300,
+            visibleRange: ProgramGuideVisibleRange(
+                start: timelineStart,
+                end: timelineEnd
+            ),
             onProgramTapped: { _ in }
         )
         let second = ProgramChannelColumnView(
@@ -288,9 +292,86 @@ struct KiririnTests {
             minuteHeight: 1,
             width: 200,
             totalHeight: 300,
+            visibleRange: ProgramGuideVisibleRange(
+                start: timelineStart,
+                end: timelineEnd
+            ),
             onProgramTapped: { _ in }
         )
 
         #expect(first != second)
+    }
+
+    @Test func programGuideVisibleRangeUsesBufferedQuantizedWindow() {
+        let timelineStart = Date(timeIntervalSince1970: 0)
+        let timelineEnd = timelineStart.addingTimeInterval(24 * 60 * 60)
+
+        let range = ProgramGuideVisibleRange.make(
+            timelineStart: timelineStart,
+            timelineEnd: timelineEnd,
+            minuteHeight: 2.5,
+            verticalScrollOffset: 52 + 300 * 2.5,
+            viewportHeight: 552,
+            sectionHeaderHeight: 52
+        )
+
+        #expect(range.start == timelineStart.addingTimeInterval(90 * 60))
+        #expect(range.end == timelineStart.addingTimeInterval(720 * 60))
+    }
+
+    @Test func programGuideVisibleRangeClampsToTimelineBounds() {
+        let timelineStart = Date(timeIntervalSince1970: 0)
+        let timelineEnd = timelineStart.addingTimeInterval(24 * 60 * 60)
+
+        let topRange = ProgramGuideVisibleRange.make(
+            timelineStart: timelineStart,
+            timelineEnd: timelineEnd,
+            minuteHeight: 2.5,
+            verticalScrollOffset: 0,
+            viewportHeight: 552,
+            sectionHeaderHeight: 52
+        )
+        let bottomRange = ProgramGuideVisibleRange.make(
+            timelineStart: timelineStart,
+            timelineEnd: timelineEnd,
+            minuteHeight: 2.5,
+            verticalScrollOffset: 10_000,
+            viewportHeight: 552,
+            sectionHeaderHeight: 52
+        )
+
+        #expect(topRange.start == timelineStart)
+        #expect(bottomRange.end == timelineEnd)
+    }
+
+    @Test func programGuideVisibleRangeTestsProgramIntersection() {
+        let timelineStart = Date(timeIntervalSince1970: 0)
+        let timelineEnd = timelineStart.addingTimeInterval(24 * 60 * 60)
+        let range = ProgramGuideVisibleRange(
+            start: timelineStart.addingTimeInterval(60 * 60),
+            end: timelineStart.addingTimeInterval(120 * 60)
+        )
+
+        #expect(
+            range.intersects(
+                programStart: timelineStart.addingTimeInterval(90 * 60),
+                programEnd: timelineStart.addingTimeInterval(150 * 60),
+                timelineEnd: timelineEnd
+            )
+        )
+        #expect(
+            !range.intersects(
+                programStart: timelineStart.addingTimeInterval(120 * 60),
+                programEnd: timelineStart.addingTimeInterval(150 * 60),
+                timelineEnd: timelineEnd
+            )
+        )
+        #expect(
+            range.intersects(
+                programStart: timelineStart.addingTimeInterval(90 * 60),
+                programEnd: timelineStart.addingTimeInterval(90 * 60),
+                timelineEnd: timelineEnd
+            )
+        )
     }
 }

--- a/kiririnTests/kiririnTests.swift
+++ b/kiririnTests/kiririnTests.swift
@@ -248,4 +248,49 @@ struct KiririnTests {
 
         #expect(applied.extended == OrderedDictionary<String, String>())
     }
+
+    @Test @MainActor func programChannelColumnEqualityDetectsProgramChanges() {
+        func makeProgram(id: String) -> Program {
+            Program(
+                id: id,
+                serverId: "server",
+                eventId: 1,
+                serviceId: 10,
+                networkId: 20,
+                startAt: Date(timeIntervalSince1970: 1_000),
+                endAt: Date(timeIntervalSince1970: 1_060),
+                duration: 60,
+                name: id,
+                desc: nil,
+                extended: nil,
+                genres: [],
+                updatedAt: nil
+            )
+        }
+
+        let timelineStart = Date(timeIntervalSince1970: 900)
+        let timelineEnd = Date(timeIntervalSince1970: 1_200)
+        let first = ProgramChannelColumnView(
+            channelId: "20-10",
+            programs: [makeProgram(id: "first")],
+            timelineStart: timelineStart,
+            timelineEnd: timelineEnd,
+            minuteHeight: 1,
+            width: 200,
+            totalHeight: 300,
+            onProgramTapped: { _ in }
+        )
+        let second = ProgramChannelColumnView(
+            channelId: "20-10",
+            programs: [makeProgram(id: "second")],
+            timelineStart: timelineStart,
+            timelineEnd: timelineEnd,
+            minuteHeight: 1,
+            width: 200,
+            totalHeight: 300,
+            onProgramTapped: { _ in }
+        )
+
+        #expect(first != second)
+    }
 }


### PR DESCRIPTION
Fixes #68
Fixes #69

## Summary by Sourcery

番組表およびサービス一覧のパフォーマンスと、番組更新・表示まわりのデータベース利用を最適化。

Bug Fixes:
- 番組クリーンアップ処理を変更し、通常の番組と duration が 0 の番組の両方について、1 日の期限に基づいて古いエントリを正しく削除するようにします。
- 番組インデックスの移行を 1 つのマイグレーションに統合し、マージ動作を検証することで、重複した古い移行を排除します。
- 有効な番組が存在しない場合にプレイヤーの「次の番組」状態をクリアし、不要な更新を避けるようにします。
- 再接続時および再生サーバー選択シートで、別のサービスが選択されているにもかかわらず候補が表示されてしまう問題を修正します。

Enhancements:
- 番組表にビューポートモデルと「可視範囲」計算を導入し、描画する番組を限定することで、プラットフォームをまたいだスクロール挙動を改善します。
- チャンネルグリッドと番組セルのレンダリングをリファクタリングし、遅延評価の横方向スタック、可視性に基づくフィルタリング、高さを考慮したテキストレイアウトを使用するようにします。
- OS の signpost に基づくパフォーマンスログと、サービス一覧およびプレイヤー番組情報の更新に対する「デバウンス付き・スナップショットベース」の再構築を追加します。
- ARIB フォールバックフォントをキャッシュして、フォント生成の繰り返しを減らし、描画効率を改善します。
- サーバー側の再生選択ダイアログを厳密化し、現在選択されているサービスに対するオプションのみが表示されるようにします。

Tests:
- キャッシュストアインデックスの作成、マイグレーションのマージ動作、番組表示スナップショット、および番組クリーンアップの意味論をカバーする単体テストを追加します。
- 番組表の可視範囲計算、リフレッシュ閾値、および可視コンテンツに基づく番組列の等価性のテストを追加します。
- ストアの動作テストを拡張し、スナップショットベースの番組表示およびクリーンアップロジックを検証します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize program guide and service list performance and database usage around program updates and display.

Bug Fixes:
- Change program cleanup to correctly remove old entries for both normal and zero-duration programs based on a one-day cutoff.
- Eliminate duplicated and outdated program index migrations by consolidating them into a single migration and validating merge behavior.
- Ensure player next-program state is cleared when no valid program exists and avoid redundant updates.
- Fix reconnection and playback server selection sheets showing candidates when a different service is selected.

Enhancements:
- Introduce viewport modeling and visible range computation in the program guide to limit rendered programs and improve scrolling behavior across platforms.
- Refactor the channel grid and program cell rendering to use lazy horizontal stacks, visibility-based filtering, and height-aware text layout.
- Add OS signpost-based performance logging and debounced, snapshot-based rebuilding for the service list and player program info refresh.
- Cache ARIB fallback fonts to reduce repeated font construction and improve rendering efficiency.
- Tighten server-side playback selection dialogs so they only show options for the currently selected service.

Tests:
- Add unit tests covering cache store index creation, migration merging behavior, program display snapshots, and program cleanup semantics.
- Add tests for program guide visible range calculation, refresh thresholds, and program column equality based on visible content.
- Extend store behavior tests to validate snapshot-based program display and cleanup logic.

</details>