### PR TITLE
chore: VLCKit更新

### DIFF
--- a/kiririn/Features/Player/PlayerState.swift
+++ b/kiririn/Features/Player/PlayerState.swift
@@ -355,6 +355,7 @@ final class PlayerState: NSObject, VLCMediaPlayerDelegate, VLCMediaDelegate {
             "--no-snapshot-preview",
             "--snapshot-format=jpg",
             "--aribcaption-font=Hiragino Maru Gothic ProN,Rounded M+ 1m WadaLab comp ARIB,Apple Symbols",
+            "--prefetch-buffer-size=2048",
             "--verbose=1",
         ]
         #if os(macOS)

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # VLCKit
 # https://github.com/neneka/vlckit/releases
-REVISION="202608090657"
+REVISION="202608110911"
 VLCKIT_URL="https://github.com/neneka/vlckit/releases/download/$REVISION/VLCKit-iOS-REPLACEWITHVERSION.dmg"
 VLCKIT_DEST="./Packages/VLCKit"
 FRAMEWORK_DEST="${VLCKIT_DEST}/VLCKit.xcframework"


### PR DESCRIPTION
一時停止中にシークすると挙動がおかしくなる件の修正

Fixes #82 

https://github.com/neneka/vlckit/pull/68

## Summary by Sourcery

一時停止中のシーク動作を改善するために、VLCKit のリビジョンを更新し、プレーヤー設定を調整しました。

Enhancements:
- シーク中の再生を安定させるため、VLC プレーヤー初期化時にプリフェッチバッファサイズのオプションを追加しました。

Build:
- VLCKit セットアップスクリプトを最新のリリース済みリビジョンを使用するように更新しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update VLCKit revision and adjust player configuration to improve seek behavior while paused.

Enhancements:
- Add a prefetch buffer size option to the VLC player initialization to stabilize playback during seeking.

Build:
- Bump VLCKit setup script to use the latest released revision.

</details>