### PR TITLE
fix: ハッシュ設定修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,17 +85,42 @@ jobs:
 
             - name: Build archive
               run: |
+                  git_commit_hash="$(git rev-parse --short=7 HEAD)"
+                  archive_path="$RUNNER_TEMP/${{ matrix.platform.id }}/kiririn-${{ matrix.platform.id }}.xcarchive"
+
+                  echo "Archiving commit $git_commit_hash"
                   xcodebuild archive \
                     -project "$PROJECT" \
                     -scheme "$SCHEME" \
                     -destination "${{ matrix.platform.destination }}" \
-                    -archivePath "$RUNNER_TEMP/${{ matrix.platform.id }}/kiririn-${{ matrix.platform.id }}.xcarchive" \
+                    -archivePath "$archive_path" \
                     -derivedDataPath "$RUNNER_TEMP/DerivedData" \
                     -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages" \
                     -skipPackagePluginValidation \
                     CODE_SIGNING_ALLOWED=NO \
                     CODE_SIGNING_REQUIRED=NO \
-                    CODE_SIGN_IDENTITY=""
+                    CODE_SIGN_IDENTITY="" \
+                    KIRIRIN_GIT_COMMIT_HASH="$git_commit_hash"
+
+                  app_path="$(find "$archive_path/Products/Applications" -type d -name '*.app' -print -quit)"
+                  if [ -z "$app_path" ]; then
+                    echo "::error::No .app found in $archive_path/Products/Applications"
+                    exit 1
+                  fi
+
+                  if [ -f "$app_path/Contents/Info.plist" ]; then
+                    info_plist="$app_path/Contents/Info.plist"
+                  else
+                    info_plist="$app_path/Info.plist"
+                  fi
+
+                  actual_git_hash="$(/usr/bin/plutil -extract KiririnGitCommitHash raw -o - "$info_plist" 2>/dev/null || true)"
+                  if [ "$actual_git_hash" != "$git_commit_hash" ]; then
+                    echo "::error::KiririnGitCommitHash is missing or incorrect in $info_plist (expected $git_commit_hash, got ${actual_git_hash:-<missing>})"
+                    exit 1
+                  fi
+
+                  echo "Verified KiririnGitCommitHash=$actual_git_hash"
 
             - name: Create XCArchive ZIP
               run: |

--- a/kiririn.xcodeproj/project.pbxproj
+++ b/kiririn.xcodeproj/project.pbxproj
@@ -376,7 +376,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\ninfo_plist=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\ngit_hash=\"-\"\n\nif [ -f \"$info_plist\" ] && git -C \"$SRCROOT\" rev-parse --is-inside-work-tree >/dev/null 2>&1; then\n    git_hash=$(git -C \"$SRCROOT\" rev-parse --short=7 HEAD)\nfi\n\nif [ -f \"$info_plist\" ]; then\n    /usr/libexec/PlistBuddy -c \"Set :KiririnGitCommitHash $git_hash\" \"$info_plist\" 2>/dev/null || \\\n        /usr/libexec/PlistBuddy -c \"Add :KiririnGitCommitHash string $git_hash\" \"$info_plist\"\nfi\n";
+			shellScript = "set -eu\n\ninfo_plist=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\n\nif [ ! -f \"$info_plist\" ]; then\n    echo \"Git commit hash: Info.plist not found at $info_plist; keeping the existing value\"\n    exit 0\nfi\n\nif ! git_hash=$(git -C \"$SRCROOT\" rev-parse --short=7 HEAD 2>/dev/null); then\n    echo \"Git commit hash unavailable; keeping the existing Info.plist value\"\n    exit 0\nfi\n\n/usr/libexec/PlistBuddy -c \"Set :KiririnGitCommitHash $git_hash\" \"$info_plist\" 2>/dev/null || \\\n    /usr/libexec/PlistBuddy -c \"Add :KiririnGitCommitHash string $git_hash\" \"$info_plist\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -577,7 +577,7 @@
 				INFOPLIST_FILE = kiririn/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = kiririn;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
