### PR TITLE
chore: Sentryのリリース管理と連動するように

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,128 @@ jobs:
 
                   gh release upload "$TAG_NAME" "$ARCHIVE_ZIP" --clobber
 
+    sentry-release:
+        name: Sentry Release
+        if: startsWith(github.ref, 'refs/tags/')
+        needs: build
+        runs-on: macos-26
+        timeout-minutes: 20
+        permissions:
+            contents: read
+        env:
+            SENTRY_ORG: ci7lus
+            SENTRY_PROJECT: kiririn
+            SENTRY_CLI_VERSION: 3.6.2
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0
+
+            - name: Download iOS XCArchive
+              uses: actions/download-artifact@v8
+              with:
+                  name: kiririn-ios.xcarchive.zip
+                  path: ${{ runner.temp }}/sentry-archives/ios
+                  skip-decompress: true
+
+            - name: Download macOS XCArchive
+              uses: actions/download-artifact@v8
+              with:
+                  name: kiririn-macos.xcarchive.zip
+                  path: ${{ runner.temp }}/sentry-archives/macos
+                  skip-decompress: true
+
+            - name: Extract XCArchives
+              run: |
+                  for platform in ios macos; do
+                    archive_zip="$RUNNER_TEMP/sentry-archives/$platform/kiririn-$platform.xcarchive.zip"
+                    extract_dir="$RUNNER_TEMP/sentry-archives/$platform"
+
+                    if [ ! -f "$archive_zip" ]; then
+                      echo "::error::XCArchive ZIP not found: $archive_zip"
+                      exit 1
+                    fi
+
+                    unzip -q "$archive_zip" -d "$extract_dir"
+                  done
+
+            - name: Resolve Sentry release metadata
+              id: metadata
+              run: |
+                  archive_path="$RUNNER_TEMP/sentry-archives/ios/kiririn-ios.xcarchive"
+                  app_path="$(find "$archive_path/Products/Applications" -type d -name '*.app' -print -quit)"
+                  if [ -z "$app_path" ]; then
+                    echo "::error::No iOS app found in $archive_path"
+                    exit 1
+                  fi
+
+                  info_plist="$app_path/Info.plist"
+                  bundle_identifier="$(/usr/bin/plutil -extract CFBundleIdentifier raw -o - "$info_plist")"
+                  short_version="$(/usr/bin/plutil -extract CFBundleShortVersionString raw -o - "$info_plist")"
+                  build_number="$(/usr/bin/plutil -extract CFBundleVersion raw -o - "$info_plist")"
+                  release="${bundle_identifier}@${short_version}"
+
+                  if [ "$GITHUB_REF_NAME" != "v$short_version" ]; then
+                    echo "::error::Tag $GITHUB_REF_NAME does not match app version $short_version"
+                    exit 1
+                  fi
+
+                  macos_app_path="$RUNNER_TEMP/sentry-archives/macos/kiririn-macos.xcarchive/Products/Applications/kiririn.app"
+                  macos_info_plist="$macos_app_path/Contents/Info.plist"
+                  macos_bundle_identifier="$(/usr/bin/plutil -extract CFBundleIdentifier raw -o - "$macos_info_plist")"
+                  macos_short_version="$(/usr/bin/plutil -extract CFBundleShortVersionString raw -o - "$macos_info_plist")"
+
+                  if [ "$bundle_identifier" != "$macos_bundle_identifier" ] || [ "$short_version" != "$macos_short_version" ]; then
+                    echo "::error::iOS and macOS archives have different bundle or version metadata"
+                    exit 1
+                  fi
+
+                  {
+                    echo "bundle_identifier=$bundle_identifier"
+                    echo "release=$release"
+                    echo "build_number=$build_number"
+                  } >> "$GITHUB_OUTPUT"
+                  echo "Resolved Sentry release $release (iOS dist $build_number)"
+
+            - name: Create and finalize Sentry release
+              uses: getsentry/action-release@v3
+              env:
+                  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+                  SENTRY_ORG: ${{ env.SENTRY_ORG }}
+                  SENTRY_PROJECT: ${{ env.SENTRY_PROJECT }}
+              with:
+                  release: ${{ steps.metadata.outputs.release }}
+                  environment: production
+                  finalize: true
+                  set_commits: auto
+                  ignore_missing: true
+
+            - name: Install Sentry CLI
+              env:
+                  INSTALL_PATH: ${{ runner.temp }}/sentry-cli/sentry-cli
+              run: |
+                  mkdir -p "$(dirname "$INSTALL_PATH")"
+                  curl https://sentry.io/get-cli/ -fsSL \
+                    | INSTALL_PATH="$INSTALL_PATH" SENTRY_CLI_VERSION="$SENTRY_CLI_VERSION" sh
+                  dirname "$INSTALL_PATH" >> "$GITHUB_PATH"
+
+            - name: Upload iOS dSYMs
+              env:
+                  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+                  SENTRY_ORG: ${{ env.SENTRY_ORG }}
+                  SENTRY_PROJECT: ${{ env.SENTRY_PROJECT }}
+                  SENTRY_CLI_BIN: ${{ runner.temp }}/sentry-cli/sentry-cli
+              run: ./misc/upload-dsym-sentry.sh "$RUNNER_TEMP/sentry-archives/ios/kiririn-ios.xcarchive"
+
+            - name: Upload macOS dSYMs
+              env:
+                  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+                  SENTRY_ORG: ${{ env.SENTRY_ORG }}
+                  SENTRY_PROJECT: ${{ env.SENTRY_PROJECT }}
+                  SENTRY_CLI_BIN: ${{ runner.temp }}/sentry-cli/sentry-cli
+              run: ./misc/upload-dsym-sentry.sh "$RUNNER_TEMP/sentry-archives/macos/kiririn-macos.xcarchive"
+
     package-test:
         name: Test Packages
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}

