### PR TITLE
feat: bridgeにシーク中情報を返す

### DIFF
--- a/Plugin/KiririnPluginBridge.d.ts
+++ b/Plugin/KiririnPluginBridge.d.ts
@@ -1,5 +1,7 @@
 /**
- * kiririn のプラグインページで利用できる app-specific bridge です。
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * kiririn v0.3.0 のプラグインページで利用できる app-specific bridge です。
  *
  * このファイルが説明するのは `window.kiririn` だけです。
  * WebExtension 標準 API は WebKit が提供するものを利用してください。
@@ -67,6 +69,10 @@ export interface PlayerPlaybackState {
     time: number;
     position: number;
     rate: number;
+    /** ネイティブのシークバーをドラッグ中かどうかです。 */
+    isScrubbing: boolean;
+    /** ドラッグ中のシークバー位置です。ドラッグ中以外は`null`です。 */
+    scrubPosition: number | null;
     /**
      * プレイヤー領域内でテレビ画面として使われる描画領域の正規化座標です。
      * データ放送表示中はデータ放送コンテンツの描画領域、それ以外は全面を示します。

--- a/Plugin/README.md
+++ b/Plugin/README.md
@@ -1,4 +1,6 @@
-# kiririn プラグイン仕様
+# kiririn v0.3.0 プラグイン仕様
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 kiririnのプラグインは、WebKitのWebExtensionを基盤にしています。プラグイン固有の機能は`window.kiririn`で提供し、それ以外はWebKitが実装するWebExtension APIを利用します。
 
@@ -346,6 +348,8 @@ interface PlayerPlaybackState {
   isPlaying: boolean;
   time: number;
   position: number;
+  isScrubbing: boolean;
+  scrubPosition: number | null;
   rate: number;
   televisionDisplayRect: PlayerDisplayRect;
   videoDisplayRect: PlayerDisplayRect;
@@ -361,6 +365,8 @@ interface PlayerDisplayRect {
 
 - `time`: 現在時刻の秒数です。
 - `position`: 0〜1の正規化された再生位置です。MPEG-TSなどでバイト位置が利用できる場合は、その正規化値が優先されます。
+- `isScrubbing`: ネイティブのシークバーをドラッグ中かどうかです。
+- `scrubPosition`: ドラッグ中のシークバー位置です。0〜1の値を取り、ドラッグ中以外は`null`です。シークバーの表示位置を表すため、MPEG-TSなどでは`position`と一致しない場合があります。
 - `rate`: 再生速度です。
 - `televisionDisplayRect`: プレイヤー表示領域内で、テレビ画面またはデータ放送コンテンツが占める矩形です。
 - `videoDisplayRect`: プレイヤー表示領域内で、映像が実際に表示されている矩形です。
@@ -399,6 +405,8 @@ getPlayerStatus(playerID: string): PlayerPlaybackState | null;
 `getFocusedPlayerID()`はアプリ全体でフォーカスされているプレイヤーを返します。フォーカス対象が閉じられた場合、`onFocusedPlayerIDChange`には`null`が渡され、その後`onPlayerClosed`が呼ばれます。
 
 `getPlayable`と`getPlayerStatus`は対象がなければ`null`を返します。再生状態は頻繁に変わるため、必要な値だけUIへ反映してください。
+
+シークバーのドラッグ開始・終了はすぐに通知します。ドラッグ中の位置更新は、Bridge負荷を抑えるため最大500msに1回です。
 
 ### 再生操作
 
@@ -440,7 +448,7 @@ interface KiririnRuntimeInfo {
 const runtime = window.kiririn.getRuntimeInfo();
 ```
 
-現在の`bridgeVersion`は`5`です。Bridgeの互換性を判定するときは、この値と`appVersion`を確認してください。
+現在の`bridgeVersion`は`6`です。Bridgeの互換性を判定するときは、この値と`appVersion`を確認してください。
 
 `osVersion`は`ProcessInfo.processInfo.operatingSystemVersionString`、`appVersion`は`CFBundleShortVersionString`、`buildVersion`は`CFBundleVersion`です。`bundleIdentifier`や`appVersion`は取得できない環境では`null`になります。
 

--- a/kiririn/Features/Player/PlayerOverlayView.swift
+++ b/kiririn/Features/Player/PlayerOverlayView.swift
@@ -49,7 +49,6 @@ struct PlayerOverlayView_iOS: View {
     @State private var isInfoSheetVisible = true
     @State private var lowerTabSelection = "caption"
     @State private var selectedPluginID: UUID?
-    @State private var scrubPosition: Float?
     @State private var initialScrubTime: Double?
     @State private var initialScrubPosition: Float?
     @State private var seekFeedbackText = ""
@@ -89,7 +88,7 @@ struct PlayerOverlayView_iOS: View {
 
     private var displayTime: Double {
         if playerState.isScrubbing,
-            let pos = scrubPosition,
+            let pos = playerState.scrubPosition,
             let initPos = initialScrubPosition,
             let initTime = initialScrubTime,
             displayDuration > 0
@@ -109,7 +108,7 @@ struct PlayerOverlayView_iOS: View {
     }
 
     private var displayProgress: Double {
-        if playerState.isScrubbing, let scrub = scrubPosition {
+        if playerState.isScrubbing, let scrub = playerState.scrubPosition {
             return Double(scrub)
         }
         return Double(playerState.playbackStatus.position)
@@ -2183,10 +2182,10 @@ struct PlayerOverlayView_iOS: View {
         if !playerState.isScrubbing {
             initialScrubPosition = playerState.playbackStatus.position
             initialScrubTime = playerState.playbackStatus.time
+            playerState.beginScrubbing(at: initialScrubPosition ?? 0)
         }
-        playerState.isScrubbing = true
         let newProgress = min(max(0, relativeX / availableWidth), 1)
-        scrubPosition = Float(newProgress)
+        playerState.updateScrubbing(to: Float(newProgress))
     }
 
     private func updateScrubFromThumbDrag(translationX: CGFloat, availableWidth: CGFloat) {
@@ -2199,24 +2198,25 @@ struct PlayerOverlayView_iOS: View {
         } else {
             baseProgress =
                 initialScrubPosition
-                ?? scrubPosition
+                ?? playerState.scrubPosition
                 ?? playerState.playbackStatus.position
         }
-        playerState.isScrubbing = true
+        if !playerState.isScrubbing {
+            playerState.beginScrubbing(at: baseProgress)
+        }
         let newProgress = min(max(0, CGFloat(baseProgress) + translationX / availableWidth), 1)
-        scrubPosition = Float(newProgress)
+        playerState.updateScrubbing(to: Float(newProgress))
     }
 
     private func finishScrub() {
-        if playerState.isScrubbing, let scrub = scrubPosition {
+        if playerState.isScrubbing, let scrub = playerState.scrubPosition {
             if displayDuration > 0 {
                 playerState.seek(toTime: displayTime)
             } else {
                 playerState.seek(to: scrub)
             }
         }
-        playerState.isScrubbing = false
-        scrubPosition = nil
+        _ = playerState.endScrubbing()
         initialScrubPosition = nil
         initialScrubTime = nil
     }

--- a/kiririn/Features/Player/PlayerState.swift
+++ b/kiririn/Features/Player/PlayerState.swift
@@ -293,6 +293,27 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
             }
         }
     }
+    /// シークバーをドラッグ中の表示位置。ドラッグ中以外は`nil`です。
+    var scrubPosition: Float?
+
+    func beginScrubbing(at position: Float) {
+        guard position.isFinite else { return }
+        isScrubbing = true
+        updateScrubbing(to: position)
+    }
+
+    func updateScrubbing(to position: Float) {
+        guard isScrubbing, position.isFinite else { return }
+        scrubPosition = min(max(position, 0), 1)
+    }
+
+    func endScrubbing() -> Float? {
+        guard isScrubbing || scrubPosition != nil else { return nil }
+        let position = scrubPosition
+        scrubPosition = nil
+        isScrubbing = false
+        return position
+    }
 
     func reloadPlugins() {
         pluginReloadToken += 1
@@ -1290,6 +1311,7 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
     }
 
     func stop() {
+        _ = endScrubbing()
         player?.stop()
         isPlaybackLoading = false
         isPlaybackSeeking = false
@@ -1299,6 +1321,7 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
     }
 
     func cleanup(releasePlayer: Bool = false, releaseSecurityScope: Bool = false) {
+        _ = endScrubbing()
         dataBroadcastSession?.stop()
         dataBroadcastSession = nil
         savePlaybackPositionIfNeeded()

--- a/kiririn/Features/Player/macOS/DetachedPlayerOverlayView.swift
+++ b/kiririn/Features/Player/macOS/DetachedPlayerOverlayView.swift
@@ -24,8 +24,6 @@
         @State private var isPointerOverBottomController = false
         @State private var titleControllerFrame = CGRect.zero
         @State private var isPlayerFullscreen = false
-        @State private var isSeeking = false
-        @State private var seekValue: Double = 0
         @State private var isCursorHidden = false
         @State private var seekFeedbackText = ""
         @State private var isSeekFeedbackVisible = false
@@ -51,11 +49,13 @@
 
         private var displayDuration: Double { playerState.currentPlayable?.length ?? 0 }
         private var displayProgress: Double {
-            if isSeeking { return seekValue }
+            if let scrubPosition = playerState.scrubPosition { return Double(scrubPosition) }
             return Double(playerState.playbackStatus.position)
         }
         private var displayTime: Double {
-            if isSeeking, displayDuration > 0 { return displayDuration * seekValue }
+            if let scrubPosition = playerState.scrubPosition, displayDuration > 0 {
+                return displayDuration * Double(scrubPosition)
+            }
             return playerState.playbackStatus.time
         }
 
@@ -364,14 +364,14 @@
                             value: Binding(
                                 get: { displayProgress },
                                 set: { newValue in
-                                    seekValue = newValue
+                                    playerState.updateScrubbing(to: Float(newValue))
                                 }
                             ),
                             range: 0...1,
                             scale: scale,
                             onEditingChanged: { editing in
                                 if editing {
-                                    isSeeking = true
+                                    playerState.beginScrubbing(at: Float(displayProgress))
                                 } else {
                                     finishSeek()
                                 }
@@ -934,14 +934,14 @@
         }
 
         private func finishSeek() {
-            if isSeeking {
+            if playerState.isScrubbing, let seekValue = playerState.scrubPosition {
                 if displayDuration > 0 {
                     playerState.seek(toTime: displayTime)
                 } else {
-                    playerState.seek(to: Float(seekValue))
+                    playerState.seek(to: seekValue)
                 }
             }
-            isSeeking = false
+            _ = playerState.endScrubbing()
         }
 
         private func showVolumeFeedback() {

--- a/kiririn/Features/Plugin/PluginOverlayView.swift
+++ b/kiririn/Features/Plugin/PluginOverlayView.swift
@@ -88,7 +88,7 @@ struct PluginOverlayView: View {
 
     var body: some View {
         // アクティブな全プレイヤーの状態を追跡するハッシュを生成し、これを元に再描画と同期をトリガーさせる。
-        // 再生位置(time)は頻繁すぎるため除外するが、番組変更や再生/停止、シーク可否、映像表示領域の変化は網羅する。
+        // 再生位置(time)は頻繁すぎるため除外するが、シークバー操作中の位置はBridgeへ公開する。
         let stateHash =
             appModel.activePlayerStates.map {
                 let stageRect = $0.dataBroadcastSession?.stageRect
@@ -97,6 +97,8 @@ struct PluginOverlayView: View {
                     $0.id,
                     $0.currentPlayable?.id ?? "none",
                     String($0.playbackStatus.isPlaying),
+                    String($0.isScrubbing),
+                    String($0.scrubPosition ?? -1),
                     String($0.currentPlayable?.isSeekable ?? false),
                     String($0.bmlContentVisible),
                     String(describing: stageRect),

--- a/kiririn/Features/Plugin/PluginOverlayView.swift
+++ b/kiririn/Features/Plugin/PluginOverlayView.swift
@@ -88,7 +88,7 @@ struct PluginOverlayView: View {
 
     var body: some View {
         // アクティブな全プレイヤーの状態を追跡するハッシュを生成し、これを元に再描画と同期をトリガーさせる。
-        // 再生位置(time)は頻繁すぎるため除外するが、シークバー操作中の位置はBridgeへ公開する。
+        // 通常の再生時間・再生位置は除外し、再生状態、シークバー操作、再生対象、映像表示領域の変化を追跡する。
         let stateHash =
             appModel.activePlayerStates.map {
                 let stageRect = $0.dataBroadcastSession?.stageRect

--- a/kiririn/Features/Plugin/PluginWebView.swift
+++ b/kiririn/Features/Plugin/PluginWebView.swift
@@ -188,7 +188,7 @@ struct PluginWebView: PluginWebViewRepresentable {
             "appVersion": appVersion ?? NSNull(),
             "buildVersion": buildVersion,
             "bundleIdentifier": bundle.bundleIdentifier ?? NSNull(),
-            "bridgeVersion": 5,
+            "bridgeVersion": 6,
             "displayAreaType": displayArea.rawValue,
             "playerID": runtimePlayerID,
         ]
@@ -250,20 +250,31 @@ struct PluginWebView: PluginWebViewRepresentable {
         into webView: WKWebView, coordinator: Coordinator, force: Bool = false
     ) {
         let statuses = appModel.activePlayerStates.compactMap(makePlayerStatusSchema)
+        let containsScrubbingStatus = appModel.activePlayerStates.contains(where: \.isScrubbing)
         guard
             let data = try? JSONSerialization.data(
                 withJSONObject: statuses, options: [.sortedKeys]),
             let json = String(data: data, encoding: .utf8)
         else { return }
 
-        if !force, let last = coordinator.lastInjectedStatusesJson, last == json {
+        if !force, let last = coordinator.lastInjectedStatusesJson, last == json,
+            coordinator.pendingStatusesJson == nil
+        {
             return
         }
-        coordinator.lastInjectedStatusesJson = json
 
-        let js =
-            "if(window.kiririn && window.kiririn._onPlayerStatusesChange) window.kiririn._onPlayerStatusesChange(\(json));"
-        webView.evaluateJavaScript(js)
+        if force || !containsScrubbingStatus || !coordinator.lastInjectedStatusesContainedScrubbing
+        {
+            coordinator.cancelPendingStatusInjection()
+            coordinator.injectStatuses(
+                json, containsScrubbing: containsScrubbingStatus, into: webView)
+        } else {
+            coordinator.queueStatusInjection(
+                json,
+                containsScrubbing: containsScrubbingStatus,
+                into: webView
+            )
+        }
     }
 
     private func injectFocus(into webView: WKWebView, coordinator: Coordinator, force: Bool = false)
@@ -296,6 +307,8 @@ struct PluginWebView: PluginWebViewRepresentable {
             "isPlaying": status.isPlaying,
             "time": status.time,
             "position": status.bytePosition > 0 ? status.bytePosition : status.position,
+            "isScrubbing": state.isScrubbing,
+            "scrubPosition": state.scrubPosition ?? NSNull(),
             "rate": status.rate,
             "televisionDisplayRect": displayRects.television,
             "videoDisplayRect": displayRects.video,
@@ -564,6 +577,11 @@ struct PluginWebView: PluginWebViewRepresentable {
         var lastReloadKey: PluginReloadKey?
         var lastInjectedPlayablesJson: String?
         var lastInjectedStatusesJson: String?
+        var lastInjectedStatusesContainedScrubbing = false
+        var lastStatusInjectionDate: Date?
+        var pendingStatusesJson: String?
+        var pendingStatusesContainedScrubbing = false
+        var pendingStatusInjectionTask: Task<Void, Never>?
         var lastInjectedFocusedPlayerID: String?
         var lastInjectedPlayerIDs: Set<String>?
         var lastInjectedDeeplinkToken: Int = 0
@@ -580,11 +598,59 @@ struct PluginWebView: PluginWebViewRepresentable {
             self.onCrash = onCrash
         }
 
+        func injectStatuses(
+            _ json: String,
+            containsScrubbing: Bool,
+            into webView: WKWebView
+        ) {
+            lastInjectedStatusesJson = json
+            lastInjectedStatusesContainedScrubbing = containsScrubbing
+            lastStatusInjectionDate = .now
+
+            let js =
+                "if(window.kiririn && window.kiririn._onPlayerStatusesChange) window.kiririn._onPlayerStatusesChange(\(json));"
+            webView.evaluateJavaScript(js)
+        }
+
+        func queueStatusInjection(
+            _ json: String,
+            containsScrubbing: Bool,
+            into webView: WKWebView
+        ) {
+            pendingStatusesJson = json
+            pendingStatusesContainedScrubbing = containsScrubbing
+            guard pendingStatusInjectionTask == nil else { return }
+
+            let elapsed = lastStatusInjectionDate.map { Date.now.timeIntervalSince($0) } ?? 0
+            let delay = max(0, 0.5 - elapsed)
+            let task = Task { @MainActor [weak self, weak webView] in
+                try? await Task.sleep(for: .seconds(delay))
+                guard !Task.isCancelled else { return }
+                guard let self, let webView, let json = self.pendingStatusesJson else { return }
+                let containsScrubbing = self.pendingStatusesContainedScrubbing
+                self.pendingStatusesJson = nil
+                self.pendingStatusesContainedScrubbing = false
+                self.pendingStatusInjectionTask = nil
+                self.injectStatuses(json, containsScrubbing: containsScrubbing, into: webView)
+            }
+            pendingStatusInjectionTask = task
+        }
+
+        func cancelPendingStatusInjection() {
+            pendingStatusInjectionTask?.cancel()
+            pendingStatusInjectionTask = nil
+            pendingStatusesJson = nil
+            pendingStatusesContainedScrubbing = false
+        }
+
         func prepareForPageLoad(pageURL: String?, reloadKey: PluginReloadKey) {
             lastLoadedPageURL = pageURL
             lastReloadKey = reloadKey
             lastInjectedPlayablesJson = nil
             lastInjectedStatusesJson = nil
+            lastInjectedStatusesContainedScrubbing = false
+            lastStatusInjectionDate = nil
+            cancelPendingStatusInjection()
             lastInjectedFocusedPlayerID = nil
             lastInjectedPlayerIDs = nil
             wantsCaptureEvents = false
@@ -600,6 +666,9 @@ struct PluginWebView: PluginWebViewRepresentable {
             announcedCaptureEvents.removeAll()
             lastInjectedPlayablesJson = nil
             lastInjectedStatusesJson = nil
+            lastInjectedStatusesContainedScrubbing = false
+            lastStatusInjectionDate = nil
+            cancelPendingStatusInjection()
             lastInjectedFocusedPlayerID = nil
             lastInjectedPlayerIDs = nil
             wantsCaptureEvents = false

--- a/kiririn/Features/Plugin/PluginWebView.swift
+++ b/kiririn/Features/Plugin/PluginWebView.swift
@@ -18,6 +18,8 @@ import WebKit
 
 @MainActor
 struct PluginWebView: PluginWebViewRepresentable {
+    private static let scrubbingStatusNotificationInterval: TimeInterval = 0.5
+
     let pluginDefinition: PluginDefinition
     let extensionRuntime: ExtensionPluginRuntime
     let webViewConfiguration: WKWebViewConfiguration
@@ -622,7 +624,7 @@ struct PluginWebView: PluginWebViewRepresentable {
             guard pendingStatusInjectionTask == nil else { return }
 
             let elapsed = lastStatusInjectionDate.map { Date.now.timeIntervalSince($0) } ?? 0
-            let delay = max(0, 0.5 - elapsed)
+            let delay = max(0, PluginWebView.scrubbingStatusNotificationInterval - elapsed)
             let task = Task { @MainActor [weak self, weak webView] in
                 try? await Task.sleep(for: .seconds(delay))
                 guard !Task.isCancelled else { return }


### PR DESCRIPTION
Fixes #67

## Summary by Sourcery

プラグインブリッジを拡張して、スクラubbing（シーク）操作とスクラブ位置を報告できるようにし、スクラブ中のステータス更新のスケジューリングを調整し、更新された v0.3.0 ブリッジ API とバージョンについて文書化しました。

New Features:
- ブリッジを通じて、ネイティブのスクラバーのドラッグ状態と位置をプラグインに公開。
- 拡張されたプレーヤーステータス API を反映するため、ブリッジバージョンを 6 に引き上げ。

Enhancements:
- スクラブ中のプレーヤーステータス更新を最大 500ms に 1 回までにスロットリングし、冗長な注入を回避。
- iOS と macOS のオーバーレイ間で、PlayerState にスクラブ状態管理を集約。

Documentation:
- スクラブ関連フィールドおよび新しいブリッジバージョンを説明するために、プラグインブリッジのドキュメントと TypeScript 定義を更新（SPDX ヘッダーを含む）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend the plugin bridge to report scrubbing activity and scrub position, adjust status update scheduling around scrubbing, and document the updated v0.3.0 bridge API and version.

New Features:
- Expose native scrubber drag state and position to plugins via the bridge.
- Increase bridge version to 6 to reflect the expanded player status API.

Enhancements:
- Throttle player status updates during scrubbing to at most once every 500ms and avoid redundant injections.
- Centralize scrubbing state management in PlayerState across iOS and macOS overlays.

Documentation:
- Update plugin bridge documentation and TypeScript definitions to describe scrubbing fields and new bridge version, including SPDX headers.

</details>