-				INFOPLIST_KEY_KiririnGitCommitHash = "-";
+				KIRIRIN_GIT_COMMIT_HASH = "-";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
 				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 ci7lus";
@@ -652,7 +652,7 @@
 				INFOPLIST_FILE = kiririn/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = kiririn;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
-				INFOPLIST_KEY_KiririnGitCommitHash = "-";
+				KIRIRIN_GIT_COMMIT_HASH = "-";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
 				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 ci7lus";

--- a/kiririn/Info.plist
+++ b/kiririn/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>KiririnGitCommitHash</key>
+	<string>$(KIRIRIN_GIT_COMMIT_HASH)</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>ローカルネットワーク上のサーバーとの通信と、リモコンに使用します。</string>
 	<key>NSBonjourServices</key>


### PR DESCRIPTION
## Summary by Sourcery

アーカイブされたアプリケーションに Git コミットハッシュを埋め込み・検証することで、ソースメタデータが無効なビルドを防止します。

Bug Fixes:
- macOS および iOS アプリケーションのアーカイブに Git コミットハッシュを埋め込み、アーカイブされたビルドが正確なソースメタデータを保持するようにします。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成されたアプリケーションメタデータが欠落している場合や不正確な場合には CI を失敗させます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Embed and verify the Git commit hash in archived applications to prevent builds with invalid source metadata.

Bug Fixes:
- Embed the Git commit hash in macOS and iOS application archives to ensure archived builds retain accurate source metadata.

CI:
- Pass the current short Git commit hash into archive builds and fail CI when the generated application metadata is missing or incorrect.

</details>

バグ修正:
- macOS および iOS アプリケーションのアーカイブに Git のコミットハッシュを埋め込み、アーカイブ済みメタデータが欠落しているか不正な場合は CI を失敗させます。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成された各アプリケーションの `Info.plist` 内でそれを検証します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

アーカイブされたアプリケーションに Git コミットハッシュを埋め込み・検証することで、ソースメタデータが無効なビルドを防止します。

Bug Fixes:
- macOS および iOS アプリケーションのアーカイブに Git コミットハッシュを埋め込み、アーカイブされたビルドが正確なソースメタデータを保持するようにします。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成されたアプリケーションメタデータが欠落している場合や不正確な場合には CI を失敗させます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Embed and verify the Git commit hash in archived applications to prevent builds with invalid source metadata.

Bug Fixes:
- Embed the Git commit hash in macOS and iOS application archives to ensure archived builds retain accurate source metadata.

CI:
- Pass the current short Git commit hash into archive builds and fail CI when the generated application metadata is missing or incorrect.

</details>

</details>

バグ修正:
- macOS および iOS アプリケーションのアーカイブに Git コミットハッシュを埋め込み、アーカイブされたメタデータが欠落している場合や不正確な場合には CI を失敗させます。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、サポートされている各プラットフォーム向けに生成されたアプリケーションの Info.plist 内でそれを検証します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

アーカイブされたアプリケーションに Git コミットハッシュを埋め込み・検証することで、ソースメタデータが無効なビルドを防止します。

Bug Fixes:
- macOS および iOS アプリケーションのアーカイブに Git コミットハッシュを埋め込み、アーカイブされたビルドが正確なソースメタデータを保持するようにします。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成されたアプリケーションメタデータが欠落している場合や不正確な場合には CI を失敗させます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Embed and verify the Git commit hash in archived applications to prevent builds with invalid source metadata.

Bug Fixes:
- Embed the Git commit hash in macOS and iOS application archives to ensure archived builds retain accurate source metadata.

CI:
- Pass the current short Git commit hash into archive builds and fail CI when the generated application metadata is missing or incorrect.

</details>

バグ修正:
- macOS および iOS アプリケーションのアーカイブに Git のコミットハッシュを埋め込み、アーカイブ済みメタデータが欠落しているか不正な場合は CI を失敗させます。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成された各アプリケーションの `Info.plist` 内でそれを検証します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

アーカイブされたアプリケーションに Git コミットハッシュを埋め込み・検証することで、ソースメタデータが無効なビルドを防止します。