--- a/kiririn/AppShell/kiririnApp.swift
+++ b/kiririn/AppShell/kiririnApp.swift
@@ -255,8 +255,13 @@ struct KiririnApp: App {
 
         static func initializeIfAvailable() {
             let buildInfo = AppBuildInfo.current
+            guard let bundleIdentifier = Bundle.main.bundleIdentifier else {
+                return
+            }
+
             SentrySDK.start { options in
                 options.dsn = dsn
+                options.releaseName = "\(bundleIdentifier)@\(buildInfo.version)"
                 options.enableNetworkBreadcrumbs = false
                 options.enableCaptureFailedRequests = false
                 options.enableNetworkTracking = false

--- a/misc/backfill-sentry-releases.sh
+++ b/misc/backfill-sentry-releases.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: misc/backfill-sentry-releases.sh [options]
+
+Create and finalize Sentry releases for version tags, and associate the
+commits between adjacent tags. The default mode is dry-run.
+
+Options:
+  --apply                 Apply the changes to Sentry.
+  --dry-run               Print commands without changing Sentry (default).
+  --tag TAG               Process only TAG. May be specified more than once.
+  --legacy-builds LIST    Additional build numbers for one tag, comma-separated.
+  -h, --help              Show this help.
+
+Environment:
+  SENTRY_AUTH_TOKEN       Sentry auth token for --apply.
+  SENTRY_ORG              Sentry organization (default: ci7lus).
+  SENTRY_PROJECT          Sentry project (default: kiririn).
+  SENTRY_REPOSITORY       Sentry repository name (default: ci7lus/kiririn).
+  SENTRY_BUNDLE_ID        Bundle identifier (default: jp.pronama.kiririn).
+  SENTRY_CLI_BIN          sentry-cli path (default: sentry-cli).
+  SENTRY_LEGACY_BUILD_NUMBERS
+                          Additional build numbers for one tag, comma-separated.
+
+The canonical release is <bundle-id>@<marketing-version>. Existing native
+release names ending in +<build> are also associated with the same tag when
+they are returned by `sentry-cli releases list --raw`.
+EOF
+}
+
+mode=dry-run
+requested_tags=()
+configured_builds=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply)
+      mode=apply
+      shift
+      ;;
+    --dry-run)
+      mode=dry-run
+      shift
+      ;;
+    --tag)
+      if [[ $# -lt 2 ]]; then
+        echo "--tag requires a tag name" >&2
+        exit 64
+      fi
+      requested_tags+=("$2")
+      shift 2
+      ;;
+    --legacy-builds)
+      if [[ $# -lt 2 ]]; then
+        echo "--legacy-builds requires a comma-separated list" >&2
+        exit 64
+      fi
+      IFS=',' read -r -a configured_builds <<< "$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+if [[ -n "${SENTRY_LEGACY_BUILD_NUMBERS:-}" ]]; then
+  IFS=',' read -r -a environment_builds <<< "$SENTRY_LEGACY_BUILD_NUMBERS"
+  configured_builds+=("${environment_builds[@]}")
+fi
+
+sentry_cli="${SENTRY_CLI_BIN:-sentry-cli}"
+sentry_org="${SENTRY_ORG:-ci7lus}"
+sentry_project="${SENTRY_PROJECT:-kiririn}"
+sentry_repository="${SENTRY_REPOSITORY:-ci7lus/kiririn}"
+bundle_id="${SENTRY_BUNDLE_ID:-jp.pronama.kiririn}"
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required" >&2
+  exit 69
+fi
+
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "Run this script from inside the Git repository" >&2
+  exit 69
+fi
+
+all_tags=()
+while IFS= read -r tag; do
+  all_tags+=("$tag")
+done < <(git tag --list 'v*' --sort=version:refname)
+
+if [[ "${#requested_tags[@]}" -gt 0 ]]; then
+  tags=()
+  for requested_tag in "${requested_tags[@]}"; do
+    duplicate=false
+    for tag in "${tags[@]}"; do
+      if [[ "$tag" == "$requested_tag" ]]; then
+        duplicate=true
+        break
+      fi
+    done
+    if [[ "$duplicate" == false ]]; then
+      tags+=("$requested_tag")
+    fi
+  done
+else
+  tags=("${all_tags[@]}")
+fi
+
+if [[ "${#tags[@]}" -eq 0 ]]; then
+  echo "No v* tags found" >&2
+  exit 0
+fi
+
+if [[ "${#configured_builds[@]}" -gt 0 && "${#tags[@]}" -ne 1 ]]; then
+  echo "--legacy-builds can only be used when processing exactly one tag" >&2
+  exit 64
+fi
+
+if ! command -v "$sentry_cli" >/dev/null 2>&1; then
+  if [[ "$mode" == apply ]]; then
+    echo "sentry-cli is required for --apply: $sentry_cli" >&2
+    exit 69
+  fi
+  echo "Warning: sentry-cli is not available; existing Sentry build variants cannot be discovered." >&2
+  sentry_versions=""
+else
+  if ! sentry_versions="$(
+    "$sentry_cli" releases \
+      --org "$sentry_org" \
+      --project "$sentry_project" \
+      list --raw 2>/dev/null
+  )"; then
+    if [[ "$mode" == apply ]]; then
+      echo "Could not list existing Sentry releases. Refusing to apply an incomplete backfill." >&2
+      exit 69
+    fi
+    echo "Warning: existing Sentry releases could not be discovered; configured build numbers only will be used." >&2
+    sentry_versions=""
+  fi
+fi
+
+append_unique_build() {
+  local candidate="$1"
+  local existing
+
+  if [[ ! "$candidate" =~ ^[0-9]+$ ]]; then
+    echo "Invalid build number: $candidate" >&2
+    exit 64
+  fi
+
+  for existing in "${build_numbers[@]}"; do
+    if [[ "$existing" == "$candidate" ]]; then
+      return
+    fi
+  done
+
+  build_numbers+=("$candidate")
+}
+
+release_exists() {
+  local candidate="$1"
+  local sentry_version
+
+  while IFS= read -r sentry_version; do
+    if [[ "$sentry_version" == "$candidate" ]]; then
+      return 0
+    fi
+  done <<< "$sentry_versions"
+
+  return 1
+}
+
+run_sentry() {
+  if [[ "$mode" == dry-run ]]; then
+    printf '  DRY-RUN:'
+    printf ' %q' "$sentry_cli" releases --org "$sentry_org" --project "$sentry_project" "$@"
+    printf '\n'
+    return 0
+  fi
+
+  "$sentry_cli" releases --org "$sentry_org" --project "$sentry_project" "$@"
+}
+
+process_release() {
+  local release="$1"
+  local commit_spec="$2"
+
+  if release_exists "$release"; then
+    echo "  existing Sentry release: $release (skip new)"
+  else
+    run_sentry new "$release"
+  fi
+  run_sentry set-commits \
+    --commit "${sentry_repository}@${commit_spec}" \
+    "$release"
+  run_sentry finalize "$release"
+}
+
+previous_version_tag() {
+  local target="$1"
+  local candidate
+  local previous=""
+
+  for candidate in "${all_tags[@]}"; do
+    if [[ "$candidate" == "$target" ]]; then
+      printf '%s' "$previous"
+      return 0
+    fi
+    previous="$candidate"
+  done
+
+  return 1
+}
+
+for tag in "${tags[@]}"; do
+  if ! git rev-parse --verify --quiet "refs/tags/$tag" >/dev/null; then
+    echo "Tag not found: $tag" >&2
+    exit 66
+  fi
+
+  if ! previous_tag="$(previous_version_tag "$tag")"; then
+    echo "Version tag not found in v* tags: $tag" >&2
+    exit 66
+  fi
+
+  tag_commit="$(git rev-list -n 1 "$tag")"
+  version="$(git show "$tag:kiririn.xcodeproj/project.pbxproj" \
+    | sed -n 's/^[[:space:]]*MARKETING_VERSION = \([^;]*\);/\1/p' \
+    | head -n 1)"
+  tag_version="${tag#v}"
+
+  if [[ -z "$version" ]]; then
+    echo "Could not read MARKETING_VERSION from $tag" >&2
+    exit 66
+  fi
+  if [[ "$tag_version" != "$version" ]]; then
+    echo "Tag/version mismatch: $tag contains MARKETING_VERSION=$version" >&2
+    exit 65
+  fi
+
+  build_number="$(git show "$tag:kiririn.xcodeproj/project.pbxproj" \
+    | sed -n 's/^[[:space:]]*CURRENT_PROJECT_VERSION = \([^;]*\);/\1/p' \
+    | head -n 1)"
+  if [[ -z "$build_number" ]]; then
+    echo "Could not read CURRENT_PROJECT_VERSION from $tag" >&2
+    exit 66
+  fi
+
+  canonical_release="${bundle_id}@${version}"
+  build_numbers=()
+  append_unique_build "$build_number"
+
+  for configured_build in "${configured_builds[@]}"; do
+    if [[ -n "$configured_build" ]]; then
+      append_unique_build "$configured_build"
+    fi
+  done
+
+  while IFS= read -r sentry_version; do
+    if [[ "$sentry_version" != "${canonical_release}+"* ]]; then
+      continue
+    fi
+
+    legacy_build="${sentry_version#"${canonical_release}"+}"
+    if [[ "$legacy_build" =~ ^[0-9]+$ ]]; then
+      append_unique_build "$legacy_build"
+    fi
+  done <<< "$sentry_versions"
+
+  if [[ -n "$previous_tag" ]]; then
+    if ! git merge-base --is-ancestor "$previous_tag" "$tag"; then
+      echo "Previous version tag $previous_tag is not an ancestor of $tag" >&2
+      exit 65
+    fi
+
+    previous_commit="$(git rev-list -n 1 "$previous_tag")"
+    commit_spec="${previous_commit}..${tag_commit}"
+    range_description="${previous_tag}..${tag}"
+  else
+    root_commit="$(git rev-list --max-parents=0 "$tag" | tail -n 1)"
+    commit_spec="${root_commit}..${tag_commit}"
+    range_description="root..${tag}"
+  fi
+
+  echo "$tag: $canonical_release (commits: $range_description)"
+  process_release "$canonical_release" "$commit_spec"
+
+  for build in "${build_numbers[@]}"; do
+    legacy_release="${canonical_release}+${build}"
+    if [[ "$legacy_release" == "$canonical_release+${build_number}" ]]; then
+      echo "  legacy native release: $legacy_release"
+    else
+      echo "  detected native release: $legacy_release"
+    fi
+    process_release "$legacy_release" "$commit_spec"
+  done
+done
+
+if [[ "$mode" == dry-run ]]; then
+  echo "Dry-run complete. Use --apply after reviewing the commands above."
+else
+  echo "Sentry release backfill complete."
+fi

--- a/misc/upload-dsym-sentry.sh
+++ b/misc/upload-dsym-sentry.sh
@@ -8,10 +8,9 @@ fi
 
 archive_path="${1%/}"
 dsym_dir="$archive_path/dSYMs"
-dsym_paths=(
-  "$dsym_dir/kiririn.app.dSYM"
-  "$dsym_dir/VLCKit.framework.dSYM"
-)
+sentry_cli="${SENTRY_CLI_BIN:-sentry-cli}"
+sentry_org="${SENTRY_ORG:-ci7lus}"
+sentry_project="${SENTRY_PROJECT:-kiririn}"
 
 if [[ ! -d "$archive_path" ]]; then
   echo "xcarchive not found: $archive_path" >&2
@@ -23,16 +22,24 @@ if [[ ! -d "$dsym_dir" ]]; then
   exit 66
 fi
 
-missing_dsyms=()
-for dsym_path in "${dsym_paths[@]}"; do
-  if [[ ! -d "$dsym_path" ]]; then
-    missing_dsyms+=("$dsym_path")
-  fi
-done
+if ! command -v "$sentry_cli" >/dev/null 2>&1; then
+  echo "sentry-cli not found: $sentry_cli" >&2
+  exit 69
+fi
 
-if (( ${#missing_dsyms[@]} > 0 )); then
-  printf 'dSYM not found: %s\n' "${missing_dsyms[@]}" >&2
+dsym_paths=()
+while IFS= read -r -d '' dsym_path; do
+  dsym_paths+=("$dsym_path")
+done < <(find "$dsym_dir" -type d -name '*.dSYM' -prune -print0)
+
+if (( ${#dsym_paths[@]} == 0 )); then
+  echo "No dSYM found under: $dsym_dir" >&2
   exit 66
 fi
 
-sentry-cli debug-files upload --org ci7lus --project kiririn "${dsym_paths[@]}"
+sentry_args=(
+  --org "$sentry_org"
+  --project "$sentry_project"
+)
+
+"$sentry_cli" debug-files upload "${sentry_args[@]}" "${dsym_paths[@]}"


### PR DESCRIPTION
Sentry上でのリリース操作を全然やっていなかったので、dSYMのアップロードごとCIで行うようにします。
アプリは常にCFBundleVersionを1で作成していて、App Store Connectに上げるときに自動インクリメントしてますが、それだとsentry-cocoaの送信するreleaseNameと相性が悪いので、その点も上書きするようにしています。

## Sourceryによる概要

タグ付きビルドへのSentryリリース管理の統合と、アプリケーション全体および過去のリリースにおけるリリース識別子の標準化を行います。

新機能:
- タグ付きのiOSおよびmacOSビルドをSentryと統合し、CIでのリリース作成、コミット関連付け、完了処理、dSYMのアップロードを実行します。
- 既存のバージョンタグ全体に対して、正規およびレガシーSentryリリースをバックフィルするためのdry-run/applyユーティリティを追加します。

バグ修正:
- アプリが報告するSentryリリース名を、自動的にインクリメントされるビルド番号ではなく、バンドル識別子とマーケティングバージョンに合わせます。

機能強化:
- dSYMのアップロードでXCArchive内のすべてのシンボルバンドルを検出できるようにし、Sentry CLI、組織、プロジェクトの設定を構成可能にします。

CI:
- タグをトリガーとして、アーカイブ済みのiOSおよびmacOSビルドを処理し、Sentryリリースを管理するCIジョブを追加します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate Sentry release management into tagged builds and standardize release identifiers across the application and historical releases.

New Features:
- Integrate tagged iOS and macOS builds with Sentry release creation, commit association, finalization, and dSYM uploads in CI.
- Add a dry-run/apply utility for backfilling canonical and legacy Sentry releases across existing version tags.

Bug Fixes:
- Align the app-reported Sentry release name with the bundle identifier and marketing version instead of the automatically incremented build number.

Enhancements:
- Make dSYM uploads discover all symbol bundles in an XCArchive and support configurable Sentry CLI, organization, and project settings.

CI:
- Add a tag-triggered CI job that processes archived iOS and macOS builds for Sentry release management.

</details>

## Sourceryによる概要

タグ付けされたAppleプラットフォームのビルド全体にSentryのリリース管理を統合し、現在および過去のリリース識別子を正規化します。

新機能:
- タグ付けされたiOSおよびmacOSのビルドを、CIでのSentryリリースの作成、コミットの関連付け、確定、デバッグシンボルのアップロードと統合。
- 既存のバージョンタグに対して、正規およびレガシーのSentryリリースをバックフィルするドライラン／適用ユーティリティを追加。

バグ修正:
- アプリがSentryに報告するリリースとして、インクリメントされたビルド番号ではなく、バンドル識別子とマーケティングバージョンを使用。

機能強化:
- 設定可能なSentry CLI、組織、プロジェクト設定により、XCArchive内のすべてのdSYMバンドルを検出してアップロード。

CI:
- タグによってトリガーされ、アーカイブ済みアプリのメタデータを検証し、対応するSentryリリースを管理するCIジョブを追加。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate Sentry release management across tagged Apple-platform builds and normalize current and historical release identifiers.

New Features:
- Integrate tagged iOS and macOS builds with Sentry release creation, commit association, finalization, and debug-symbol uploads in CI.
- Add a dry-run/apply utility to backfill canonical and legacy Sentry releases for existing version tags.

Bug Fixes:
- Use the bundle identifier and marketing version as the app-reported Sentry release instead of the incremented build number.

Enhancements:
- Discover and upload all dSYM bundles in an XCArchive with configurable Sentry CLI, organization, and project settings.

CI:
- Add a tag-triggered CI job that validates archived app metadata and manages the corresponding Sentry release.

</details>