### PR TITLE
chore: VLCKitを更新 (202609020405)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ kiririn は macOS/iOS 上において、デジタル放送の視聴を行うプ�
 
 アプリの主な機能は次のとおりです。
 
-- 番組情報の表示 (MPEG2-TS のみ)
+- 番組情報の表示 (MPEG2-TS または MMT/TLV のみ)
 - 番組表の表示 (Mirakurun / EPGStation 接続時)
 - 録画の再生 (EPGStation / KonomiTV / Google Drive 接続時)
 - キャプチャ画像の簡易管理
 - [プラグイン](#プラグイン)による機能拡張
-- データ放送 (web-bml・Mahiron 接続時)
+- データ放送 (Mahiron 接続時のみ)
 
 動画再生周りの機能は次のとおりです。(VLCKit 由来)
 
@@ -21,8 +21,8 @@ kiririn は macOS/iOS 上において、デジタル放送の視聴を行うプ�
 - ARIB STD-B24 形式の字幕表示 (libaribcaption)
 - デュアルモノ対応
 - 5.1ch 音声の仮想サラウンド化
-- MMT/TLV の再生 (部分的なサポート・superfashi/FFmpeg)
-- HDR 表示
+- MMT/TLV の再生 (部分的なサポート)
+- HDR 表示 / BS4K 向け SDR トーンマッピング
 - PiP (iOS のみ)
 
 ## 実行方法
@@ -71,6 +71,7 @@ VLCKit は[フォーク](https://github.com/neneka/vlckit)して改変したも�
 - [otya128/web-bml](https://github.com/otya128/web-bml)
 - [xtne6f/tsreadex](https://github.com/xtne6f/tsreadex)
 - [superfashi/FFmpeg](https://github.com/superfashi/FFmpeg)
+- [saindriches/FFmpeg](https://github.com/saindriches/FFmpeg)
 - [Chinachu/Mirakurun](https://github.com/Chinachu/Mirakurun)
 - [l3tnun/EPGStation](https://github.com/l3tnun/EPGStation)
 - [tsukumijima/KonomiTV](https://github.com/tsukumijima/KonomiTV)

--- a/kiririn.xcodeproj/project.pbxproj
+++ b/kiririn.xcodeproj/project.pbxproj
@@ -577,7 +577,6 @@
 				INFOPLIST_FILE = kiririn/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = kiririn;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
-				KIRIRIN_GIT_COMMIT_HASH = "-";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
 				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 ci7lus";
@@ -590,6 +589,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 18.4;
+				KIRIRIN_GIT_COMMIT_HASH = "-";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.4;
@@ -652,7 +652,6 @@
 				INFOPLIST_FILE = kiririn/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = kiririn;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
-				KIRIRIN_GIT_COMMIT_HASH = "-";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
 				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 ci7lus";
@@ -665,6 +664,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 18.4;
+				KIRIRIN_GIT_COMMIT_HASH = "-";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.4;

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # VLCKit
 # https://github.com/neneka/vlckit/releases
-REVISION="202608110911"
+REVISION="202609020405"
 VLCKIT_URL="https://github.com/neneka/vlckit/releases/download/$REVISION/VLCKit-iOS-REPLACEWITHVERSION.dmg"
 VLCKIT_DEST="./Packages/VLCKit"
 FRAMEWORK_DEST="${VLCKIT_DEST}/VLCKit.xcframework"


### PR DESCRIPTION
Fixes #37 
Fixes #86 
Fixes #95

## Sourceryによる概要

VLCKitを更新し、新しいメディアスタックに合わせて、文書化されている再生および放送機能を整合させます。

新機能:
- 文書化されているメディア機能に、MMT/TLVの番組情報およびBS4K SDRトーンマッピングのサポートを追加。

バグ修正:
- 参照されている問題の修正を取り込むため、VLCKitを2026年9月2日ビルドに更新。

機能強化:
- データ放送でweb-bmlがサポートされなくなったことを明確化し、プロジェクトで使用する更新版FFmpegフォークを文書化。

ビルド:
- VLCKitリビジョン202609020405をダウンロードするようセットアップスクリプトを更新。

ドキュメント:
- 現在のMMT/TLV、データ放送、HDR、およびFFmpegのサポート状況を反映するようREADMEを更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update VLCKit and align the documented playback and broadcast capabilities with the new media stack.

New Features:
- Add support for MMT/TLV program information and BS4K SDR tone mapping in the documented media capabilities.

Bug Fixes:
- Update VLCKit to the September 2, 2026 build to incorporate fixes for the referenced issues.

Enhancements:
- Clarify that web-bml is no longer supported for data broadcasting and document the updated FFmpeg fork used by the project.

Build:
- Update the setup script to download VLCKit revision 202609020405.

Documentation:
- Refresh the README to reflect current MMT/TLV, data broadcasting, HDR, and FFmpeg support.

</details>