Bug Fixes:
- macOS および iOS アプリケーションのアーカイブに Git コミットハッシュを埋め込み、アーカイブされたビルドが正確なソースメタデータを保持するようにします。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成されたアプリケーションメタデータが欠落している場合や不正確な場合には CI を失敗させます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Embed and verify the Git commit hash in archived applications to prevent builds with invalid source metadata.

Bug Fixes:
- Embed the Git commit hash in macOS and iOS application archives to ensure archived builds retain accurate source metadata.

CI:
- Pass the current short Git commit hash into archive builds and fail CI when the generated application metadata is missing or incorrect.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

アーカイブされたアプリケーションに Git コミットハッシュを埋め込み・検証することで、ソースメタデータが無効なビルドを防止します。

Bug Fixes:
- macOS および iOS アプリケーションのアーカイブに Git コミットハッシュを埋め込み、アーカイブされたビルドが正確なソースメタデータを保持するようにします。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成されたアプリケーションメタデータが欠落している場合や不正確な場合には CI を失敗させます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Embed and verify the Git commit hash in archived applications to prevent builds with invalid source metadata.

Bug Fixes:
- Embed the Git commit hash in macOS and iOS application archives to ensure archived builds retain accurate source metadata.

CI:
- Pass the current short Git commit hash into archive builds and fail CI when the generated application metadata is missing or incorrect.

</details>

バグ修正:
- macOS および iOS アプリケーションのアーカイブに Git のコミットハッシュを埋め込み、アーカイブ済みメタデータが欠落しているか不正な場合は CI を失敗させます。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成された各アプリケーションの `Info.plist` 内でそれを検証します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

アーカイブされたアプリケーションに Git コミットハッシュを埋め込み・検証することで、ソースメタデータが無効なビルドを防止します。

Bug Fixes:
- macOS および iOS アプリケーションのアーカイブに Git コミットハッシュを埋め込み、アーカイブされたビルドが正確なソースメタデータを保持するようにします。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成されたアプリケーションメタデータが欠落している場合や不正確な場合には CI を失敗させます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Embed and verify the Git commit hash in archived applications to prevent builds with invalid source metadata.

Bug Fixes:
- Embed the Git commit hash in macOS and iOS application archives to ensure archived builds retain accurate source metadata.

CI:
- Pass the current short Git commit hash into archive builds and fail CI when the generated application metadata is missing or incorrect.

</details>

</details>

バグ修正:
- macOS および iOS アプリケーションのアーカイブに Git コミットハッシュを埋め込み、アーカイブされたメタデータが欠落している場合や不正確な場合には CI を失敗させます。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、サポートされている各プラットフォーム向けに生成されたアプリケーションの Info.plist 内でそれを検証します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

アーカイブされたアプリケーションに Git コミットハッシュを埋め込み・検証することで、ソースメタデータが無効なビルドを防止します。

Bug Fixes:
- macOS および iOS アプリケーションのアーカイブに Git コミットハッシュを埋め込み、アーカイブされたビルドが正確なソースメタデータを保持するようにします。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成されたアプリケーションメタデータが欠落している場合や不正確な場合には CI を失敗させます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Embed and verify the Git commit hash in archived applications to prevent builds with invalid source metadata.

Bug Fixes:
- Embed the Git commit hash in macOS and iOS application archives to ensure archived builds retain accurate source metadata.

CI:
- Pass the current short Git commit hash into archive builds and fail CI when the generated application metadata is missing or incorrect.

</details>

バグ修正:
- macOS および iOS アプリケーションのアーカイブに Git のコミットハッシュを埋め込み、アーカイブ済みメタデータが欠落しているか不正な場合は CI を失敗させます。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成された各アプリケーションの `Info.plist` 内でそれを検証します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

アーカイブされたアプリケーションに Git コミットハッシュを埋め込み・検証することで、ソースメタデータが無効なビルドを防止します。

Bug Fixes:
- macOS および iOS アプリケーションのアーカイブに Git コミットハッシュを埋め込み、アーカイブされたビルドが正確なソースメタデータを保持するようにします。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成されたアプリケーションメタデータが欠落している場合や不正確な場合には CI を失敗させます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Embed and verify the Git commit hash in archived applications to prevent builds with invalid source metadata.

