### PR TITLE
feat: サービスを開くDeepLinkを追加

### DIFF
--- a/Plugin/KiririnPluginBridge.d.ts
+++ b/Plugin/KiririnPluginBridge.d.ts
@@ -112,6 +112,34 @@ export interface DeeplinkOpenedPayload {
     url: string;
 }
 
+export interface ServiceOpenRequest {
+    networkId: number;
+    serviceId: number;
+    /** 優先して使用するサーバーID。利用できない場合は他のサーバーへフォールバックします。 */
+    serverId?: string;
+}
+
+export type OpenURLErrorCode = "invalidURL";
+
+export type OpenServiceErrorCode =
+    | "invalidService"
+    | "serviceNotFound"
+    | "serviceUnavailable";
+
+export interface KiririnOpenURLError extends Error {
+    readonly name: "KiririnOpenError";
+    readonly operation: "openURL";
+    readonly code: OpenURLErrorCode;
+}
+
+export interface KiririnOpenServiceError extends Error {
+    readonly name: "KiririnOpenError";
+    readonly operation: "openService";
+    readonly code: OpenServiceErrorCode;
+}
+
+export type KiririnOpenError = KiririnOpenURLError | KiririnOpenServiceError;
+
 export type CaptureVariant = "original" | "composite";
 
 export interface CaptureVariantMetadata {
@@ -146,6 +174,11 @@ export interface KiririnPluginBridge {
 
     onDeeplinkOpened(callback: (payload: DeeplinkOpenedPayload) => void): void;
     onCaptureTaken(callback: (payload: CaptureTakenPayload) => void): void;
+
+    /** HTTPまたはHTTPSのメディアURLをプレイヤーで開きます。 */
+    openURL(url: string): Promise<void>;
+    /** 指定した放送サービスをプレイヤーで開きます。 */
+    openService(request: ServiceOpenRequest): Promise<void>;
 
     play(playerID?: string): void;
     pause(playerID?: string): void;

--- a/Plugin/KiririnPluginBridge.d.ts
+++ b/Plugin/KiririnPluginBridge.d.ts
@@ -1,7 +1,7 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  *
- * kiririn v0.3.0 のプラグインページで利用できる app-specific bridge です。
+ * kiririn v0.4.0 のプラグインページで利用できる app-specific bridge です。
  *
  * このファイルが説明するのは `window.kiririn` だけです。
  * WebExtension 標準 API は WebKit が提供するものを利用してください。

--- a/Plugin/README.md
+++ b/Plugin/README.md
@@ -431,6 +431,43 @@ seekToTime(time: number, playerID?: string): void;
 - `seekToTime`の`time`は秒数です。負数は0に、再生時間を超える値は再生時間にクランプされます。
 - `seekToTime`はリモートファイルなどで正確な位置への移動を保証しません。
 
+### URL・サービスを開く
+
+```ts
+interface ServiceOpenRequest {
+  networkId: number;
+  serviceId: number;
+  serverId?: string;
+}
+
+openURL(url: string): Promise<void>;
+openService(request: ServiceOpenRequest): Promise<void>;
+```
+
+`openURL`はHTTPまたはHTTPSのメディアURLをプレイヤーで開きます。`file:`、`data:`、`javascript:`、`kiririn:`などのスキームは利用できません。
+
+`openService`は`networkId`と`serviceId`で放送サービスを指定します。`serverId`は優先して使用するサーバーIDですが、指定サーバーが利用できない場合は他のサーバーへフォールバックします。
+
+同じURLまたは同じサービスがすでに再生中、または開く要求中の場合、新しいプレイヤーは作成されません。その場合もPromiseは成功します。Promiseの成功は再生要求の受け付けを示すもので、実際の再生開始までは保証しません。
+
+要求が不正な場合や再生可能な対象がない場合は、`name`が`KiririnOpenError`のErrorでrejectされます。安定した判定には`code`を使用してください。
+
+| operation | code | 意味 |
+| --- | --- | --- |
+| `openURL` | `invalidURL` | URLがHTTPまたはHTTPSのメディアURLではありません |
+| `openService` | `invalidService` | サービスIDが不正です |
+| `openService` | `serviceNotFound` | サービスを提供するサーバーが見つかりません |
+| `openService` | `serviceUnavailable` | サービスは見つかりましたが再生できません |
+
+アプリを外部から開くDeep Linkも`open`配下に統一されています。
+
+```text
+kiririn://open?url=https%3A%2F%2Fexample.com%2Flive.ts
+kiririn://open/service?networkId=32736&serviceId=1024&serverId=server-id
+```
+
+サービス用のDeep Linkは`kiririn://open/service`です。`serverId`は任意の優先サーバー指定で、利用できない場合は他のサーバーへフォールバックします。
+
 ### 実行環境情報
 
 ```ts
@@ -448,7 +485,7 @@ interface KiririnRuntimeInfo {
 const runtime = window.kiririn.getRuntimeInfo();
 ```
 
-現在の`bridgeVersion`は`6`です。Bridgeの互換性を判定するときは、この値と`appVersion`を確認してください。
+現在の`bridgeVersion`は`7`です。Bridgeの互換性を判定するときは、この値と`appVersion`を確認してください。
 
 `osVersion`は`ProcessInfo.processInfo.operatingSystemVersionString`、`appVersion`は`CFBundleShortVersionString`、`buildVersion`は`CFBundleVersion`です。`bundleIdentifier`や`appVersion`は取得できない環境では`null`になります。
 

--- a/Plugin/README.md
+++ b/Plugin/README.md
@@ -1,4 +1,4 @@
-# kiririn v0.3.0 プラグイン仕様
+# kiririn v0.4.0 プラグイン仕様
 
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 

--- a/kiririn.xcodeproj/project.pbxproj
+++ b/kiririn.xcodeproj/project.pbxproj
@@ -593,8 +593,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.4;
-				MARKETING_VERSION = 0.3.0;
-				"MARKETING_VERSION[sdk=iphoneos*]" = 0.3.0;
+				MARKETING_VERSION = 0.4.0;
+				"MARKETING_VERSION[sdk=iphoneos*]" = 0.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -668,8 +668,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.4;
-				MARKETING_VERSION = 0.3.0;
-				"MARKETING_VERSION[sdk=iphoneos*]" = 0.3.0;
+				MARKETING_VERSION = 0.4.0;
+				"MARKETING_VERSION[sdk=iphoneos*]" = 0.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/kiririn/AppShell/AppModel.swift
+++ b/kiririn/AppShell/AppModel.swift
@@ -30,6 +30,8 @@ final class AppModel {
     let remoteControlService: RemoteControlService
     @ObservationIgnored
     private let mediaPlaybackCoordinator: MediaPlaybackCoordinator
+    @ObservationIgnored
+    let openRequestCoordinator: PlaybackOpenCoordinator
     private(set) var cacheStore: CacheStore?
 
     var activePlayerStates: [PlayerState] = []
@@ -57,6 +59,8 @@ final class AppModel {
     }
 
     private var didSetupManager = false
+    @ObservationIgnored
+    private var setupTask: Task<Void, Never>?
     #if os(macOS)
         @ObservationIgnored
         private var globalCaptureHotKeyManager: GlobalCaptureHotKeyManager?
@@ -80,11 +84,21 @@ final class AppModel {
         pluginStore = PluginStore()
         remoteControlService = RemoteControlService()
         mediaPlaybackCoordinator = MediaPlaybackCoordinator()
+        let openRequestCoordinator = PlaybackOpenCoordinator(
+            manager: manager,
+            playerState: playerState
+        )
+        self.openRequestCoordinator = openRequestCoordinator
         pluginStore.onLocalFolderManifestChanged = { [weak self] pluginID in
             guard let self else { return }
             self.syncPluginsToPlayer(forceReloadPluginIDs: [pluginID])
         }
         playerState.plugins = pluginStore.plugins
+        openRequestCoordinator.register(playerState)
+        openRequestCoordinator.configureManagerSetupWaiter { [weak self] in
+            guard let self else { return }
+            await self.waitForManagerSetup()
+        }
         remoteControlService.configure(appModel: self)
         mediaPlaybackCoordinator.configure(appModel: self)
     }
@@ -96,7 +110,8 @@ final class AppModel {
             ensureGlobalCaptureHotKeyManager()
         #endif
         logger.debug("setupIfNeeded start: providers=\(manager.providers.count)")
-        Task {
+        setupTask = Task { @MainActor [weak self] in
+            guard let self else { return }
             let cacheStore = CacheStore()
             await installCacheStore(cacheStore)
             await manager.connectAll()
@@ -280,6 +295,22 @@ final class AppModel {
         playerState.play(playable: playable)
     }
 
+    func registerActivePlayerState(_ state: PlayerState) {
+        guard !activePlayerStates.contains(where: { $0 === state }) else { return }
+        activePlayerStates.append(state)
+        openRequestCoordinator.register(state)
+    }
+
+    func unregisterActivePlayerState(_ state: PlayerState) {
+        activePlayerStates.removeAll { $0 === state }
+        openRequestCoordinator.unregister(state)
+    }
+
+    private func waitForManagerSetup() async {
+        setupIfNeeded()
+        await setupTask?.value
+    }
+
     func handleDeepLink(url: URL) {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
             components.scheme?.lowercased() == "kiririn",
@@ -290,7 +321,7 @@ final class AppModel {
 
         switch host {
         case "open":
-            handleOpenDeepLink(components: components)
+            openRequestCoordinator.handleOpenDeepLink(components: components)
         case "plugins":
             handlePluginDeepLink(components: components)
         default:
@@ -327,15 +358,6 @@ final class AppModel {
     func consumePendingPluginDeeplinks(manifestID: String) -> [URL] {
         defer { pendingPluginDeeplinks.removeValue(forKey: manifestID) }
         return pendingPluginDeeplinks[manifestID] ?? []
-    }
-
-    private func handleOpenDeepLink(components: URLComponents) {
-        guard let mediaURL = parseMediaURL(from: components) else {
-            logger.warning("deep link open rejected: invalid media url")
-            return
-        }
-        playDirectURL(mediaURL)
-        logger.info("deep link open accepted: \(mediaURL.absoluteString)")
     }
 
     private func handlePluginDeepLink(components: URLComponents) {
@@ -399,47 +421,4 @@ final class AppModel {
         }
     }
 
-    private func parseMediaURL(from components: URLComponents) -> URL? {
-        guard let rawValue = components.queryItems?.first(where: { $0.name == "url" })?.value else {
-            return nil
-        }
-
-        let candidate = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !candidate.isEmpty else { return nil }
-
-        if let parsedURL = validatedMediaURL(from: candidate) {
-            return parsedURL
-        }
-
-        if let decodedCandidate = candidate.removingPercentEncoding,
-            decodedCandidate != candidate,
-            let parsedURL = validatedMediaURL(from: decodedCandidate)
-        {
-            return parsedURL
-        }
-
-        return nil
-    }
-
-    private func validatedMediaURL(from candidate: String) -> URL? {
-        guard let parsedURL = URL(string: candidate),
-            let scheme = parsedURL.scheme?.lowercased(),
-            scheme == "http" || scheme == "https"
-        else {
-            return nil
-        }
-        return parsedURL
-    }
-
-    private func playDirectURL(_ url: URL) {
-        let playable = Playable(
-            streamURL: url,
-            source: .directURL(url)
-        )
-        #if os(macOS)
-            NotificationCenter.default.post(name: .requestOpenPlayable, object: playable)
-        #else
-            playerState.play(playable: playable)
-        #endif
-    }
 }

--- a/kiririn/Features/Player/PlaybackOpenCoordinator.swift
+++ b/kiririn/Features/Player/PlaybackOpenCoordinator.swift
@@ -1,0 +1,347 @@
+import Foundation
+import KppxKit
+import Logging
+
+@MainActor
+final class PlaybackOpenCoordinator {
+    private enum Target: Hashable {
+        case url(String)
+        case service(networkId: Int, serviceId: Int)
+    }
+
+    private let logger = Logger(label: "PlaybackOpenCoordinator")
+    private let manager: ServerManager
+    private let playerState: PlayerState
+    private var activePlayerStates: [PlayerState] = []
+    private var managerSetupWaiter: @MainActor () async -> Void = {}
+    private var pendingOpenTasks: [Target: Task<Void, Error>] = [:]
+    #if os(macOS)
+        private static let pendingOpenTargetTimeout: Duration = .seconds(5)
+        private var pendingOpenTargets: Set<Target> = []
+        private var pendingOpenTargetExpirationTasks: [Target: Task<Void, Never>] = [:]
+    #endif
+
+    init(manager: ServerManager, playerState: PlayerState) {
+        self.manager = manager
+        self.playerState = playerState
+    }
+
+    func configureManagerSetupWaiter(_ waiter: @escaping @MainActor () async -> Void) {
+        managerSetupWaiter = waiter
+    }
+
+    func register(_ state: PlayerState) {
+        guard !activePlayerStates.contains(where: { $0 === state }) else { return }
+        activePlayerStates.append(state)
+    }
+
+    func unregister(_ state: PlayerState) {
+        activePlayerStates.removeAll { $0 === state }
+    }
+
+    func openURL(_ rawURL: String) async throws {
+        guard let url = Self.validatedMediaURL(from: rawURL) else {
+            throw KiririnOpenError.invalidURL
+        }
+
+        let target = Target.url(url.absoluteString)
+        try await executeOpenRequest(target: target) { [weak self] in
+            guard let self else { throw KiririnOpenError.invalidURL }
+            try self.performOpenURL(url, target: target)
+        }
+    }
+
+    func openService(_ request: ServiceOpenRequest) async throws {
+        guard
+            ServiceOpenRequest.isValidIdentifier(request.networkId),
+            ServiceOpenRequest.isValidIdentifier(request.serviceId)
+        else {
+            throw KiririnOpenError.invalidService
+        }
+
+        let preferredServerId = request.preferredServerId?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        let normalizedRequest = ServiceOpenRequest(
+            networkId: request.networkId,
+            serviceId: request.serviceId,
+            preferredServerId: preferredServerId?.isEmpty == false ? preferredServerId : nil
+        )
+        let target = Target.service(
+            networkId: normalizedRequest.networkId,
+            serviceId: normalizedRequest.serviceId
+        )
+
+        try await executeOpenRequest(target: target) { [weak self] in
+            guard let self else { throw KiririnOpenError.serviceUnavailable }
+            try await self.performOpenService(normalizedRequest, target: target)
+        }
+    }
+
+    #if os(macOS)
+        func markOpenRequestStarted(for playable: Playable) {
+            guard let target = openTarget(for: playable) else { return }
+            clearPendingOpenTarget(target)
+        }
+    #endif
+
+    func handleOpenDeepLink(components: URLComponents) {
+        let pathComponents = components.path.split(separator: "/").map(String.init)
+        switch pathComponents {
+        case []:
+            handleURLDeepLink(components: components)
+        case ["service"]:
+            handleServiceDeepLink(components: components)
+        default:
+            logger.warning("deep link open rejected: unsupported path")
+        }
+    }
+
+    private func handleURLDeepLink(components: URLComponents) {
+        guard let mediaURL = parseMediaURL(from: components) else {
+            logger.warning("deep link open rejected: invalid media url")
+            return
+        }
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                try await openURL(mediaURL.absoluteString)
+            } catch {
+                logger.warning("deep link open rejected: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func handleServiceDeepLink(components: URLComponents) {
+        guard let request = ServiceOpenRequest(components: components) else {
+            logger.warning("deep link service rejected: invalid parameters")
+            return
+        }
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                try await openService(request)
+            } catch {
+                logger.warning("deep link service rejected: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func executeOpenRequest(
+        target: Target,
+        operation: @escaping @MainActor () async throws -> Void
+    ) async throws {
+        if isAlreadyOpen(target) {
+            return
+        }
+
+        if let pendingTask = pendingOpenTasks[target] {
+            try await pendingTask.value
+            return
+        }
+
+        let task = Task { @MainActor in
+            try await operation()
+        }
+        pendingOpenTasks[target] = task
+
+        do {
+            try await task.value
+            pendingOpenTasks.removeValue(forKey: target)
+        } catch {
+            pendingOpenTasks.removeValue(forKey: target)
+            throw error
+        }
+    }
+
+    private func isAlreadyOpen(_ target: Target) -> Bool {
+        #if os(macOS)
+            if pendingOpenTargets.contains(target) {
+                return true
+            }
+        #endif
+
+        for state in activePlayerStates {
+            guard let playable = state.currentPlayable else { continue }
+            switch target {
+            case .url(let expectedURL):
+                guard case .directURL(let currentURL) = playable.source,
+                    let normalizedURL = Self.validatedMediaURL(from: currentURL.absoluteString),
+                    normalizedURL.absoluteString == expectedURL
+                else {
+                    continue
+                }
+                return true
+            case .service(let networkId, let serviceId):
+                guard case .liveService = playable.source,
+                    let service = playable.displayService,
+                    service.networkId == networkId,
+                    service.serviceId == serviceId
+                else {
+                    continue
+                }
+                return true
+            }
+        }
+        return false
+    }
+
+    private func performOpenURL(_ url: URL, target: Target) throws {
+        guard !isAlreadyOpen(target) else { return }
+
+        let playable = Playable(
+            streamURL: url,
+            source: .directURL(url)
+        )
+        dispatchOpenPlayable(playable, target: target)
+        logger.info("open URL accepted: \(url.absoluteString)")
+    }
+
+    private func performOpenService(
+        _ request: ServiceOpenRequest,
+        target: Target
+    ) async throws {
+        await managerSetupWaiter()
+
+        let candidates = manager.playbackCandidates(
+            networkId: request.networkId,
+            serviceId: request.serviceId,
+            preferredServerId: request.preferredServerId
+        )
+        guard !candidates.isEmpty else {
+            throw KiririnOpenError.serviceNotFound
+        }
+
+        for initialCandidate in candidates {
+            var candidate = initialCandidate
+            if manager.connectionStates[candidate.serverId]?.status != .connected {
+                _ = await manager.connect(serverId: candidate.serverId)
+                guard manager.connectionStates[candidate.serverId]?.status == .connected else {
+                    continue
+                }
+                guard
+                    let refreshedCandidate = manager.playbackCandidates(
+                        networkId: request.networkId,
+                        serviceId: request.serviceId,
+                        preferredServerId: candidate.serverId
+                    ).first(where: { $0.serverId == candidate.serverId })
+                else {
+                    continue
+                }
+                candidate = refreshedCandidate
+            }
+
+            guard let provider = manager.liveProvider(for: candidate.serverId) else {
+                continue
+            }
+            let currentProgram = await manager.currentProgram(for: candidate)
+            guard
+                let playable = try? provider.buildLiveStreamPlayable(
+                    service: candidate,
+                    currentProgram: currentProgram
+                )
+            else {
+                continue
+            }
+
+            if isAlreadyOpen(target) {
+                return
+            }
+
+            dispatchOpenPlayable(playable, target: target)
+            logger.info(
+                "open service accepted: networkId=\(request.networkId), serviceId=\(request.serviceId), serverId=\(candidate.serverId)"
+            )
+            return
+        }
+
+        throw KiririnOpenError.serviceUnavailable
+    }
+
+    private func dispatchOpenPlayable(_ playable: Playable, target: Target) {
+        #if os(macOS)
+            markPendingOpenTarget(target)
+            NotificationCenter.default.post(name: .requestOpenPlayable, object: playable)
+        #else
+            playerState.play(playable: playable)
+        #endif
+    }
+
+    #if os(macOS)
+        private func markPendingOpenTarget(_ target: Target) {
+            pendingOpenTargets.insert(target)
+            pendingOpenTargetExpirationTasks.removeValue(forKey: target)?.cancel()
+            pendingOpenTargetExpirationTasks[target] = Task { @MainActor [weak self] in
+                do {
+                    try await Task.sleep(for: Self.pendingOpenTargetTimeout)
+                } catch {
+                    return
+                }
+
+                guard let self, pendingOpenTargets.remove(target) != nil else { return }
+                pendingOpenTargetExpirationTasks.removeValue(forKey: target)
+                logger.warning(
+                    "open request expired before playback started: \(String(describing: target))")
+            }
+        }
+
+        private func clearPendingOpenTarget(_ target: Target) {
+            pendingOpenTargets.remove(target)
+            pendingOpenTargetExpirationTasks.removeValue(forKey: target)?.cancel()
+        }
+
+        private func openTarget(for playable: Playable) -> Target? {
+            switch playable.source {
+            case .directURL(let url):
+                guard let normalizedURL = Self.validatedMediaURL(from: url.absoluteString) else {
+                    return nil
+                }
+                return .url(normalizedURL.absoluteString)
+            case .liveService:
+                guard let service = playable.displayService else { return nil }
+                return .service(networkId: service.networkId, serviceId: service.serviceId)
+            case .recordedFile, .fileURL:
+                return nil
+            }
+        }
+    #endif
+
+    private func parseMediaURL(from components: URLComponents) -> URL? {
+        guard let rawValue = components.queryItems?.first(where: { $0.name == "url" })?.value else {
+            return nil
+        }
+
+        let candidate = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !candidate.isEmpty else { return nil }
+
+        if let parsedURL = Self.validatedMediaURL(from: candidate) {
+            return parsedURL
+        }
+
+        if let decodedCandidate = candidate.removingPercentEncoding,
+            decodedCandidate != candidate,
+            let parsedURL = Self.validatedMediaURL(from: decodedCandidate)
+        {
+            return parsedURL
+        }
+
+        return nil
+    }
+
+    nonisolated static func validatedMediaURL(from candidate: String) -> URL? {
+        let trimmedCandidate = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard var components = URLComponents(string: trimmedCandidate),
+            let scheme = components.scheme?.lowercased(),
+            scheme == "http" || scheme == "https",
+            let host = components.host,
+            !host.isEmpty
+        else {
+            return nil
+        }
+
+        components.scheme = scheme
+        return components.url
+    }
+}

--- a/kiririn/Features/Player/macOS/PlayerWindowView.swift
+++ b/kiririn/Features/Player/macOS/PlayerWindowView.swift
@@ -74,7 +74,7 @@
                 playerState.plugins = newPlugins
             }
             .onAppear {
-                appModel.activePlayerStates.append(playerState)
+                appModel.registerActivePlayerState(playerState)
                 appModel.focusedPlayerID = playerState.id
                 appModel.setupIfNeeded()
                 appModel.configureDetachedPlayerState(playerState)
@@ -125,7 +125,7 @@
             .onDisappear {
                 appModel.remoteControlService.unregisterWindowEndpoint(playerID: playerState.id)
                 remoteEndpoint = nil
-                appModel.activePlayerStates.removeAll { $0 === playerState }
+                appModel.unregisterActivePlayerState(playerState)
                 if appModel.focusedPlayerID == playerState.id {
                     appModel.focusedPlayerID = nil
                 }
@@ -250,11 +250,13 @@
             restorationWaitTask?.cancel()
             restorationWaitTask = nil
             if playerState.currentPlayable?.id == playable.id {
+                appModel.openRequestCoordinator.markOpenRequestStarted(for: playable)
                 logger.debug("playback already active (\(trigger)): id=\(playable.id)")
                 return
             }
             logWindowContext(trigger: trigger, playable: playable)
             playerState.play(playable: playable)
+            appModel.openRequestCoordinator.markOpenRequestStarted(for: playable)
         }
 
         private func scheduleRestorationFallbackIfNeeded() {

--- a/kiririn/Features/Plugin/PluginWebView.swift
+++ b/kiririn/Features/Plugin/PluginWebView.swift
@@ -193,7 +193,7 @@ struct PluginWebView: PluginWebViewRepresentable {
             "appVersion": appVersion ?? NSNull(),
             "buildVersion": buildVersion,
             "bundleIdentifier": bundle.bundleIdentifier ?? NSNull(),
-            "bridgeVersion": 6,
+            "bridgeVersion": 7,
             "displayAreaType": displayArea.rawValue,
             "playerID": runtimePlayerID,
         ]
@@ -392,6 +392,7 @@ struct PluginWebView: PluginWebViewRepresentable {
                 _runtimeInfo: \(runtimeInfoString),
                 _safeAreaInsets: \(safeAreaInsetsString),
                 _deeplinkOpenedListeners: [],
+                _openResolvers: Object.create(null),
                 _captureTakenListeners: [],
                 _captureBlobResolvers: Object.create(null),
                 _captureEventsSubscribed: false,
@@ -471,6 +472,14 @@ struct PluginWebView: PluginWebViewRepresentable {
                     window.webkit.messageHandlers.kiririn.postMessage({type: type, data: data});
                 },
 
+                openURL: function(url) {
+                    return this._performOpenURLRequest(url);
+                },
+
+                openService: function(request) {
+                    return this._performOpenServiceRequest(request);
+                },
+
                 play: function(playerID) {
                     window.webkit.messageHandlers.kiririn.postMessage({type: 'player:play', data: {playerID: playerID || null}});
                 },
@@ -493,6 +502,29 @@ struct PluginWebView: PluginWebViewRepresentable {
 
                 getCaptureBlob: function(captureID, variant) {
                     return this._performCaptureBlobRequest(captureID, variant);
+                },
+
+                _resolveOpenRequest: function(requestID) {
+                    const pending = this._openResolvers[requestID];
+                    if (!pending) { return; }
+                    delete this._openResolvers[requestID];
+                    pending.resolve();
+                },
+
+                _rejectOpenRequest: function(requestID, payload) {
+                    const pending = this._openResolvers[requestID];
+                    if (!pending) { return; }
+                    delete this._openResolvers[requestID];
+
+                    const error = new Error(
+                        payload && typeof payload.message === 'string'
+                            ? payload.message
+                            : 'Kiririn open request failed'
+                    );
+                    error.name = payload && payload.name || 'KiririnOpenError';
+                    error.operation = payload && payload.operation;
+                    error.code = payload && payload.code;
+                    pending.reject(error);
                 },
 
                 _resolveCaptureBlob: function(requestID, payload) {
@@ -526,6 +558,53 @@ struct PluginWebView: PluginWebViewRepresentable {
                     pending.reject(new TypeError(message || 'Capture blob request failed'));
                 }
             };
+
+            (function() {
+                let nextOpenRequestID = 0;
+                function bridgeUnavailable() {
+                    return Promise.reject(new TypeError('Kiririn bridge is unavailable'));
+                }
+
+                window.kiririn._performOpenURLRequest = function(url) {
+                    if (!window.webkit || !window.webkit.messageHandlers || !window.webkit.messageHandlers.kiririn) {
+                        return bridgeUnavailable();
+                    }
+
+                    return new Promise(function(resolve, reject) {
+                        const requestID = 'open-' + (++nextOpenRequestID);
+                        window.kiririn._openResolvers[requestID] = {
+                            resolve: resolve,
+                            reject: reject
+                        };
+                        window.webkit.messageHandlers.kiririn.postMessage({
+                            type: '_openURLRequest',
+                            data: {
+                                requestID: requestID,
+                                url: url
+                            }
+                        });
+                    });
+                };
+
+                window.kiririn._performOpenServiceRequest = function(request) {
+                    if (!window.webkit || !window.webkit.messageHandlers || !window.webkit.messageHandlers.kiririn) {
+                        return bridgeUnavailable();
+                    }
+
+                    const serviceRequest = request && typeof request === 'object' ? request : {};
+                    return new Promise(function(resolve, reject) {
+                        const requestID = 'open-' + (++nextOpenRequestID);
+                        window.kiririn._openResolvers[requestID] = {
+                            resolve: resolve,
+                            reject: reject
+                        };
+                        window.webkit.messageHandlers.kiririn.postMessage({
+                            type: '_openServiceRequest',
+                            data: Object.assign({}, serviceRequest, {requestID: requestID})
+                        });
+                    });
+                };
+            })();
 
             (function() {
                 let nextCaptureBlobRequestID = 0;
@@ -694,7 +773,13 @@ struct PluginWebView: PluginWebViewRepresentable {
                     let type = body["type"] as? String
                 else { return }
 
-                if type == "_captureTakenSubscribe" {
+                if type == "_openURLRequest" {
+                    guard let data = body["data"] as? [String: Any] else { return }
+                    await handleOpenURLRequest(data)
+                } else if type == "_openServiceRequest" {
+                    guard let data = body["data"] as? [String: Any] else { return }
+                    await handleOpenServiceRequest(data)
+                } else if type == "_captureTakenSubscribe" {
                     wantsCaptureEvents = true
                     subscribeToCaptureEventsIfNeeded()
                 } else if type == "_captureBlobRequest" {
@@ -736,6 +821,69 @@ struct PluginWebView: PluginWebViewRepresentable {
                     }
                 }
             }
+        }
+
+        @MainActor
+        private func handleOpenURLRequest(_ data: [String: Any]) async {
+            guard let requestID = data["requestID"] as? String else { return }
+            guard let rawURL = data["url"] as? String else {
+                rejectOpenRequest(requestID: requestID, error: .invalidURL)
+                return
+            }
+            guard let coordinator = parent?.appModel.openRequestCoordinator else {
+                rejectOpenRequest(requestID: requestID, error: .invalidURL)
+                return
+            }
+
+            do {
+                try await coordinator.openURL(rawURL)
+                resolveOpenRequest(requestID: requestID)
+            } catch let error as KiririnOpenError {
+                rejectOpenRequest(requestID: requestID, error: error)
+            } catch {
+                rejectOpenRequest(requestID: requestID, error: .invalidURL)
+            }
+        }
+
+        @MainActor
+        private func handleOpenServiceRequest(_ data: [String: Any]) async {
+            guard let requestID = data["requestID"] as? String else { return }
+            guard let networkId = Self.integerValue(data["networkId"]),
+                let serviceId = Self.integerValue(data["serviceId"])
+            else {
+                rejectOpenRequest(requestID: requestID, error: .invalidService)
+                return
+            }
+
+            let serverId = (data["serverId"] as? String)?.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            )
+            guard let coordinator = parent?.appModel.openRequestCoordinator else {
+                rejectOpenRequest(requestID: requestID, error: .serviceUnavailable)
+                return
+            }
+
+            do {
+                try await coordinator.openService(
+                    ServiceOpenRequest(
+                        networkId: networkId,
+                        serviceId: serviceId,
+                        preferredServerId: serverId?.isEmpty == false ? serverId : nil
+                    )
+                )
+                resolveOpenRequest(requestID: requestID)
+            } catch let error as KiririnOpenError {
+                rejectOpenRequest(requestID: requestID, error: error)
+            } catch {
+                rejectOpenRequest(requestID: requestID, error: .serviceUnavailable)
+            }
+        }
+
+        nonisolated private static func integerValue(_ value: Any?) -> Int? {
+            guard let number = value as? NSNumber, !(value is Bool) else { return nil }
+            let doubleValue = number.doubleValue
+            guard doubleValue.isFinite, doubleValue.rounded() == doubleValue else { return nil }
+            return Int(exactly: doubleValue)
         }
 
         @MainActor
@@ -867,6 +1015,29 @@ struct PluginWebView: PluginWebViewRepresentable {
 
             evaluateJavaScript(
                 "if (window.kiririn && window.kiririn._rejectCaptureBlob) { window.kiririn._rejectCaptureBlob(\(requestIDLiteral), \(messageLiteral)); }"
+            )
+        }
+
+        private func resolveOpenRequest(requestID: String) {
+            guard let requestIDLiteral = Self.javaScriptStringLiteral(requestID) else { return }
+
+            evaluateJavaScript(
+                "if (window.kiririn && window.kiririn._resolveOpenRequest) { window.kiririn._resolveOpenRequest(\(requestIDLiteral)); }"
+            )
+        }
+
+        private func rejectOpenRequest(requestID: String, error: KiririnOpenError) {
+            guard let requestIDLiteral = Self.javaScriptStringLiteral(requestID),
+                let payloadLiteral = Self.javaScriptObjectLiteral([
+                    "name": "KiririnOpenError",
+                    "operation": error.operation,
+                    "code": error.code,
+                    "message": error.localizedDescription,
+                ])
+            else { return }
+
+            evaluateJavaScript(
+                "if (window.kiririn && window.kiririn._rejectOpenRequest) { window.kiririn._rejectOpenRequest(\(requestIDLiteral), \(payloadLiteral)); }"
             )
         }
 

--- a/kiririn/Features/ProgramGuide/ProgramGuideView.swift
+++ b/kiririn/Features/ProgramGuide/ProgramGuideView.swift
@@ -740,6 +740,7 @@ struct ProgramGuideView: View {
                         .font(.subheadline)
                         .fontWeight(.semibold)
                         .lineLimit(1)
+                        .serviceOpenLinkContextMenu(for: service)
 
                     Spacer(minLength: 0)
                 }

--- a/kiririn/Features/Server/ServerManager.swift
+++ b/kiririn/Features/Server/ServerManager.swift
@@ -28,6 +28,27 @@ nonisolated enum ProgramCatalogRefreshPolicy: Sendable {
     case automaticIfDue
     case force
     case forceIgnoringNetwork
+
+    func merged(with other: Self) -> Self {
+        priority >= other.priority ? self : other
+    }
+
+    func satisfies(_ other: Self) -> Bool {
+        priority >= other.priority
+    }
+
+    private var priority: Int {
+        switch self {
+        case .none:
+            0
+        case .automaticIfDue:
+            1
+        case .force:
+            2
+        case .forceIgnoringNetwork:
+            3
+        }
+    }
 }
 
 nonisolated enum ManualProgramCatalogRefreshResult: Sendable, Equatable {
@@ -94,6 +115,10 @@ class ServerManager {
     @ObservationIgnored
     private var periodicProgramRefreshTask: Task<Void, Never>?
     @ObservationIgnored
+    private var connectionTasks: [String: Task<ProgramCatalogRefreshExecutionResult, Never>] = [:]
+    @ObservationIgnored
+    private var requestedConnectionRefreshPolicies: [String: ProgramCatalogRefreshPolicy] = [:]
+    @ObservationIgnored
     private var serverOperationGenerations: [String: Int] = [:]
     @ObservationIgnored
     private var isAutomaticProgramRefreshEvaluationRunning = false
@@ -132,6 +157,9 @@ class ServerManager {
     }
 
     deinit {
+        for task in connectionTasks.values {
+            task.cancel()
+        }
         periodicProgramRefreshTask?.cancel()
         #if !os(macOS)
             networkMonitor?.cancel()
@@ -310,6 +338,52 @@ class ServerManager {
     func connect(
         serverId: String,
         programRefreshPolicy: ProgramCatalogRefreshPolicy = .none
+    ) async -> ProgramCatalogRefreshExecutionResult {
+        if let existingTask = connectionTasks[serverId] {
+            let pendingPolicy = requestedConnectionRefreshPolicies[serverId] ?? .none
+            requestedConnectionRefreshPolicies[serverId] = pendingPolicy.merged(
+                with: programRefreshPolicy
+            )
+            return await existingTask.value
+        }
+
+        requestedConnectionRefreshPolicies[serverId] = programRefreshPolicy
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return ProgramCatalogRefreshExecutionResult.skipped }
+            defer {
+                self.connectionTasks.removeValue(forKey: serverId)
+                self.requestedConnectionRefreshPolicies.removeValue(forKey: serverId)
+            }
+
+            let initialPolicy =
+                self.requestedConnectionRefreshPolicies[serverId]
+                ?? programRefreshPolicy
+            var satisfiedPolicy = initialPolicy
+            var result = await self.performConnect(
+                serverId: serverId,
+                programRefreshPolicy: initialPolicy
+            )
+
+            while let requestedPolicy = self.requestedConnectionRefreshPolicies[serverId],
+                !satisfiedPolicy.satisfies(requestedPolicy),
+                self.connectionStates[serverId]?.status == .connected
+            {
+                result = await self.refreshData(
+                    serverId: serverId,
+                    programRefreshPolicy: requestedPolicy
+                )
+                satisfiedPolicy = requestedPolicy
+            }
+
+            return result
+        }
+        connectionTasks[serverId] = task
+        return await task.value
+    }
+
+    private func performConnect(
+        serverId: String,
+        programRefreshPolicy: ProgramCatalogRefreshPolicy
     ) async -> ProgramCatalogRefreshExecutionResult {
         let generation = operationGeneration(for: serverId)
         guard let provider = providers[serverId],
@@ -949,6 +1023,40 @@ class ServerManager {
 
     func playbackCandidates(for service: TVService) -> [TVService] {
         candidateServices(for: service)
+    }
+
+    func playbackCandidates(
+        networkId: Int,
+        serviceId: Int,
+        preferredServerId: String?
+    ) -> [TVService] {
+        var candidatesByServerId: [String: TVService] = [:]
+        for service in cachedServicesByServer.values.flatMap({ $0 }) {
+            guard service.networkId == networkId,
+                service.serviceId == serviceId,
+                isServerEnabled(service.serverId),
+                serverSupports(.live, serverId: service.serverId)
+            else {
+                continue
+            }
+            candidatesByServerId[service.serverId] = service
+        }
+
+        let sortedCandidates = sortServicesByServerPriority(
+            Array(candidatesByServerId.values)
+        )
+        guard let preferredServerId,
+            let preferredIndex = sortedCandidates.firstIndex(where: {
+                $0.serverId == preferredServerId
+            })
+        else {
+            return sortedCandidates
+        }
+
+        let preferred = sortedCandidates[preferredIndex]
+        return [preferred]
+            + Array(sortedCandidates.prefix(preferredIndex))
+            + Array(sortedCandidates.dropFirst(preferredIndex + 1))
     }
 
     func connectedPlaybackCandidates(for service: TVService) -> [TVService] {

--- a/kiririn/Features/Services/ServiceListView.swift
+++ b/kiririn/Features/Services/ServiceListView.swift
@@ -1129,6 +1129,7 @@ struct ServiceRowView: View {
                             .fontWeight(.medium)
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
+                            .serviceOpenLinkContextMenu(for: service)
 
                         if hasDifferentChildProgram {
                             HStack(spacing: 2) {

--- a/kiririn/Shared/Models/KiririnOpenRequest.swift
+++ b/kiririn/Shared/Models/KiririnOpenRequest.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+nonisolated enum KiririnOpenError: LocalizedError, Equatable, Sendable {
+    case invalidURL
+    case invalidService
+    case serviceNotFound
+    case serviceUnavailable
+
+    var operation: String {
+        switch self {
+        case .invalidURL:
+            return "openURL"
+        case .invalidService, .serviceNotFound, .serviceUnavailable:
+            return "openService"
+        }
+    }
+
+    var code: String {
+        switch self {
+        case .invalidURL:
+            return "invalidURL"
+        case .invalidService:
+            return "invalidService"
+        case .serviceNotFound:
+            return "serviceNotFound"
+        case .serviceUnavailable:
+            return "serviceUnavailable"
+        }
+    }
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "再生するURLが不正です"
+        case .invalidService:
+            return "サービス指定が不正です"
+        case .serviceNotFound:
+            return "指定されたサービスが見つかりません"
+        case .serviceUnavailable:
+            return "指定されたサービスを再生できるサーバーがありません"
+        }
+    }
+}
+
+nonisolated struct ServiceOpenRequest: Equatable, Sendable {
+    let networkId: Int
+    let serviceId: Int
+    let preferredServerId: String?
+
+    init(networkId: Int, serviceId: Int, preferredServerId: String? = nil) {
+        self.networkId = networkId
+        self.serviceId = serviceId
+        self.preferredServerId = preferredServerId
+    }
+
+    var deepLinkURL: URL? {
+        guard Self.isValidIdentifier(networkId), Self.isValidIdentifier(serviceId) else {
+            return nil
+        }
+
+        var components = URLComponents()
+        components.scheme = "kiririn"
+        components.host = "open"
+        components.path = "/service"
+        components.queryItems = [
+            URLQueryItem(name: "networkId", value: String(networkId)),
+            URLQueryItem(name: "serviceId", value: String(serviceId)),
+        ]
+
+        if let preferredServerId, !preferredServerId.isEmpty {
+            components.queryItems?.append(
+                URLQueryItem(name: "serverId", value: preferredServerId)
+            )
+        }
+
+        return components.url
+    }
+
+    init?(components: URLComponents) {
+        guard
+            let networkId = Self.integerQueryValue(
+                named: "networkId", in: components.queryItems),
+            let serviceId = Self.integerQueryValue(
+                named: "serviceId", in: components.queryItems),
+            Self.isValidIdentifier(networkId),
+            Self.isValidIdentifier(serviceId)
+        else {
+            return nil
+        }
+
+        let preferredServerId = components.queryItems?
+            .first(where: { $0.name == "serverId" })?.value?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        self.init(
+            networkId: networkId,
+            serviceId: serviceId,
+            preferredServerId: preferredServerId?.isEmpty == false ? preferredServerId : nil
+        )
+    }
+
+    static func isValidIdentifier(_ value: Int) -> Bool {
+        (0...Int(UInt16.max)).contains(value)
+    }
+
+    private static func integerQueryValue(
+        named name: String,
+        in queryItems: [URLQueryItem]?
+    ) -> Int? {
+        guard let value = queryItems?.first(where: { $0.name == name })?.value,
+            let integer = Int(value.trimmingCharacters(in: .whitespacesAndNewlines))
+        else {
+            return nil
+        }
+        return integer
+    }
+}

--- a/kiririn/Shared/UI/ServiceOpenLinkContextMenu.swift
+++ b/kiririn/Shared/UI/ServiceOpenLinkContextMenu.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+private struct ServiceOpenLinkContextMenuModifier: ViewModifier {
+    let service: TVService
+
+    func body(content: Content) -> some View {
+        content.contextMenu {
+            if let url = serviceOpenLinkURL {
+                Button {
+                    copyTextToClipboard(url.absoluteString)
+                } label: {
+                    Label {
+                        Text("リンクをコピー")
+                    } icon: {
+                        accentMenuIcon(systemName: "link")
+                    }
+                }
+            }
+        }
+    }
+
+    private var serviceOpenLinkURL: URL? {
+        ServiceOpenRequest(
+            networkId: service.networkId,
+            serviceId: service.serviceId,
+            preferredServerId: service.serverId
+        ).deepLinkURL
+    }
+}
+
+extension View {
+    func serviceOpenLinkContextMenu(for service: TVService) -> some View {
+        modifier(ServiceOpenLinkContextMenuModifier(service: service))
+    }
+}

--- a/kiririnTests/KiririnOpenRequestTests.swift
+++ b/kiririnTests/KiririnOpenRequestTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+
+@testable import kiririn
+
+struct KiririnOpenRequestTests {
+    @Test func parsesServiceDeepLinkRequest() throws {
+        let url = try #require(
+            URL(string: "kiririn://open/service?networkId=32736&serviceId=1024&serverId=server-a")
+        )
+        let components = try #require(
+            URLComponents(url: url, resolvingAgainstBaseURL: false)
+        )
+
+        #expect(components.host == "open")
+        #expect(components.path == "/service")
+        #expect(
+            ServiceOpenRequest(components: components)
+                == ServiceOpenRequest(
+                    networkId: 32736,
+                    serviceId: 1024,
+                    preferredServerId: "server-a"
+                )
+        )
+    }
+
+    @Test func rejectsInvalidServiceIdentifiers() throws {
+        let url = try #require(
+            URL(string: "kiririn://open/service?networkId=65536&serviceId=1024")
+        )
+        let components = try #require(
+            URLComponents(url: url, resolvingAgainstBaseURL: false)
+        )
+
+        #expect(ServiceOpenRequest(components: components) == nil)
+    }
+
+    @Test func emptyPreferredServerIDIsIgnored() throws {
+        let url = try #require(
+            URL(string: "kiririn://open/service?networkId=1&serviceId=2&serverId=%20")
+        )
+        let components = try #require(
+            URLComponents(url: url, resolvingAgainstBaseURL: false)
+        )
+
+        #expect(
+            ServiceOpenRequest(components: components)
+                == ServiceOpenRequest(networkId: 1, serviceId: 2)
+        )
+    }
+
+    @Test func buildsServiceDeepLinkURL() throws {
+        let url = try #require(
+            ServiceOpenRequest(
+                networkId: 32736,
+                serviceId: 1024,
+                preferredServerId: "server-a"
+            ).deepLinkURL
+        )
+
+        #expect(
+            url.absoluteString
+                == "kiririn://open/service?networkId=32736&serviceId=1024&serverId=server-a"
+        )
+    }
+
+    @Test func openErrorsExposeOperationAndCode() {
+        #expect(KiririnOpenError.invalidURL.operation == "openURL")
+        #expect(KiririnOpenError.invalidURL.code == "invalidURL")
+        #expect(KiririnOpenError.serviceNotFound.operation == "openService")
+        #expect(KiririnOpenError.serviceNotFound.code == "serviceNotFound")
+    }
+
+    @Test(arguments: [
+        "http:stream.ts",
+        "https:/stream.ts",
+        "https://",
+        "ftp://example.com/stream.ts",
+    ])
+    func rejectsMediaURLsWithoutAnHTTPHost(_ rawURL: String) {
+        #expect(PlaybackOpenCoordinator.validatedMediaURL(from: rawURL) == nil)
+    }
+
+    @Test func acceptsAndNormalizesHTTPMediaURL() throws {
+        let url = try #require(
+            PlaybackOpenCoordinator.validatedMediaURL(
+                from: " HTTPS://example.com/live.ts "
+            )
+        )
+
+        #expect(url.absoluteString == "https://example.com/live.ts")
+    }
+}

--- a/kiririnTests/ModelBehaviorTests.swift
+++ b/kiririnTests/ModelBehaviorTests.swift
@@ -253,6 +253,23 @@ struct ModelBehaviorTests {
         )
     }
 
+    @Test func programCatalogRefreshPolicyMergesToStrongestRequest() {
+        #expect(
+            ProgramCatalogRefreshPolicy.none.merged(with: .automaticIfDue)
+                == .automaticIfDue
+        )
+        #expect(
+            ProgramCatalogRefreshPolicy.automaticIfDue.merged(with: .force)
+                == .force
+        )
+        #expect(
+            ProgramCatalogRefreshPolicy.force.merged(with: .forceIgnoringNetwork)
+                == .forceIgnoringNetwork
+        )
+        #expect(ProgramCatalogRefreshPolicy.force.satisfies(.automaticIfDue))
+        #expect(!ProgramCatalogRefreshPolicy.force.satisfies(.forceIgnoringNetwork))
+    }
+
     @Test func playableSourceLegacyDirectURLArrayDecodesFileURLsAsFileSource() throws {
         let url = URL(filePath: "/tmp/video.ts")
         let jsonData = "{\"directURL\":[\"\(url.absoluteString)\",null]}".data(using: .utf8)!


### PR DESCRIPTION
Fixes #7

## Sourceryによる概要

プラグインとDeep LinkからメディアURLおよび放送サービスを開ける再生起動機能を追加する。

新機能:
- プラグインからHTTP/HTTPSメディアURLや放送サービスをプレイヤーで開く機能を追加する。
- 放送サービスを開くDeep Linkと、サービス用Deep Linkをコピーするコンテキストメニューを追加する。

機能強化:
- URL・サービスの重複した再生要求を抑制し、サーバー接続や再生候補のフォールバックを統合的に扱う。
- プラグインBridgeをv0.4.0、bridgeVersion 7へ更新し、操作結果と失敗理由をPromiseおよび安定したエラーコードで通知する。

ドキュメント:
- プラグイン仕様にURL・サービス起動API、Deep Link形式、エラーコードを追記する。

テスト:
- Deep Link解析、識別子検証、URL検証、エラーコード、更新ポリシー統合のテストを追加する。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

プラグインとDeep LinkからメディアURLおよび放送サービスを開ける再生起動機能を追加する。

New Features:
- プラグインからHTTP/HTTPSメディアURLや放送サービスをプレイヤーで開く機能を追加する。
- 放送サービスを開くDeep Linkと、サービス用Deep Linkをコピーするコンテキストメニューを追加する。

Enhancements:
- URL・サービスの重複した再生要求を抑制し、サーバー接続や再生候補のフォールバックを統合的に扱う。
- プラグインBridgeをv0.4.0、bridgeVersion 7へ更新し、操作結果と失敗理由をPromiseおよび安定したエラーコードで通知する。

Documentation:
- プラグイン仕様にURL・サービス起動API、Deep Link形式、エラーコードを追記する。

Tests:
- Deep Link解析、識別子検証、URL検証、エラーコード、更新ポリシー統合のテストを追加する。

</details>