### PR TITLE
docs: improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+
+
 # kiririn
 
 kiririn は macOS/iOS 上において、デジタル放送の視聴を行うプログラムの実装を研究する目的で頒布される研究資料です。<br>
@@ -85,6 +87,6 @@ macOS 版の公証や TestFlight 配布のための各種手続きについて�
 
 MPL 2.0
 
-### [web](./web/)
+### [web/bml](./web/bm/)
 
 MIT


### PR DESCRIPTION
Makes one small, focused improvement to the existing README.

## Summary by Sourcery

ドキュメント:
- README のリンクを修正し、`web/bml` ディレクトリを指すようにする。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Correct the README link to point to the web/bml directory.

</details>