Bug Fixes:
- Embed the Git commit hash in macOS and iOS application archives to ensure archived builds retain accurate source metadata.

CI:
- Pass the current short Git commit hash into archive builds and fail CI when the generated application metadata is missing or incorrect.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

アーカイブされたアプリケーションに Git コミットハッシュを埋め込み・検証することで、ソースメタデータが無効なビルドを防止します。

Bug Fixes:
- macOS および iOS アプリケーションのアーカイブに Git コミットハッシュを埋め込み、アーカイブされたビルドが正確なソースメタデータを保持するようにします。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成されたアプリケーションメタデータが欠落している場合や不正確な場合には CI を失敗させます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Embed and verify the Git commit hash in archived applications to prevent builds with invalid source metadata.

Bug Fixes:
- Embed the Git commit hash in macOS and iOS application archives to ensure archived builds retain accurate source metadata.

CI:
- Pass the current short Git commit hash into archive builds and fail CI when the generated application metadata is missing or incorrect.

</details>

バグ修正:
- macOS および iOS アプリケーションのアーカイブに Git のコミットハッシュを埋め込み、アーカイブ済みメタデータが欠落しているか不正な場合は CI を失敗させます。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成された各アプリケーションの `Info.plist` 内でそれを検証します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

アーカイブされたアプリケーションに Git コミットハッシュを埋め込み・検証することで、ソースメタデータが無効なビルドを防止します。

Bug Fixes:
- macOS および iOS アプリケーションのアーカイブに Git コミットハッシュを埋め込み、アーカイブされたビルドが正確なソースメタデータを保持するようにします。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成されたアプリケーションメタデータが欠落している場合や不正確な場合には CI を失敗させます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Embed and verify the Git commit hash in archived applications to prevent builds with invalid source metadata.

Bug Fixes:
- Embed the Git commit hash in macOS and iOS application archives to ensure archived builds retain accurate source metadata.

CI:
- Pass the current short Git commit hash into archive builds and fail CI when the generated application metadata is missing or incorrect.

</details>

</details>

バグ修正:
- macOS および iOS アプリケーションのアーカイブに Git コミットハッシュを埋め込み、アーカイブされたメタデータが欠落している場合や不正確な場合には CI を失敗させます。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、サポートされている各プラットフォーム向けに生成されたアプリケーションの Info.plist 内でそれを検証します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

アーカイブされたアプリケーションに Git コミットハッシュを埋め込み・検証することで、ソースメタデータが無効なビルドを防止します。

Bug Fixes:
- macOS および iOS アプリケーションのアーカイブに Git コミットハッシュを埋め込み、アーカイブされたビルドが正確なソースメタデータを保持するようにします。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成されたアプリケーションメタデータが欠落している場合や不正確な場合には CI を失敗させます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Embed and verify the Git commit hash in archived applications to prevent builds with invalid source metadata.

Bug Fixes:
- Embed the Git commit hash in macOS and iOS application archives to ensure archived builds retain accurate source metadata.

CI:
- Pass the current short Git commit hash into archive builds and fail CI when the generated application metadata is missing or incorrect.

</details>

バグ修正:
- macOS および iOS アプリケーションのアーカイブに Git のコミットハッシュを埋め込み、アーカイブ済みメタデータが欠落しているか不正な場合は CI を失敗させます。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成された各アプリケーションの `Info.plist` 内でそれを検証します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

アーカイブされたアプリケーションに Git コミットハッシュを埋め込み・検証することで、ソースメタデータが無効なビルドを防止します。

Bug Fixes:
- macOS および iOS アプリケーションのアーカイブに Git コミットハッシュを埋め込み、アーカイブされたビルドが正確なソースメタデータを保持するようにします。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成されたアプリケーションメタデータが欠落している場合や不正確な場合には CI を失敗させます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Embed and verify the Git commit hash in archived applications to prevent builds with invalid source metadata.

Bug Fixes:
- Embed the Git commit hash in macOS and iOS application archives to ensure archived builds retain accurate source metadata.

