### PR TITLE
fix: 色々修正

### DIFF
--- a/kiririn/AppShell/kiririnApp.swift
+++ b/kiririn/AppShell/kiririnApp.swift
@@ -124,14 +124,6 @@ extension Notification.Name {
         ) -> UIInterfaceOrientationMask {
             PlayerOrientationController.shared.supportedOrientations
         }
-
-        func application(
-            _ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>
-        ) {
-            if application.connectedScenes.isEmpty {
-                exit(0)
-            }
-        }
     }
 #endif
 

--- a/kiririn/Features/Server/MirakurunProvider.swift
+++ b/kiririn/Features/Server/MirakurunProvider.swift
@@ -31,7 +31,23 @@ final class MirakurunProvider: LiveServerProvider {
 
     func fetchPrograms() async throws -> [Program] {
         let raw: [MirakurunProgram] = try await client.request(path: "api/programs")
-        return raw.map { $0.toProgram(serverId: configuration.id) }
+        return try await Self.convertPrograms(raw, serverId: configuration.id)
+    }
+
+    @concurrent
+    private nonisolated static func convertPrograms(
+        _ rawPrograms: [MirakurunProgram],
+        serverId: String
+    ) async throws -> [Program] {
+        var programs: [Program] = []
+        programs.reserveCapacity(rawPrograms.count)
+        for (index, rawProgram) in rawPrograms.enumerated() {
+            if index.isMultiple(of: 256) {
+                try Task.checkCancellation()
+            }
+            programs.append(rawProgram.toProgram(serverId: serverId))
+        }
+        return programs
     }
 
     func fetchServiceLogoData(for service: TVService) async throws -> Data? {

--- a/kiririn/Shared/Infrastructure/APIClient.swift
+++ b/kiririn/Shared/Infrastructure/APIClient.swift
@@ -47,6 +47,7 @@ nonisolated final class APIClient: Sendable {
         session.cancelAllTasks()
     }
 
+    @concurrent
     func request<T: Decodable & Sendable>(
         path: String,
         queryItems: [URLQueryItem]? = nil


### PR DESCRIPTION
Sentryで判明したハングとかを直しています

## Sourcery による概要

キャプチャプレビュー、サーバーデータの変換、API リクエスト全体の応答性と信頼性を向上させます。

バグ修正:
- アクセス可能な一時コピーを非同期で準備し、使用後に削除することで、キャプチャプレビューを開く際のハングや失敗を防止。
- シーンが破棄された際にアプリケーションが終了しないように修正。
- 大容量の Mirakurun プログラムレスポンスや API リクエストで、処理を一時停止してキャンセルに応答できるように修正。

機能改善:
- キャプチャプレビューの読み込み状況のフィードバック、エラーハンドリング、キャンセル、アクセシビリティアクションを改善。

テスト:
- 準備済み Quick Look プレビューファイルの作成と削除に関するテストカバレッジを追加。

<details>
<summary>Original summary in English</summary>

## Sourceryによる概要

ハング、失敗、応答しないキャンセルを防ぐため、プレビュー処理と非同期リクエスト処理を改善しました。

バグ修正:
- 破棄されたシーンセッションによって接続中のシーンがなくなった場合でも、アプリケーションが終了しないようにしました。
- 大容量のMirakurun番組レスポンスとAPIリクエストをキャンセル可能にし、より迅速に応答できるようにしました。

機能改善:
- 一時的なプレビューファイルを非同期で処理し、クリーンアップ、キャンセル、アクセシビリティアクション、より明確な読み込み状態とエラー状態に対応することで、キャプチャプレビューの信頼性とユーザーフィードバックを改善しました。

テスト:
- Quick Look用に準備されたプレビューファイルの作成と削除に関するテストカバレッジを追加しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve preview handling and asynchronous request processing to prevent hangs, failures, and unresponsive cancellation.

Bug Fixes:
- Prevent the application from exiting when discarded scene sessions leave no connected scenes.
- Make large Mirakurun program responses and API requests cancellable and more responsive.

Enhancements:
- Improve capture preview reliability and user feedback by handling temporary preview files asynchronously with cleanup, cancellation, accessibility actions, and clearer loading and error states.

Tests:
- Add coverage for creating and removing prepared Quick Look preview files.

</details>

</details>