### PR TITLE
fix(macOS): ダブルクリックによる全画面切り替えの判定が広すぎた

### DIFF
--- a/kiririn/Features/Player/macOS/DetachedPlayerOverlayView.swift
+++ b/kiririn/Features/Player/macOS/DetachedPlayerOverlayView.swift
@@ -7,6 +7,7 @@
 
     struct DetachedPlayerOverlayView_macOS: View {
         private static let overlayCoordinateSpaceName = "DetachedPlayerOverlay"
+        private static let backgroundDoubleClickMaximumDistance: CGFloat = 8
 
         @State var playerState: PlayerState
         let appModel: AppModel
@@ -23,6 +24,8 @@
         @State private var isPointerOverTitleController = false
         @State private var isPointerOverBottomController = false
         @State private var titleControllerFrame = CGRect.zero
+        @State private var lastBackgroundTap: BackgroundTap?
+        @State private var activationTapSuppressionDeadline: TimeInterval?
         @State private var isPlayerFullscreen = false
         @State private var isCursorHidden = false
         @State private var seekFeedbackText = ""
@@ -93,7 +96,7 @@
                             if let session = playerState.dataBroadcastSession {
                                 // Visibility is content-driven (ARIB invisible state):
                                 // the content shows itself on DataButton. Mouse input
-                                // never reaches this layer anyway - WindowDragSurface
+                                // never reaches this layer anyway - the input surface
                                 // sits above it in the ZStack; BML is keyboard-only.
                                 BMLOverlayView_macOS(session: session)
                                     .id(ObjectIdentifier(session.webView))
@@ -133,12 +136,11 @@
                         .contentShape(Rectangle())
                         .gesture(WindowDragGesture())
                         .simultaneousGesture(
-                            TapGesture(count: 2)
-                                .onEnded {
-                                    onToggleFullscreen()
+                            SpatialTapGesture()
+                                .onEnded { tap in
+                                    handleBackgroundTap(at: tap.location)
                                 }
                         )
-                        .allowsWindowActivationEvents()
                         .contextMenu {
                             Button {
                                 isAlwaysOnTop.toggle()
@@ -220,6 +222,24 @@
                         for: NSWindow.didExitFullScreenNotification)
                 ) { notification in
                     updateFullscreenState(false, from: notification)
+                }
+                .onReceive(
+                    NotificationCenter.default.publisher(
+                        for: NSWindow.didResignKeyNotification)
+                ) { notification in
+                    guard let window = notification.object as? NSWindow,
+                        window === playerWindow
+                    else {
+                        return
+                    }
+                    lastBackgroundTap = nil
+                    activationTapSuppressionDeadline = nil
+                }
+                .onReceive(
+                    NotificationCenter.default.publisher(
+                        for: NSWindow.didBecomeKeyNotification)
+                ) { notification in
+                    recordWindowActivationTap(from: notification)
                 }
                 .onChange(of: playerState.isRecording) { oldValue, newValue in
                     if newValue {
@@ -622,6 +642,8 @@
                 return
             }
             isPlayerFullscreen = isFullscreen
+            lastBackgroundTap = nil
+            activationTapSuppressionDeadline = nil
         }
 
         /// 全キーボードショートカットの置き場。コントロールバーのボタンには
@@ -777,6 +799,68 @@
                 NSCursor.unhide()
             }
             isCursorHidden = hidden
+        }
+
+        private func handleBackgroundTap(at location: CGPoint) {
+            let timestamp = ProcessInfo.processInfo.systemUptime
+            if let activationTapSuppressionDeadline {
+                self.activationTapSuppressionDeadline = nil
+                guard timestamp > activationTapSuppressionDeadline else {
+                    lastBackgroundTap = nil
+                    return
+                }
+            }
+
+            let tap = BackgroundTap(
+                timestamp: timestamp,
+                location: location
+            )
+            guard let lastBackgroundTap,
+                isDoubleClick(tap, after: lastBackgroundTap)
+            else {
+                self.lastBackgroundTap = tap
+                return
+            }
+
+            self.lastBackgroundTap = nil
+            onToggleFullscreen()
+        }
+
+        private func isDoubleClick(_ tap: BackgroundTap, after previousTap: BackgroundTap) -> Bool {
+            let interval = tap.timestamp - previousTap.timestamp
+            guard interval >= 0, interval <= NSEvent.doubleClickInterval else { return false }
+
+            let horizontalDistance = tap.location.x - previousTap.location.x
+            let verticalDistance = tap.location.y - previousTap.location.y
+            let distance = hypot(horizontalDistance, verticalDistance)
+            return distance <= Self.backgroundDoubleClickMaximumDistance
+        }
+
+        private func recordWindowActivationTap(from notification: Notification) {
+            guard let window = notification.object as? NSWindow,
+                window === playerWindow,
+                NSEvent.pressedMouseButtons & 1 != 0,
+                !isPointerOverBottomController,
+                playerState.dataBroadcastSession?.inputRequest == nil,
+                !isPointerOverStandardWindowButton(in: window)
+            else { return }
+
+            lastBackgroundTap = nil
+            activationTapSuppressionDeadline =
+                ProcessInfo.processInfo.systemUptime + NSEvent.doubleClickInterval
+        }
+
+        private func isPointerOverStandardWindowButton(in window: NSWindow) -> Bool {
+            let location = window.mouseLocationOutsideOfEventStream
+            let buttonTypes: [NSWindow.ButtonType] = [
+                .closeButton,
+                .miniaturizeButton,
+                .zoomButton,
+            ]
+            return buttonTypes.contains { buttonType in
+                guard let button = window.standardWindowButton(buttonType) else { return false }
+                return button.convert(button.bounds, to: nil).contains(location)
+            }
         }
 
         private var volumeIconName: String {
@@ -979,6 +1063,11 @@
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.2, execute: task)
         }
 