CI:
- Pass the current short Git commit hash into archive builds and fail CI when the generated application metadata is missing or incorrect.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

アーカイブされたアプリケーションに Git コミットハッシュを埋め込み・検証することで、ソースメタデータが無効なビルドを防止します。

Bug Fixes:
- macOS および iOS アプリケーションのアーカイブに Git コミットハッシュを埋め込み、アーカイブされたビルドが正確なソースメタデータを保持するようにします。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成されたアプリケーションメタデータが欠落している場合や不正確な場合には CI を失敗させます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Embed and verify the Git commit hash in archived applications to prevent builds with invalid source metadata.

Bug Fixes:
- Embed the Git commit hash in macOS and iOS application archives to ensure archived builds retain accurate source metadata.

CI:
- Pass the current short Git commit hash into archive builds and fail CI when the generated application metadata is missing or incorrect.

</details>

バグ修正:
- macOS および iOS アプリケーションのアーカイブに Git のコミットハッシュを埋め込み、アーカイブ済みメタデータが欠落しているか不正な場合は CI を失敗させます。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成された各アプリケーションの `Info.plist` 内でそれを検証します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

アーカイブされたアプリケーションに Git コミットハッシュを埋め込み・検証することで、ソースメタデータが無効なビルドを防止します。

Bug Fixes:
- macOS および iOS アプリケーションのアーカイブに Git コミットハッシュを埋め込み、アーカイブされたビルドが正確なソースメタデータを保持するようにします。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成されたアプリケーションメタデータが欠落している場合や不正確な場合には CI を失敗させます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Embed and verify the Git commit hash in archived applications to prevent builds with invalid source metadata.

Bug Fixes:
- Embed the Git commit hash in macOS and iOS application archives to ensure archived builds retain accurate source metadata.

CI:
- Pass the current short Git commit hash into archive builds and fail CI when the generated application metadata is missing or incorrect.

</details>

</details>

バグ修正:
- macOS および iOS アプリケーションのアーカイブに Git コミットハッシュを埋め込み、アーカイブされたメタデータが欠落している場合や不正確な場合には CI を失敗させます。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、サポートされている各プラットフォーム向けに生成されたアプリケーションの Info.plist 内でそれを検証します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

アーカイブされたアプリケーションに Git コミットハッシュを埋め込み・検証することで、ソースメタデータが無効なビルドを防止します。

Bug Fixes:
- macOS および iOS アプリケーションのアーカイブに Git コミットハッシュを埋め込み、アーカイブされたビルドが正確なソースメタデータを保持するようにします。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成されたアプリケーションメタデータが欠落している場合や不正確な場合には CI を失敗させます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Embed and verify the Git commit hash in archived applications to prevent builds with invalid source metadata.

Bug Fixes:
- Embed the Git commit hash in macOS and iOS application archives to ensure archived builds retain accurate source metadata.

CI:
- Pass the current short Git commit hash into archive builds and fail CI when the generated application metadata is missing or incorrect.

</details>

バグ修正:
- macOS および iOS アプリケーションのアーカイブに Git のコミットハッシュを埋め込み、アーカイブ済みメタデータが欠落しているか不正な場合は CI を失敗させます。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成された各アプリケーションの `Info.plist` 内でそれを検証します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

アーカイブされたアプリケーションに Git コミットハッシュを埋め込み・検証することで、ソースメタデータが無効なビルドを防止します。

Bug Fixes:
- macOS および iOS アプリケーションのアーカイブに Git コミットハッシュを埋め込み、アーカイブされたビルドが正確なソースメタデータを保持するようにします。

CI:
- 現在の短い Git コミットハッシュをアーカイブビルドに渡し、生成されたアプリケーションメタデータが欠落している場合や不正確な場合には CI を失敗させます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Embed and verify the Git commit hash in archived applications to prevent builds with invalid source metadata.

Bug Fixes:
- Embed the Git commit hash in macOS and iOS application archives to ensure archived builds retain accurate source metadata.

CI:
- Pass the current short Git commit hash into archive builds and fail CI when the generated application metadata is missing or incorrect.

</details>

</details>

</details>

</details>

</details>