### PR TITLE
chore: リモコンが切れた時に再接続するように

### DIFF
--- a/kiririn/AppShell/ContentView.swift
+++ b/kiririn/AppShell/ContentView.swift
@@ -171,12 +171,19 @@ struct ContentView: View {
                 showCacheDatabaseFailureToast()
             }
             .onChange(of: scenePhase) { _, newPhase in
-                guard newPhase == .active else { return }
-                if playerState.isPipEnabled {
-                    playerState.isPipEnabled = false
-                }
-                Task {
-                    await manager.handleAppDidBecomeActive()
+                switch newPhase {
+                case .active:
+                    appModel.remoteControlService.handleAppDidBecomeActive()
+                    if playerState.isPipEnabled {
+                        playerState.isPipEnabled = false
+                    }
+                    Task {
+                        await manager.handleAppDidBecomeActive()
+                    }
+                case .background:
+                    appModel.remoteControlService.handleAppDidEnterBackground()
+                default:
+                    break
                 }
             }
             .onOpenURL { url in

--- a/kiririn/Features/RemoteControl/RemoteControlModels.swift
+++ b/kiririn/Features/RemoteControl/RemoteControlModels.swift
@@ -70,6 +70,7 @@ nonisolated enum RemoteConnectionStatus: Equatable, Sendable {
     case idle
     case browsing
     case connecting(peerID: String, displayName: String)
+    case reconnecting(String)
     case pairing(String)
     case connected(String)
     case failed(String)

--- a/kiririn/Features/RemoteControl/RemoteControlService.swift
+++ b/kiririn/Features/RemoteControl/RemoteControlService.swift
@@ -25,6 +25,13 @@ final class RemoteControlService {
     private(set) var lastErrorMessage: String?
     var selectedPlayerID: String?
 
+    var isReconnecting: Bool {
+        if case .reconnecting = connectionStatus {
+            return true
+        }
+        return false
+    }
+
     private let defaults: UserDefaults
     private let trustedPeerStore: RemoteTrustedPeerStore
     private let dispatcher = RemotePlayerCommandDispatcher()
@@ -63,6 +70,11 @@ final class RemoteControlService {
     private var isAuthenticated = false
     private var authenticatedConnectionID: String?
     private var awaitingAuthenticationAcceptanceConnectionID: String?
+    private var reconnectingControllerPeerID: String?
+    private var reconnectingControllerPeerName: String?
+    private var reconnectingDisconnectPendingID: String?
+    private var reconnectionTask: Task<Void, Never>?
+    private var isApplicationInBackground = false
     private var pairingFailureCount = 0
     private var snapshotTask: Task<Void, Never>?
     private var lastSentSnapshots: [RemotePlayerSnapshot] = []
@@ -108,6 +120,36 @@ final class RemoteControlService {
         pairingFailureCount = 0
     }
 
+    func handleAppDidEnterBackground() {
+        isApplicationInBackground = true
+        reconnectionTask?.cancel()
+        reconnectionTask = nil
+
+        guard operationMode == .controller,
+            isAuthenticated,
+            let connectionID = authenticatedConnectionID ?? currentConnectionID
+        else {
+            return
+        }
+        rememberControllerForReconnection(connectionID: connectionID)
+    }
+
+    func handleAppDidBecomeActive() {
+        isApplicationInBackground = false
+
+        guard operationMode == .controller,
+            let connectionID = reconnectingControllerPeerID
+        else {
+            return
+        }
+
+        if isAuthenticated, authenticatedConnectionID == connectionID {
+            beginControllerReconnection(connectionID: connectionID)
+        } else if currentConnectionID == nil {
+            scheduleControllerReconnection(after: .milliseconds(0))
+        }
+    }
+
     func startBrowsing() {
         guard
             operationMode != .controller
@@ -124,27 +166,36 @@ final class RemoteControlService {
             connectionStatus = .failed("登録済み端末をKeychainから読み込めませんでした")
             return
         }
+        let preservesRemotePlayers = reconnectingControllerPeerID != nil
         operationMode = .controller
-        resetConnectionState()
+        resetConnectionState(preservingRemotePlayers: preservesRemotePlayers)
         discoveredPeers = []
-        connectionStatus = .browsing
+        if preservesRemotePlayers {
+            connectionStatus = .reconnecting(reconnectingControllerPeerName ?? "接続先")
+        } else {
+            connectionStatus = .browsing
+        }
         transport.stopAdvertising()
+        reconnectionTask?.cancel()
+        reconnectionTask = nil
         transport.startBrowsing()
     }
 
     func stopBrowsing() {
         transport.stopBrowsing()
-        if !isAuthenticated {
-            if currentConnectionID != nil {
-                transport.disconnect()
-                resetConnectionState()
-            }
-            operationMode = .idle
-            connectionStatus = .idle
+        guard !isAuthenticated, !isApplicationInBackground else { return }
+
+        if currentConnectionID != nil {
+            transport.disconnect()
         }
+        clearControllerReconnection()
+        resetConnectionState()
+        operationMode = .idle
+        connectionStatus = .idle
     }
 
     func connect(to peer: RemoteDiscoveredPeer) {
+        clearControllerReconnection()
         operationMode = .controller
         currentConnectionID = peer.id
         connectionStatus = .connecting(peerID: peer.id, displayName: peer.displayName)
@@ -153,6 +204,7 @@ final class RemoteControlService {
     }
 
     func disconnect() {
+        clearControllerReconnection()
         transport.disconnect()
         resetConnectionState()
         if operationMode == .controller {
@@ -282,6 +334,7 @@ final class RemoteControlService {
             return
         }
         operationMode = .receiver
+        clearControllerReconnection()
         resetConnectionState()
         rotatePairingPIN()
         transport.stopBrowsing()
@@ -292,6 +345,7 @@ final class RemoteControlService {
         transport.stopAdvertising()
         transport.disconnect()
         operationMode = .idle
+        clearControllerReconnection()
         resetConnectionState()
         connectionStatus = .idle
     }
@@ -307,6 +361,7 @@ final class RemoteControlService {
                     $0.displayName.localizedCompare($1.displayName) == .orderedAscending
                 }
             }
+            reconnect(to: peer)
         case .lost(let connectionID):
             discoveredPeers.removeAll { $0.id == connectionID }
         case .connecting(let connectionID):
@@ -318,7 +373,11 @@ final class RemoteControlService {
                 discoveredPeers.first(where: { $0.id == connectionID })?.displayName
                 ?? remoteIdentity?.displayName
                 ?? "接続先"
-            connectionStatus = .connecting(peerID: connectionID, displayName: name)
+            if reconnectingControllerPeerID == connectionID {
+                connectionStatus = .reconnecting(reconnectingControllerPeerName ?? name)
+            } else {
+                connectionStatus = .connecting(peerID: connectionID, displayName: name)
+            }
         case .connected(let connectionID):
             guard currentConnectionID == nil || currentConnectionID == connectionID else {
                 return
@@ -335,17 +394,45 @@ final class RemoteControlService {
             guard currentConnectionID == nil || currentConnectionID == connectionID else {
                 return
             }
-            resetConnectionState()
-            if operationMode == .controller {
-                connectionStatus = .browsing
-                transport.startBrowsing()
+
+            if reconnectingDisconnectPendingID == connectionID {
+                reconnectingDisconnectPendingID = nil
+                scheduleControllerReconnection(after: .milliseconds(0))
+                return
+            }
+
+            let shouldReconnect =
+                operationMode == .controller
+                && (reconnectingControllerPeerID == connectionID
+                    || (isAuthenticated && authenticatedConnectionID == connectionID))
+            if shouldReconnect {
+                rememberControllerForReconnection(connectionID: connectionID)
+                let name = reconnectingControllerPeerName ?? "接続先"
+                resetConnectionState(preservingRemotePlayers: true)
+                connectionStatus = .reconnecting(name)
+                scheduleControllerReconnection(after: .milliseconds(0))
             } else {
-                connectionStatus = .idle
+                resetConnectionState()
+                if operationMode == .controller {
+                    connectionStatus = .browsing
+                    transport.startBrowsing()
+                } else {
+                    connectionStatus = .idle
+                }
             }
         case .received(let data, let connectionID):
             guard currentConnectionID == connectionID else { return }
             handleReceivedData(data, connectionID: connectionID)
         case .failed(let message):
+            if operationMode == .controller,
+                reconnectingControllerPeerID != nil
+            {
+                let name = reconnectingControllerPeerName ?? "接続先"
+                resetConnectionState(preservingRemotePlayers: true)
+                connectionStatus = .reconnecting(name)
+                scheduleControllerReconnection(after: .seconds(1))
+                return
+            }
             lastErrorMessage = message
             connectionStatus = .failed(message)
         }
@@ -691,6 +778,7 @@ final class RemoteControlService {
         authenticatedConnectionID = connectionID
         awaitingAuthenticationAcceptanceConnectionID = nil
         transport.stopBrowsing()
+        clearControllerReconnection()
         pairingRequest = nil
         pairingChallenge = nil
         let name = remoteIdentity?.displayName ?? "Mac"
@@ -832,11 +920,12 @@ final class RemoteControlService {
     private func rejectConnection(message: String) {
         lastErrorMessage = message
         connectionStatus = .failed(message)
+        clearControllerReconnection()
         transport.disconnect()
         resetConnectionState()
     }
 
-    private func resetConnectionState() {
+    private func resetConnectionState(preservingRemotePlayers: Bool = false) {
         snapshotTask?.cancel()
         snapshotTask = nil
         currentConnectionID = nil
@@ -848,11 +937,88 @@ final class RemoteControlService {
         isAuthenticated = false
         authenticatedConnectionID = nil
         awaitingAuthenticationAcceptanceConnectionID = nil
-        remotePlayers = []
-        selectedPlayerID = nil
+        if !preservingRemotePlayers {
+            remotePlayers = []
+            selectedPlayerID = nil
+        }
         lastSentSnapshots = []
         processedCommandResponses.removeAll()
         processedCommandOrder.removeAll()
+    }
+
+    private func reconnect(to peer: RemoteDiscoveredPeer) {
+        guard operationMode == .controller,
+            currentConnectionID == nil,
+            reconnectingControllerPeerID == peer.id
+        else {
+            return
+        }
+
+        reconnectionTask?.cancel()
+        reconnectionTask = nil
+        reconnectingControllerPeerName = peer.displayName
+        currentConnectionID = peer.id
+        connectionStatus = .reconnecting(peer.displayName)
+        transport.connect(to: peer.id)
+    }
+
+    private func beginControllerReconnection(connectionID: String) {
+        rememberControllerForReconnection(connectionID: connectionID)
+        let name = reconnectingControllerPeerName ?? "接続先"
+        resetConnectionState(preservingRemotePlayers: true)
+        connectionStatus = .reconnecting(name)
+        reconnectingDisconnectPendingID = connectionID
+        transport.disconnect()
+        scheduleControllerReconnection(after: .milliseconds(250))
+    }
+
+    private func rememberControllerForReconnection(connectionID: String) {
+        let existingName =
+            reconnectingControllerPeerID == connectionID
+            ? reconnectingControllerPeerName
+            : nil
+        reconnectingControllerPeerID = connectionID
+        reconnectingControllerPeerName =
+            remoteIdentity?.displayName
+            ?? existingName
+            ?? discoveredPeers.first(where: { $0.id == connectionID })?.displayName
+            ?? "接続先"
+    }
+
+    private func scheduleControllerReconnection(after delay: Duration) {
+        guard !isApplicationInBackground,
+            operationMode == .controller,
+            reconnectingControllerPeerID != nil
+        else {
+            return
+        }
+
+        reconnectionTask?.cancel()
+        reconnectionTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: delay)
+            guard !Task.isCancelled,
+                let self
+            else {
+                return
+            }
+            self.reconnectionTask = nil
+            guard !self.isApplicationInBackground,
+                self.operationMode == .controller,
+                self.reconnectingControllerPeerID != nil,
+                self.currentConnectionID == nil
+            else {
+                return
+            }
+            self.transport.startBrowsing()
+        }
+    }
+
+    private func clearControllerReconnection() {
+        reconnectionTask?.cancel()
+        reconnectionTask = nil
+        reconnectingControllerPeerID = nil
+        reconnectingControllerPeerName = nil
+        reconnectingDisconnectPendingID = nil
     }
 
     private func commandErrorMessage(_ error: RemoteCommandError) -> String {

--- a/kiririn/Features/RemoteControl/iOS/PlayerRemoteControlView.swift
+++ b/kiririn/Features/RemoteControl/iOS/PlayerRemoteControlView.swift
@@ -18,6 +18,17 @@
                                 service.sendCommand(command, playerID: playerID)
                             }
                         )
+                        .disabled(service.isReconnecting)
+                        .overlay(alignment: .top) {
+                            if service.isReconnecting {
+                                AppFeedbackLabel(
+                                    text: "再接続中…",
+                                    showsProgress: true
+                                )
+                                .padding(.top)
+                                .allowsHitTesting(false)
+                            }
+                        }
                         .padding(.horizontal)
                         .padding(.bottom)
                     }

--- a/kiririn/Features/RemoteControl/iOS/RemoteDataBroadcastControlView.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemoteDataBroadcastControlView.swift
@@ -15,6 +15,17 @@
                         ) { key in
                             service.sendCommand(.pressBMLKey(key), playerID: playerID)
                         }
+                        .disabled(service.isReconnecting)
+                        .overlay(alignment: .top) {
+                            if service.isReconnecting {
+                                AppFeedbackLabel(
+                                    text: "再接続中…",
+                                    showsProgress: true
+                                )
+                                .padding(.top)
+                                .allowsHitTesting(false)
+                            }
+                        }
                         .padding()
                     }
                 } else {

--- a/kiririn/Features/RemoteControl/iOS/RemoteDestinationListView.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemoteDestinationListView.swift
@@ -22,6 +22,7 @@
                 service.startBrowsing()
             }
             .onDisappear {
+                guard !service.isReconnecting else { return }
                 service.stopBrowsing()
             }
             .onChange(of: service.pairingRequest) { _, request in
@@ -70,7 +71,7 @@
                         .foregroundStyle(.secondary)
                 }
 
-                if case .connected = service.connectionStatus {
+                if isConnected {
                     Button("切断", role: .destructive) {
                         service.disconnect()
                     }
@@ -109,10 +110,12 @@
         }
 
         private var isConnected: Bool {
-            guard case .connected = service.connectionStatus else {
-                return false
+            switch service.connectionStatus {
+            case .connected, .reconnecting:
+                true
+            default:
+                false
             }
-            return true
         }
 
         private var statusText: String {
@@ -123,6 +126,8 @@
                 "検索中"
             case .connecting(_, let name):
                 "\(name)へ接続中"
+            case .reconnecting(let name):
+                "\(name)へ再接続中…"
             case .pairing(let name):
                 "\(name)とペアリング中"
             case .connected(let name):
@@ -134,7 +139,7 @@
 
         private var isBusy: Bool {
             switch service.connectionStatus {
-            case .connecting, .pairing, .connected:
+            case .connecting, .reconnecting, .pairing, .connected:
                 true
             default:
                 false

--- a/kiririn/Features/RemoteControl/iOS/RemoteOptionControls.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemoteOptionControls.swift
@@ -1,19 +1,38 @@
 #if os(iOS)
     import SwiftUI
 
-    struct RemoteOptionControls: View {
+    struct RemoteOptionControls: View, Equatable {
         let player: RemotePlayerSnapshot
         let send: (RemoteControlCommand) -> Void
+
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.player.id == rhs.player.id
+                && lhs.player.capabilities == rhs.player.capabilities
+                && lhs.player.rate == rhs.player.rate
+                && lhs.player.audioTracks == rhs.player.audioTracks
+                && lhs.player.selectedAudioTrackSelection
+                    == rhs.player.selectedAudioTrackSelection
+                && lhs.player.videoTracks == rhs.player.videoTracks
+                && lhs.player.selectedVideoTrackID == rhs.player.selectedVideoTrackID
+        }
 
         var body: some View {
             HStack(spacing: 8) {
                 if player.capabilities.contains(.rate) {
                     Menu {
-                        ForEach(PlayerPlaybackOptionCatalog.rateOptions, id: \.self) { rate in
-                            Button(PlayerPlaybackOptionCatalog.rateLabel(rate)) {
-                                send(.setRate(rate))
+                        Picker(
+                            "再生速度",
+                            selection: Binding<Float>(
+                                get: { player.rate },
+                                set: { send(.setRate($0)) }
+                            )
+                        ) {
+                            ForEach(PlayerPlaybackOptionCatalog.rateOptions, id: \.self) { rate in
+                                Text(PlayerPlaybackOptionCatalog.rateLabel(rate))
+                                    .tag(rate)
                             }
                         }
+                        .labelsHidden()
                     } label: {
                         optionLabel(
                             title: "速度",

--- a/kiririn/Features/RemoteControl/iOS/RemotePlayerControlPanel.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemotePlayerControlPanel.swift
@@ -9,14 +9,18 @@
         var body: some View {
             VStack(spacing: 12) {
                 RemotePlayerHeaderView(player: player)
+                    .equatable()
                 RemotePlaybackControls(player: player, send: send)
                 RemoteVolumeControls(player: player, send: send)
+                    .equatable()
                 RemoteOptionControls(player: player, send: send)
+                    .equatable()
                 RemoteQuickActionsView(
                     service: service,
                     player: player,
                     send: send
                 )
+                .equatable()
             }
         }
     }

--- a/kiririn/Features/RemoteControl/iOS/RemotePlayerHeaderView.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemotePlayerHeaderView.swift
@@ -1,8 +1,15 @@
 #if os(iOS)
     import SwiftUI
 
-    struct RemotePlayerHeaderView: View {
+    struct RemotePlayerHeaderView: View, Equatable {
         let player: RemotePlayerSnapshot
+
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.player.id == rhs.player.id
+                && lhs.player.title == rhs.player.title
+                && lhs.player.serviceName == rhs.player.serviceName
+                && lhs.player.isRecording == rhs.player.isRecording
+        }
 
         var body: some View {
             HStack(spacing: 12) {

--- a/kiririn/Features/RemoteControl/iOS/RemoteQuickActionsView.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemoteQuickActionsView.swift
@@ -1,7 +1,7 @@
 #if os(iOS)
     import SwiftUI
 
-    struct RemoteQuickActionsView: View {
+    struct RemoteQuickActionsView: View, Equatable {
         let service: RemoteControlService
         let player: RemotePlayerSnapshot
         let send: (RemoteControlCommand) -> Void
@@ -14,6 +14,16 @@
             GridItem(.flexible()),
             GridItem(.flexible()),
         ]
+
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.player.id == rhs.player.id
+                && lhs.player.capabilities == rhs.player.capabilities
+                && lhs.player.isSubtitleEnabled == rhs.player.isSubtitleEnabled
+                && lhs.player.isPipEnabled == rhs.player.isPipEnabled
+                && lhs.player.isRecording == rhs.player.isRecording
+                && lhs.player.isFullscreen == rhs.player.isFullscreen
+                && lhs.player.isAlwaysOnTop == rhs.player.isAlwaysOnTop
+        }
 
         var body: some View {
             LazyVGrid(columns: columns, spacing: 8) {

--- a/kiririn/Features/RemoteControl/iOS/RemoteVolumeControls.swift
+++ b/kiririn/Features/RemoteControl/iOS/RemoteVolumeControls.swift
@@ -1,11 +1,17 @@
 #if os(iOS)
     import SwiftUI
 
-    struct RemoteVolumeControls: View {
+    struct RemoteVolumeControls: View, Equatable {
         let player: RemotePlayerSnapshot
         let send: (RemoteControlCommand) -> Void
         @State private var volume = 100.0
         @State private var isAdjustingVolume = false
+
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.player.id == rhs.player.id
+                && lhs.player.volume == rhs.player.volume
+                && lhs.player.isMuted == rhs.player.isMuted
+        }
 
         var body: some View {
             HStack(spacing: 10) {


### PR DESCRIPTION
## Sourceryによる概要

リモコン接続が切れた場合でも、登録済みの再生端末へ自動的に復帰できるようにする。

新機能:
- 再生アプリがバックグラウンドから復帰した際やリモコン接続が切断された際に、登録済みの接続先へ自動的に再接続する機能を追加する。

機能強化:
- 再接続中の状態表示と操作の無効化により、接続状態を明確にする。
- リモコン画面の不要な再描画を抑制し、操作パネルの応答性を改善する。

<details>
<summary>Original summary in English</summary>

## Sourceryによる概要

インターフェースの応答性を維持し、接続状態を明確に伝えながら、リモートコントロールセッションが自動的に復旧できるようにします。

新機能:
- 切断後、またはバックグラウンドから復帰した際に、リモートコントローラーを以前接続していた再生デバイスへ自動的に再接続します。

改善:
- 再接続中も再生デバイスの状態を保持し、リモートコントロールを無効にしながら、再接続の進行状況を明確に表示します。
- 不要なリモートコントロールパネルの再描画を減らし、応答性を向上させます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable remote-control sessions to recover automatically while keeping the interface responsive and clearly communicating connection state.

New Features:
- Automatically reconnect the remote controller to its previously connected playback device after disconnection or returning from the background.

Enhancements:
- Preserve playback-device state during reconnection and clearly indicate reconnection progress while disabling remote controls.
- Reduce unnecessary remote-control panel redraws to improve responsiveness.

</details>

</details>