+    }
+
+    private struct BackgroundTap {
+        let timestamp: TimeInterval
+        let location: CGPoint
     }
 
     /// 再生オプションメニュー（macOS 分離プレイヤー用）。


### PR DESCRIPTION
今別にダブルクリックしてないんだけどなと言う時に全画面化してしまっていたので、そこら辺を直したい

## Sourceryによる概要

macOSの分離プレイヤーにおけるフルスクリーン切り替えのダブルクリック判定を、意図した背景操作にのみ反応するよう修正しました。

Bug Fixes:
- macOSの分離プレイヤーで、意図しないクリックによるフルスクリーン切り替えを防ぎ、背景上での有効なダブルクリックに限定しました。

Enhancements:
- 分離プレイヤーのダブルクリック判定をウィンドウレベルのマウスイベント処理に移し、コントロール、ウィンドウボタン、ドラッグ操作、間隔の空いたクリックを除外するよう改善しました。

<details>
<summary>Original summary in English</summary>

## Sourceryによる概要

macOSの分離プレーヤーにおけるダブルクリック検出を改善し、意図しないフルスクリーン切り替えを防止します。

バグ修正:
- macOSの分離プレーヤーでのフルスクリーン切り替えを、意図的に背景をダブルクリックした場合に限定します。コントロール、ウィンドウボタン、ドラッグ操作、離れた位置でのクリック、ウィンドウをアクティブ化するクリックは除外されます。

機能強化:
- 入力をより正確に分類できるよう、分離プレーヤーのダブルクリック処理をウィンドウレベルのマウスイベント監視に移行します。

<details>
<summary>Original summary in English</summary>

## Sourceryによる概要

macOSで、デタッチドプレーヤーのフルスクリーン切り替えを、有効な背景ダブルクリックに限定します。

バグ修正:
- macOSのデタッチドプレーヤーのフルスクリーン切り替えを、意図的な背景のダブルクリックに限定し、コントロール、ウィンドウボタン、アクティベーション時のクリック、ドラッグ、クリック間の距離が離れすぎている場合を除外します。

機能強化:
- 入力をより正確に分類できるよう、デタッチドプレーヤーのダブルクリック処理をウィンドウレベルのマウスイベント監視に移行します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restrict detached-player fullscreen toggling to valid background double-clicks on macOS.

Bug Fixes:
- Limit macOS detached-player fullscreen toggling to intentional background double-clicks, excluding controls, window buttons, activation clicks, drags, and clicks that are too far apart.

Enhancements:
- Move detached-player double-click handling to window-level mouse event monitoring for more accurate input classification.

</details>

</details>

</details>